### PR TITLE
fix(aep-84): clarify Console Air ships as a separate repo

### DIFF
--- a/spec/aep-84/README.md
+++ b/spec/aep-84/README.md
@@ -64,13 +64,14 @@ Each application has a single identity model, a single billing model, and a sing
 
 ### Shared Infrastructure
 
-Both applications continue to be built in the same [akash-network/console](https://github.com/akash-network/console) monorepo and share:
+The two applications live in separate repositories — [akash-network/console](https://github.com/akash-network/console) for the managed platform and [akash-network/console-air](https://github.com/akash-network/console-air) for the self-custodial app — and share code through published `@akashnetwork/*` packages:
 
-- The underlying SDL editor, deployment lifecycle UI components, and provider selection logic.
-- Common design system and component library.
+- SDL editor, deployment lifecycle UI components, and provider selection logic via shared UI packages.
+- Common design system and component library (`@akashnetwork/ui`).
 - The Console API layer ([AEP-63](../aep-63), [AEP-69](../aep-69), [AEP-70](../aep-70)) for features that apply to both audiences (e.g., provider data, pricing).
+- Chain SDK, network utilities, and HTTP clients for talking to Akash.
 
-What is *not* shared is the identity, billing, and account management surface. Those diverge cleanly between the two apps and are no longer forced into a single abstraction.
+What is *not* shared is the identity, billing, and account management surface. Those diverge cleanly between the two apps and are no longer forced into a single abstraction. Splitting at the repository boundary (rather than within a monorepo) reinforces the separation: each app's dependencies, CI, release cadence, and contributor model can evolve independently of the other.
 
 ## Rationale
 
@@ -106,6 +107,7 @@ A first-party, open-source self-custodial client ensures that self-custodial usa
 ## Implementations
 
 - Akash Console: [github.com/akash-network/console](https://github.com/akash-network/console)
+- Console Air: [github.com/akash-network/console-air](https://github.com/akash-network/console-air)
 
 ## References
 


### PR DESCRIPTION
## Summary

- Updates the **Shared Infrastructure** section of AEP-84 to reflect that Console Air ships in its own repository (`akash-network/console-air`) rather than as a sibling app inside the `akash-network/console` monorepo.
- Sharing happens through published `@akashnetwork/*` packages (UI, chain-sdk, http-sdk, network utilities, Console API client) instead of direct in-repo imports.
- Adds Console Air to the **Implementations** list.

## Rationale

The original draft said "Both applications continue to be built in the same `akash-network/console` monorepo and share..." That framing doesn't match the actual implementation plan. Console Air is being extracted from `baktun14/console-crypto` (a fork that already carries the wallet-only experience) into its own repo under `akash-network/console-air`.

Splitting at the repo boundary — rather than within a monorepo — gives each app independent:
- dependency surface (`@cosmos-kit`, `@cosmjs`, etc. only live in Console Air),
- CI and release cadence,
- contributor model.

This reinforces the separation that AEP-84 is already arguing for at the application level.

## Test plan

- [x] `spec/aep-84/README.md` renders cleanly on GitHub
- [x] All cross-AEP references still resolve
- [x] No other AEP file mentions the monorepo arrangement for Console Air