### PR TITLE
(AEP-63) mark as completed

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -62,7 +62,7 @@
 | [60](spec/aep-60) | Akash at Home | Draft | Meta | 2024-12-01 |  | 2026-03-30 |
 | [61](spec/aep-61) | Enhanced Read Performance Onchain Queries | Last Call | Standard/Core | 2025-01-30 | 2025-03-12 |  |
 | [62](spec/aep-62) | Provider Console - Node Manager | Final | Standard/Interface | 2024-03-15 | 2025-04-17 |  |
-| [63](spec/aep-63) | Console API for Managed Wallet Users - v1 | Draft | Standard/Interface | 2024-03-14 |  | 2025-05-30 |
+| [63](spec/aep-63) | Console API for Managed Wallet Users - v1 | Final | Standard/Interface | 2024-03-14 | 2025-05-28 |  |
 | [64](spec/aep-64) | JWT Authentication for Provider API | Final | Standard/Core | 2025-04-03 |  | 2025-04-30 |
 | [65](spec/aep-65) | Confidential Computing | Draft | Standard/Core | 2025-05-14 |  | 2025-12-31 |
 | [67](spec/aep-67) | Console Bid PreCheck | Draft | Standard/Core | 2025-05-16 |  | 2025-06-15 |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@
 | [62](spec/aep-62) | Provider Console - Node Manager | 2025-04-17 | Minor |
 | [37](spec/aep-37) | Lease control API via GRPC | 2025-04-30 | Minor |
 | [64](spec/aep-64) | JWT Authentication for Provider API | 2025-04-30 | Major |
-| [63](spec/aep-63) | Console API for Managed Wallet Users - v1 | 2025-05-30 | Major |
+| [63](spec/aep-63) | Console API for Managed Wallet Users - v1 | 2025-05-28 | Major |
 | [29](spec/aep-29) | Hardware Verification (Via Attestation) | 2025-06-15 | Major |
 | [33](spec/aep-33) | Escrow Balance Alerts in Akash Console | 2025-06-15 | Major |
 | [67](spec/aep-67) | Console Bid PreCheck | 2025-06-15 | Major |

--- a/index.json
+++ b/index.json
@@ -722,12 +722,12 @@
     "aep": 63,
     "title": "Console API for Managed Wallet Users - v1",
     "author": "Anil Murty (@anilmurty) Maxime Beauchamp (@baktun14)",
-    "status": "Draft",
+    "status": "Final",
     "type": "Standard",
     "category": "Interface",
     "created": "2024-03-14T00:00:00.000Z",
-    "updated": "2025-03-14T00:00:00.000Z",
-    "estimated-completion": "2025-05-30T00:00:00.000Z",
+    "updated": "2025-05-28T00:00:00.000Z",
+    "completed": "2025-05-28T00:00:00.000Z",
     "roadmap": "major"
   },
   {

--- a/spec/aep-63/README.md
+++ b/spec/aep-63/README.md
@@ -2,12 +2,12 @@
 aep: 63
 title: "Console API for Managed Wallet Users - v1"
 author: Anil Murty (@anilmurty) Maxime Beauchamp (@baktun14)
-status: Draft
+status: Final
 type: Standard
 category: Interface
 created: 2024-03-14
-updated: 2025-03-14
-estimated-completion: 2025-05-30
+updated: 2025-05-28
+completed: 2025-05-28
 roadmap: major
 ---
 
@@ -104,14 +104,6 @@ implementation tracked in [issue #989](https://github.com/akash-network/console/
 #### Funding Account
 
 This is for the customer to purchase more credits and fund their account - we will decide if we offer this or not based on customer requests but it will likely directly go to the Stripe Checkout API https://docs.stripe.com/api/checkout/sessions/object
-
-#### Retrieving Logs
-
-`GET/v1/logs/{dseq}`
-
-#### Retrieving Events
-
-`GET/v1/events/{dseq}`
 
 ### UI for Managing API Keys
 


### PR DESCRIPTION
Updating this to complete and removing the last 2 outstanding endpoints in the original spec (logs and events). The reason for this is because we were waiting for the JWT Authentication to become available and so we can transition the API calls to it but that is taking way longer than expected.

We will create a new AEP for transitioning to JWT and adding the log and event retrieval API endpoints