### PR TITLE
chore: rename aep-82 to aep-84 to avoid collision with unmerged AEP-82

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -80,4 +80,4 @@
 | [79](spec/aep-79) | Akash on Shared Security | Final | Standard/Core | 2025-12-15 |  | 2026-12-31 |
 | [80](spec/aep-80) | On-Chain Oracle Module | Final | Standard/Core | 2026-03-06 |  | 2026-03-23 |
 | [81](spec/aep-81) | Pyth Price feed Integration | Final | Standard/Core | 2026-03-06 |  | 2026-03-23 |
-| [82](spec/aep-82) | Console Split: Managed Platform and Self-Custodial Air | Draft | Standard/Interface | 2026-04-24 |  | 2026-05-31 |
+| [84](spec/aep-84) | Console Split: Managed Platform and Self-Custodial Air | Draft | Standard/Interface | 2026-04-24 |  | 2026-05-31 |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,7 +49,7 @@
 | [29](spec/aep-29) | Hardware Verification using Trusted Execution | 2026-05-30 | Major |
 | [59](spec/aep-59) | Provider Notifications | 2026-05-31 | Major |
 | [73](spec/aep-73) | Console - New Product Announcement feature | 2026-05-31 | Minor |
-| [82](spec/aep-82) | Console Split: Managed Platform and Self-Custodial Air | 2026-05-31 | Major |
+| [84](spec/aep-84) | Console Split: Managed Platform and Self-Custodial Air | 2026-05-31 | Major |
 | [40](spec/aep-40) | Continuous Provider Audits | 2026-06-15 | Minor |
 | [50](spec/aep-50) | Secrets Management | 2026-06-30 | Minor |
 | [66](spec/aep-66) | Custom Domain Certificates | 2026-06-30 | Major |

--- a/index.json
+++ b/index.json
@@ -972,7 +972,7 @@
     ]
   },
   {
-    "aep": 82,
+    "aep": 84,
     "title": "Console Split: Managed Platform and Self-Custodial Air",
     "description": "Split Akash Console into a fully-managed platform (console.akash.network) and a dedicated self-custodial app (Console Air)",
     "author": "Maxime Beauchamp (@baktun14) Greg Osuri (@gosuri)",

--- a/spec/aep-84/README.md
+++ b/spec/aep-84/README.md
@@ -1,5 +1,5 @@
 ---
-aep: 82
+aep: 84
 title: "Console Split: Managed Platform and Self-Custodial Air"
 description: "Split Akash Console into a fully-managed platform (console.akash.network) and a dedicated self-custodial app (Console Air)"
 author: Maxime Beauchamp (@baktun14) Greg Osuri (@gosuri)


### PR DESCRIPTION
## Summary
- Rename `spec/aep-82/` to `spec/aep-84/` because there is an unmerged AEP-82 proposal elsewhere; this reclaims the next available number.
- Update the `aep:` field in the README frontmatter from `82` to `84`.
- Regenerate `INDEX.md`, `ROADMAP.md`, and `index.json` via `node scripts/index.js`.

## Test plan
- [ ] Verify `spec/aep-84/README.md` renders correctly on GitHub
- [ ] Confirm `INDEX.md`, `ROADMAP.md`, and `index.json` reference `aep-84` (not `aep-82`)
- [ ] Confirm no other references to the old `aep-82` path remain