### PR TITLE
feat: add workflow to trigger AEP spec update in akash-network/website repo

### DIFF
--- a/.github/workflows/trigger-aep-spec-update.yml
+++ b/.github/workflows/trigger-aep-spec-update.yml
@@ -1,0 +1,32 @@
+name: Trigger AEP Spec Update
+
+on:
+  push:
+    branches:
+      - main
+
+# REPO_WEBSITE_ACCESS_TOKEN is a PAT token that allows akash-network/aep to trigger workflows in akash-network/website via repository dispatch.
+# PAT token repo access is limited to akash-network/website only with the following permissions necessary for triggering the workflow:
+# - Actions: Read & Write (Trigger workflows)
+# - Workflows: Read & Write (Dispatch events)
+# - Contents: Read & Write (Required for repository dispatch)
+# - Metadata: Read (Mandatory)
+
+jobs:
+  dispatch-update-specs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger AEP Spec Update in akash-network/website repo
+        run: |
+          repo_owner="akash-network"
+          repo_name="website"
+          event_type="aep-repo-trigger"
+
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.REPO_WEBSITE_ACCESS_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
+            -d "{\"event_type\": \"$event_type\"}")
+
+          [[ "$STATUS" -ge 200 && "$STATUS" -lt 300 ]] || { echo "Error: HTTP $STATUS"; exit 1; }


### PR DESCRIPTION
# READ BEFORE MERGING :warning: 
## Prerequisites
- [x] :warning: Grant @andy108369 with the necessary GH Repo access to satisfy the following prerequisites
- [x] :warning: Ensure this repo has `REPO_WEBSITE_ACCESS_TOKEN` Secret added first!
- [x] :warning: Ensure https://github.com/akash-network/website/pull/578 is merged **BEFORE** merging this PR!

## Once merged:
- [ ] verify the [AEP Actions](https://github.com/akash-network/AEP/actions) and [website Actions](https://github.com/akash-network/website/actions) tabs to confirm the workflows got triggered and finished without errors
- [ ] verify the [website PR](https://github.com/akash-network/website/pulls?q=is%3Apr) page - there must be a PR named `Update AEP Specs YYYY-MM-DD` **created** & **merged**
- [ ] verify the `Deploy Astro site to Pages` at the [website Actions](https://github.com/akash-network/website/actions) got triggered
- [ ] verify the change got rendered, e.g. you can issue and merge a PR to the AEP GH repo with a tiny change (say add one dot in the end of text or so) to one of the AEP's, say AEP-49 and then confirm the changes rendered, e.g. https://akash.network/roadmap/aep-49/

----

### **🔹 Changes Summary**  

#### **`akash-network/website` GH repo (`akash-aep-spec.yml` workflow)**  
- 🔹 **Removed** the 6-hour cron job (no longer runs automatically).  
- 🔹 **Enabled auto-merge** for PRs updating AEP specs in `src/content/aeps/` (previously merged manually, e.g., [PR #573](https://github.com/akash-network/website/pull/573)).  
- 🔹 **Added `repository_dispatch` trigger** to allow `aep` repo to trigger updates.  

#### **`akash-network/aep` GH repo (`trigger-aep-spec-update.yml` workflow)**  
- 🔹 **New workflow:** Triggers AEP spec update in `website` on every push to `main`.  
- 🔹 Uses **GitHub repository dispatch** to trigger the workflow in `website`.  