### PR TITLE
(chore): update roadmap dates on mutiple AEPs

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -32,17 +32,17 @@
 | [30](spec/aep-30) | Cosmos SDK v0.47 Migration | Final | Standard/Core | 2024-08-29 |  | 2025-08-31 |
 | [31](spec/aep-31) | Credit Card Payments In Console | Final | Standard/Interface | 2024-08-29 | 2024-11-04 |  |
 | [32](spec/aep-32) | Akash Provider Console 1.0 | Final | Standard/Interface | 2024-12-01 | 2025-02-18 |  |
-| [33](spec/aep-33) | Escrow Balance Alerts in Akash Console | Draft | Standard/Interface | 2024-12-01 |  | 2025-05-23 |
-| [34](spec/aep-34) | Workload Log Forwarding via Akash Console | Draft | Standard/Interface | 2024-12-01 |  | 2025-06-15 |
-| [35](spec/aep-35) | Realtime Pricing In Akash Console | Draft | Standard/Interface | 2024-12-01 |  | 2025-05-31 |
-| [36](spec/aep-36) | Custom Domain Configuration via Akash Console | Draft | Standard/Interface | 2024-12-01 |  | 2025-06-30 |
+| [33](spec/aep-33) | Escrow Balance Alerts in Akash Console | Draft | Standard/Interface | 2024-12-01 |  | 2025-06-15 |
+| [34](spec/aep-34) | Workload Log Forwarding via Akash Console | Draft | Standard/Interface | 2024-12-01 |  | 2025-08-15 |
+| [35](spec/aep-35) | Realtime Pricing In Akash Console | Draft | Standard/Interface | 2024-12-01 |  | 2025-09-30 |
+| [36](spec/aep-36) | Custom Domain Configuration via Akash Console | Draft | Standard/Interface | 2024-12-01 |  | 2025-10-15 |
 | [37](spec/aep-37) | Lease control API via GRPC | Draft | Standard/Core | 2024-12-01 |  | 2025-04-30 |
 | [38](spec/aep-38) | Provider Content Moderation | Draft | Standard/Interface | 2024-12-01 |  | 2025-07-30 |
-| [39](spec/aep-39) | Lease Termination Reasons | Draft | Standard/Interface | 2024-12-01 |  | 2025-06-30 |
-| [40](spec/aep-40) | Continuous Provider Audits | Draft | Standard/Interface | 2024-12-01 |  | 2025-05-15 |
-| [41](spec/aep-41) | Standard Provider Attributes | Draft | Standard/Interface | 2024-12-01 |  | 2025-06-30 |
+| [39](spec/aep-39) | Lease Termination Reasons | Draft | Standard/Interface | 2024-12-01 |  | 2025-07-30 |
+| [40](spec/aep-40) | Continuous Provider Audits | Draft | Standard/Interface | 2024-12-01 |  | 2026-02-15 |
+| [41](spec/aep-41) | Standard Provider Attributes | Draft | Standard/Interface | 2024-12-01 |  | 2025-08-30 |
 | [42](spec/aep-42) | Workload Logs on Decentralized Storage | Draft | Standard/Interface | 2024-12-01 |  | 2025-12-30 |
-| [43](spec/aep-43) | Workload Utilization Metrics | Draft | Standard/Interface | 2024-12-01 |  | 2025-06-30 |
+| [43](spec/aep-43) | Workload Utilization Metrics | Draft | Standard/Interface | 2024-12-01 |  | 2025-09-15 |
 | [44](spec/aep-44) | Reserved Instances | Draft | Standard/Core | 2024-12-01 |  | 2026-08-30 |
 | [45](spec/aep-45) | Offchain Compute Inventory | Draft | Standard/Interface | 2024-12-01 |  | 2025-11-30 |
 | [46](spec/aep-46) | Spot Instances | Draft | Standard/Interface | 2024-12-01 |  | 2026-08-30 |
@@ -51,14 +51,14 @@
 | [49](spec/aep-49) | Virtual Machines | Draft | Standard/Core | 2024-12-01 |  | 2026-02-20 |
 | [50](spec/aep-50) | Secrets Management | Draft | Standard/Core | 2024-12-01 |  | 2025-11-30 |
 | [51](spec/aep-51) | Lease Change Request | Draft | Standard/Core | 2024-12-01 |  | 2026-01-30 |
-| [52](spec/aep-52) | Rollover Provider | Draft | Core/Interface | 2024-12-01 |  | 2025-06-30 |
-| [53](spec/aep-53) | Onchain Provider Incentives | Draft | Standard/Interface | 2024-12-01 |  | 2025-05-30 |
-| [54](spec/aep-54) | NextGen AMD GPU support | Draft | Standard/Core | 2024-01-05 |  | 2025-05-15 |
+| [52](spec/aep-52) | Rollover Provider | Draft | Core/Interface | 2024-12-01 |  | 2026-01-31 |
+| [53](spec/aep-53) | Onchain Provider Incentives | Draft | Standard/Interface | 2024-12-01 |  | 2025-08-30 |
+| [54](spec/aep-54) | NextGen AMD GPU support | Draft | Standard/Core | 2024-01-05 |  | 2025-12-15 |
 | [55](spec/aep-55) | Buy Back and Burn AKT | Draft | Standard/Economics | 2024-12-07 |  | 2025-06-30 |
 | [56](spec/aep-56) | Chain SDK | Draft | Standard/Interface | 2025-01-10 |  | 2025-06-30 |
 | [57](spec/aep-57) | Automatic Escrow Top Up | Draft | Standard/Interface | 2024-01-05 | 2025-01-30 |  |
-| [58](spec/aep-58) | Per Node Resources in Console | Draft | Standard/Interface | 2024-01-05 |  | 2025-05-15 |
-| [59](spec/aep-59) | Provider Notifications | Draft | Standard/Interface | 2024-01-05 |  | 2025-06-15 |
+| [58](spec/aep-58) | Per Node Resources in Console | Draft | Standard/Interface | 2024-01-05 |  | 2025-08-15 |
+| [59](spec/aep-59) | Provider Notifications | Draft | Standard/Interface | 2024-01-05 |  | 2025-07-15 |
 | [60](spec/aep-60) | Akash at Home | Draft | Meta | 2024-12-01 |  | 2026-03-30 |
 | [61](spec/aep-61) | Enhanced Read Performance Onchain Queries | Last Call | Standard/Core | 2025-01-30 | 2025-03-12 |  |
 | [62](spec/aep-62) | Provider Console - Node Manager | Final | Standard/Interface | 2024-03-15 | 2025-04-17 |  |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,33 +24,33 @@
 | [62](spec/aep-62) | Provider Console - Node Manager | 2025-04-17 | Minor |
 | [37](spec/aep-37) | Lease control API via GRPC | 2025-04-30 | Minor |
 | [64](spec/aep-64) | JWT Authentication for Provider API | 2025-04-30 | Major |
-| [40](spec/aep-40) | Continuous Provider Audits | 2025-05-15 | Minor |
-| [54](spec/aep-54) | NextGen AMD GPU support | 2025-05-15 | Minor |
-| [58](spec/aep-58) | Per Node Resources in Console | 2025-05-15 | Minor |
-| [33](spec/aep-33) | Escrow Balance Alerts in Akash Console | 2025-05-23 | Major |
-| [53](spec/aep-53) | Onchain Provider Incentives | 2025-05-30 | Major |
 | [63](spec/aep-63) | Console API for Managed Wallet Users - v1 | 2025-05-30 | Major |
-| [35](spec/aep-35) | Realtime Pricing In Akash Console | 2025-05-31 | Minor |
 | [29](spec/aep-29) | Hardware Verification (Via Attestation) | 2025-06-15 | Major |
-| [34](spec/aep-34) | Workload Log Forwarding via Akash Console | 2025-06-15 | Minor |
-| [59](spec/aep-59) | Provider Notifications | 2025-06-15 | Minor |
+| [33](spec/aep-33) | Escrow Balance Alerts in Akash Console | 2025-06-15 | Major |
 | [12](spec/aep-12) | Trusted Execution Environment (TEE) | 2025-06-30 | Major |
-| [36](spec/aep-36) | Custom Domain Configuration via Akash Console | 2025-06-30 | Minor |
-| [39](spec/aep-39) | Lease Termination Reasons | 2025-06-30 | Minor |
-| [41](spec/aep-41) | Standard Provider Attributes | 2025-06-30 | Minor |
-| [43](spec/aep-43) | Workload Utilization Metrics | 2025-06-30 | Minor |
-| [52](spec/aep-52) | Rollover Provider | 2025-06-30 | Minor |
 | [55](spec/aep-55) | Buy Back and Burn AKT | 2025-06-30 | Minor |
 | [56](spec/aep-56) | Chain SDK | 2025-06-30 | Major |
+| [59](spec/aep-59) | Provider Notifications | 2025-07-15 | Minor |
 | [38](spec/aep-38) | Provider Content Moderation | 2025-07-30 | Minor |
+| [39](spec/aep-39) | Lease Termination Reasons | 2025-07-30 | Minor |
+| [34](spec/aep-34) | Workload Log Forwarding via Akash Console | 2025-08-15 | Minor |
+| [58](spec/aep-58) | Per Node Resources in Console | 2025-08-15 | Minor |
+| [41](spec/aep-41) | Standard Provider Attributes | 2025-08-30 | Minor |
+| [53](spec/aep-53) | Onchain Provider Incentives | 2025-08-30 | Major |
 | [30](spec/aep-30) | Cosmos SDK v0.47 Migration | 2025-08-31 | Major |
+| [43](spec/aep-43) | Workload Utilization Metrics | 2025-09-15 | Minor |
+| [35](spec/aep-35) | Realtime Pricing In Akash Console | 2025-09-30 | Minor |
+| [36](spec/aep-36) | Custom Domain Configuration via Akash Console | 2025-10-15 | Minor |
 | [45](spec/aep-45) | Offchain Compute Inventory | 2025-11-30 | Minor |
 | [50](spec/aep-50) | Secrets Management | 2025-11-30 | Minor |
+| [54](spec/aep-54) | NextGen AMD GPU support | 2025-12-15 | Minor |
 | [42](spec/aep-42) | Workload Logs on Decentralized Storage | 2025-12-30 | Minor |
 | [47](spec/aep-47) | Long Standing Orders | 2025-12-31 | Minor |
 | [65](spec/aep-65) | Confidential Computing | 2025-12-31 | Major |
 | [11](spec/aep-11) | Managed Services Market | 2026-01-01 | Major |
 | [51](spec/aep-51) | Lease Change Request | 2026-01-30 | Minor |
+| [52](spec/aep-52) | Rollover Provider | 2026-01-31 | Minor |
+| [40](spec/aep-40) | Continuous Provider Audits | 2026-02-15 | Minor |
 | [49](spec/aep-49) | Virtual Machines | 2026-02-20 | Major |
 | [60](spec/aep-60) | Akash at Home | 2026-03-30 | Major |
 | [48](spec/aep-48) | Private Overlay Networking | 2026-05-30 | Major |

--- a/index.json
+++ b/index.json
@@ -330,7 +330,7 @@
     "category": "Interface",
     "created": "2024-12-01T00:00:00.000Z",
     "updated": "2025-03-12T00:00:00.000Z",
-    "estimated-completion": "2025-05-23T00:00:00.000Z",
+    "estimated-completion": "2025-06-15T00:00:00.000Z",
     "roadmap": "major"
   },
   {
@@ -342,7 +342,7 @@
     "category": "Interface",
     "created": "2024-12-01T00:00:00.000Z",
     "updated": "2025-01-10T00:00:00.000Z",
-    "estimated-completion": "2025-06-15T00:00:00.000Z",
+    "estimated-completion": "2025-08-15T00:00:00.000Z",
     "roadmap": "minor"
   },
   {
@@ -354,7 +354,7 @@
     "category": "Interface",
     "created": "2024-12-01T00:00:00.000Z",
     "updated": "2024-03-19T00:00:00.000Z",
-    "estimated-completion": "2025-05-31T00:00:00.000Z",
+    "estimated-completion": "2025-09-30T00:00:00.000Z",
     "roadmap": "minor"
   },
   {
@@ -366,7 +366,7 @@
     "category": "Interface",
     "created": "2024-12-01T00:00:00.000Z",
     "updated": "2024-12-01T00:00:00.000Z",
-    "estimated-completion": "2025-06-30T00:00:00.000Z",
+    "estimated-completion": "2025-10-15T00:00:00.000Z",
     "roadmap": "minor"
   },
   {
@@ -402,7 +402,7 @@
     "category": "Interface",
     "created": "2024-12-01T00:00:00.000Z",
     "updated": "2025-01-11T00:00:00.000Z",
-    "estimated-completion": "2025-06-30T00:00:00.000Z",
+    "estimated-completion": "2025-07-30T00:00:00.000Z",
     "roadmap": "minor"
   },
   {
@@ -428,7 +428,7 @@
     "category": "Interface",
     "created": "2024-12-01T00:00:00.000Z",
     "updated": "2025-01-10T00:00:00.000Z",
-    "estimated-completion": "2025-05-15T00:00:00.000Z",
+    "estimated-completion": "2026-02-15T00:00:00.000Z",
     "roadmap": "minor"
   },
   {
@@ -440,7 +440,7 @@
     "category": "Interface",
     "created": "2024-12-01T00:00:00.000Z",
     "updated": "2024-03-19T00:00:00.000Z",
-    "estimated-completion": "2025-06-30T00:00:00.000Z",
+    "estimated-completion": "2025-08-30T00:00:00.000Z",
     "roadmap": "minor"
   },
   {
@@ -464,7 +464,7 @@
     "category": "Interface",
     "created": "2024-12-01T00:00:00.000Z",
     "updated": "2024-01-11T00:00:00.000Z",
-    "estimated-completion": "2025-06-30T00:00:00.000Z",
+    "estimated-completion": "2025-09-15T00:00:00.000Z",
     "roadmap": "minor"
   },
   {
@@ -583,7 +583,7 @@
     "category": "Interface",
     "created": "2024-12-01T00:00:00.000Z",
     "updated": "2024-12-01T00:00:00.000Z",
-    "estimated-completion": "2025-06-30T00:00:00.000Z",
+    "estimated-completion": "2026-01-31T00:00:00.000Z",
     "roadmap": "minor"
   },
   {
@@ -595,7 +595,7 @@
     "category": "Interface",
     "created": "2024-12-01T00:00:00.000Z",
     "updated": "2025-01-10T00:00:00.000Z",
-    "estimated-completion": "2025-05-30T00:00:00.000Z",
+    "estimated-completion": "2025-08-30T00:00:00.000Z",
     "roadmap": "major"
   },
   {
@@ -607,7 +607,7 @@
     "category": "Core",
     "created": "2024-01-05T00:00:00.000Z",
     "updated": "2025-01-10T00:00:00.000Z",
-    "estimated-completion": "2025-05-15T00:00:00.000Z",
+    "estimated-completion": "2025-12-15T00:00:00.000Z",
     "roadmap": "minor"
   },
   {
@@ -655,7 +655,7 @@
     "category": "Interface",
     "created": "2024-01-05T00:00:00.000Z",
     "updated": "2024-01-05T00:00:00.000Z",
-    "estimated-completion": "2025-05-15T00:00:00.000Z",
+    "estimated-completion": "2025-08-15T00:00:00.000Z",
     "roadmap": "minor"
   },
   {
@@ -667,7 +667,7 @@
     "category": "Interface",
     "created": "2024-01-05T00:00:00.000Z",
     "updated": "2025-03-13T00:00:00.000Z",
-    "estimated-completion": "2025-06-15T00:00:00.000Z",
+    "estimated-completion": "2025-07-15T00:00:00.000Z",
     "roadmap": "minor"
   },
   {

--- a/spec/aep-33/README.md
+++ b/spec/aep-33/README.md
@@ -8,7 +8,7 @@ type: Standard
 category: Interface
 created: 2024-12-01
 updated: 2025-03-12
-estimated-completion: 2025-05-23
+estimated-completion: 2025-06-15
 roadmap: major
 ---
 

--- a/spec/aep-34/README.md
+++ b/spec/aep-34/README.md
@@ -7,7 +7,7 @@ type: Standard
 category: Interface
 created: 2024-12-01
 updated: 2025-01-10
-estimated-completion: 2025-06-15
+estimated-completion: 2025-08-15
 roadmap: minor
 ---
 

--- a/spec/aep-35/README.md
+++ b/spec/aep-35/README.md
@@ -7,7 +7,7 @@ type: Standard
 category: Interface
 created: 2024-12-01
 updated: 2024-03-19
-estimated-completion: 2025-05-31
+estimated-completion: 2025-09-30
 roadmap: minor
 ---
 

--- a/spec/aep-36/README.md
+++ b/spec/aep-36/README.md
@@ -7,7 +7,7 @@ type: Standard
 category: Interface
 created: 2024-12-01
 updated: 2024-12-01
-estimated-completion: 2025-06-30
+estimated-completion: 2025-10-15
 roadmap: minor
 ---
 

--- a/spec/aep-39/README.md
+++ b/spec/aep-39/README.md
@@ -7,7 +7,7 @@ type: Standard
 category: Interface
 created: 2024-12-01
 updated: 2025-01-11
-estimated-completion: 2025-06-30
+estimated-completion: 2025-07-30
 roadmap: minor
 ---
 

--- a/spec/aep-40/README.md
+++ b/spec/aep-40/README.md
@@ -7,7 +7,7 @@ type: Standard
 category: Interface
 created: 2024-12-01
 updated: 2025-01-10
-estimated-completion: 2025-05-15
+estimated-completion: 2026-02-15
 roadmap: minor
 ---
 

--- a/spec/aep-41/README.md
+++ b/spec/aep-41/README.md
@@ -7,7 +7,7 @@ type: Standard
 category: Interface
 created: 2024-12-01
 updated: 2024-03-19
-estimated-completion: 2025-06-30
+estimated-completion: 2025-08-30
 roadmap: minor
 ---
 

--- a/spec/aep-43/README.md
+++ b/spec/aep-43/README.md
@@ -7,7 +7,7 @@ type: Standard
 category: Interface
 created: 2024-12-01
 updated: 2024-01-11
-estimated-completion: 2025-06-30
+estimated-completion: 2025-09-15
 roadmap: minor
 ---
 

--- a/spec/aep-52/README.md
+++ b/spec/aep-52/README.md
@@ -7,7 +7,7 @@ type: Core
 category: Interface
 created: 2024-12-01
 updated: 2024-12-01
-estimated-completion: 2025-06-30
+estimated-completion: 2026-01-31
 roadmap: minor
 ---
 

--- a/spec/aep-53/README.md
+++ b/spec/aep-53/README.md
@@ -7,7 +7,7 @@ type: Standard
 category: Interface
 created: 2024-12-01
 updated: 2025-01-10
-estimated-completion: 2025-05-30
+estimated-completion: 2025-08-30
 roadmap: major
 ---
 

--- a/spec/aep-54/README.md
+++ b/spec/aep-54/README.md
@@ -7,7 +7,7 @@ type: Standard
 category: Core
 created: 2024-01-05
 updated: 2025-01-10
-estimated-completion: 2025-05-15
+estimated-completion: 2025-12-15
 roadmap: minor
 ---
 

--- a/spec/aep-58/README.md
+++ b/spec/aep-58/README.md
@@ -7,7 +7,7 @@ type: Standard
 category: Interface
 created: 2024-01-05
 updated: 2024-01-05
-estimated-completion: 2025-05-15
+estimated-completion: 2025-08-15
 roadmap: minor
 ---
 

--- a/spec/aep-59/README.md
+++ b/spec/aep-59/README.md
@@ -7,7 +7,7 @@ type: Standard
 category: Interface
 created: 2024-01-05
 updated: 2025-03-13
-estimated-completion: 2025-06-15
+estimated-completion: 2025-07-15
 roadmap: minor
 ---
 


### PR DESCRIPTION
Updated Roadmap to reflect current plans and to make space for 2-3 new AEPs driven by user feedback

Completion Date adjusted on the following AEPs
modified:   spec/aep-33/README.md
modified:   spec/aep-34/README.md
modified:   spec/aep-35/README.md
modified:   spec/aep-36/README.md
modified:   spec/aep-39/README.md
modified:   spec/aep-40/README.md
modified:   spec/aep-41/README.md
modified:   spec/aep-43/README.md
modified:   spec/aep-52/README.md
modified:   spec/aep-53/README.md
modified:   spec/aep-54/README.md
modified:   spec/aep-58/README.md
modified:   spec/aep-59/README.md