### PR TITLE
chore: mark BME AEPs (76, 78, 80, 81) as completed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+.worktrees
 

--- a/INDEX.md
+++ b/INDEX.md
@@ -75,11 +75,11 @@
 | [73](spec/aep-73) | Console - New Product Announcement feature | Draft | Standard/Interface | 2025-07-31 |  | 2026-05-31 |
 | [74](spec/aep-74) | Console - Auto Credit Reload | Draft | Standard/Interface | 2025-07-31 | 2025-12-31 |  |
 | [75](spec/aep-75) | Multi-depositor escrow account | Final | Standard/Core | 2025-08-18 | 2025-08-30 |  |
-| [76](spec/aep-76) | Burn Mint Equilibrium On Akash | Final | Standard/Economics | 2025-09-21 |  | 2026-03-23 |
-| [78](spec/aep-78) | Enable CosmWasm Smart Contracts on Akash Network | Final | Standard/Core | 2025-11-14 |  | 2026-03-23 |
+| [76](spec/aep-76) | Burn Mint Equilibrium On Akash | Final | Standard/Economics | 2025-09-21 | 2026-03-23 |  |
+| [78](spec/aep-78) | Enable CosmWasm Smart Contracts on Akash Network | Final | Standard/Core | 2025-11-14 | 2026-03-23 |  |
 | [79](spec/aep-79) | Akash on Shared Security | Final | Standard/Core | 2025-12-15 |  | 2026-12-31 |
-| [80](spec/aep-80) | On-Chain Oracle Module | Final | Standard/Core | 2026-03-06 |  | 2026-03-23 |
-| [81](spec/aep-81) | Pyth Price feed Integration | Final | Standard/Core | 2026-03-06 |  | 2026-03-23 |
+| [80](spec/aep-80) | On-Chain Oracle Module | Final | Standard/Core | 2026-03-06 | 2026-03-23 |  |
+| [81](spec/aep-81) | Pyth Price feed Integration | Final | Standard/Core | 2026-03-06 | 2026-03-23 |  |
 | [82](spec/aep-82) | Resource Reclamation | Last Call | Standard/Core | 2026-04-22 |  | 2026-05-31 |
 | [83](spec/aep-83) | Confidential Compute via Kata Containers | Draft | Standard/Core | 2026-04-14 |  |  |
 | [84](spec/aep-84) | Console Split: Managed Platform and Self-Custodial Air | Final | Standard/Interface | 2026-04-24 |  | 2026-05-31 |

--- a/index.json
+++ b/index.json
@@ -904,8 +904,8 @@
     "type": "Standard",
     "category": "Economics",
     "created": "2025-09-21T00:00:00.000Z",
-    "updated": "2026-03-06T00:00:00.000Z",
-    "estimated-completion": "2026-03-23T00:00:00.000Z",
+    "updated": "2026-03-23T00:00:00.000Z",
+    "completed": "2026-03-23T00:00:00.000Z",
     "roadmap": "major",
     "replaces": 55
   },
@@ -918,7 +918,8 @@
     "category": "Core",
     "roadmap": "major",
     "created": "2025-11-14T00:00:00.000Z",
-    "estimated-completion": "2026-03-23T00:00:00.000Z"
+    "updated": "2026-03-23T00:00:00.000Z",
+    "completed": "2026-03-23T00:00:00.000Z"
   },
   {
     "aep": 79,
@@ -952,7 +953,8 @@
     "type": "Standard",
     "category": "Core",
     "created": "2026-03-06T00:00:00.000Z",
-    "estimated-completion": "2026-03-23T00:00:00.000Z",
+    "updated": "2026-03-23T00:00:00.000Z",
+    "completed": "2026-03-23T00:00:00.000Z",
     "roadmap": "major",
     "requires": 76
   },
@@ -964,7 +966,8 @@
     "type": "Standard",
     "category": "Core",
     "created": "2026-03-06T00:00:00.000Z",
-    "estimated-completion": "2026-03-23T00:00:00.000Z",
+    "updated": "2026-03-23T00:00:00.000Z",
+    "completed": "2026-03-23T00:00:00.000Z",
     "roadmap": "major",
     "requires": [
       "76",

--- a/spec/aep-76/README.md
+++ b/spec/aep-76/README.md
@@ -6,8 +6,8 @@ status: Final
 type: Standard
 category: Economics
 created: 2025-09-21
-updated: 2026-03-06
-estimated-completion: 2026-03-23
+updated: 2026-03-23
+completed: 2026-03-23
 roadmap: major
 replaces: 55
 ---

--- a/spec/aep-78/README.md
+++ b/spec/aep-78/README.md
@@ -7,7 +7,8 @@ type: Standard
 category: Core
 roadmap: major
 created: 2025-11-14
-estimated-completion: 2026-03-23
+updated: 2026-03-23
+completed: 2026-03-23
 ---
 
 ## Summary

--- a/spec/aep-80/README.md
+++ b/spec/aep-80/README.md
@@ -6,7 +6,8 @@ status: Final
 type: Standard
 category: Core
 created: 2026-03-06
-estimated-completion: 2026-03-23
+updated: 2026-03-23
+completed: 2026-03-23
 roadmap: major
 requires: 76
 ---

--- a/spec/aep-81/README.md
+++ b/spec/aep-81/README.md
@@ -6,7 +6,8 @@ status: Final
 type: Standard
 category: Core
 created: 2026-03-06
-estimated-completion: 2026-03-23
+updated: 2026-03-23
+completed: 2026-03-23
 roadmap: major
 requires: 76,80
 ---


### PR DESCRIPTION
## Summary

- Marks AEP-76 (Burn Mint Equilibrium), AEP-78 (CosmWasm), AEP-80 (x/oracle), and AEP-81 (Pyth integration) as completed on 2026-03-23 — Akash shipped BME in March 2026
- Replaces each AEP's `estimated-completion: 2026-03-23` with `completed: 2026-03-23` and bumps `updated`
- Regenerates `INDEX.md`, `ROADMAP.md`, and `index.json` via `scripts/index.js`
- Includes a small prerequisite commit adding `.worktrees` to `.gitignore`

## Test plan

- [ ] Confirm INDEX.md shows all four AEPs with `Completed = 2026-03-23` and no `Estimated`
- [ ] Confirm ROADMAP.md lists all four under the 2026-03-23 date
- [ ] Confirm `index.json` has `completed` field on all four entries and no `estimated-completion`
- [ ] Spot-check each spec README frontmatter