### PR TITLE
chore: update roadmap dates for AEPs 49, 60, 83

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -48,7 +48,7 @@
 | [46](spec/aep-46) | Spot Instances | Draft | Standard/Interface | 2024-12-01 |  | 2026-08-30 |
 | [47](spec/aep-47) | Long Standing Orders | Draft | Standard/Core | 2024-12-01 |  | 2026-12-31 |
 | [48](spec/aep-48) | Private Overlay Networking | Draft | Standard/Core | 2024-12-01 |  | 2026-07-30 |
-| [49](spec/aep-49) | Virtual Machines | Draft | Standard/Core | 2024-12-01 |  | 2026-03-31 |
+| [49](spec/aep-49) | Virtual Machines | Draft | Standard/Core | 2024-12-01 |  | 2026-08-30 |
 | [50](spec/aep-50) | Secrets Management | Draft | Standard/Core | 2024-12-01 |  | 2026-06-30 |
 | [51](spec/aep-51) | Lease Change Request | Draft | Standard/Core | 2024-12-01 |  | 2026-07-31 |
 | [52](spec/aep-52) | Rollover Provider | Draft | Core/Interface | 2024-12-01 |  | 2026-08-30 |
@@ -59,7 +59,7 @@
 | [57](spec/aep-57) | Automatic Escrow Top Up | Draft | Standard/Interface | 2024-01-05 | 2025-01-30 |  |
 | [58](spec/aep-58) | Per Node Resources in Console | Draft | Standard/Interface | 2024-01-05 |  | 2026-07-31 |
 | [59](spec/aep-59) | Provider Notifications | Draft | Standard/Interface | 2024-01-05 |  | 2026-05-31 |
-| [60](spec/aep-60) | Akash HomeNode - MVP | Draft | Meta | 2024-12-01 |  | 2026-03-31 |
+| [60](spec/aep-60) | Akash HomeNode - MVP | Final | Meta | 2024-12-01 | 2026-04-30 |  |
 | [61](spec/aep-61) | Enhanced Read Performance Onchain Queries | Last Call | Standard/Core | 2025-01-30 | 2025-03-12 |  |
 | [62](spec/aep-62) | Provider Console - Node Manager | Final | Standard/Interface | 2024-03-15 | 2025-04-17 |  |
 | [63](spec/aep-63) | Console API for Managed Wallet Users - v1 | Final | Standard/Interface | 2024-03-14 | 2025-05-28 |  |
@@ -81,6 +81,6 @@
 | [80](spec/aep-80) | On-Chain Oracle Module | Final | Standard/Core | 2026-03-06 | 2026-03-23 |  |
 | [81](spec/aep-81) | Pyth Price feed Integration | Final | Standard/Core | 2026-03-06 | 2026-03-23 |  |
 | [82](spec/aep-82) | Resource Reclamation | Last Call | Standard/Core | 2026-04-22 |  | 2026-05-31 |
-| [83](spec/aep-83) | Confidential Compute via Kata Containers | Draft | Standard/Core | 2026-04-14 |  |  |
+| [83](spec/aep-83) | Confidential Compute via Kata Containers | Draft | Standard/Core | 2026-04-14 |  | 2026-07-31 |
 | [84](spec/aep-84) | Console Split: Managed Platform and Self-Custodial Air | Final | Standard/Interface | 2026-04-24 |  | 2026-05-31 |
 | [85](spec/aep-85) | Console: Buildpacks-Powered Deployments | Draft | Standard/Interface | 2026-04-24 |  | 2026-09-30 |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,8 +42,7 @@
 | [78](spec/aep-78) | Enable CosmWasm Smart Contracts on Akash Network | 2026-03-23 | Major |
 | [80](spec/aep-80) | On-Chain Oracle Module | 2026-03-23 | Major |
 | [81](spec/aep-81) | Pyth Price feed Integration | 2026-03-23 | Major |
-| [49](spec/aep-49) | Virtual Machines | 2026-03-31 | Major |
-| [60](spec/aep-60) | Akash HomeNode - MVP | 2026-03-31 | Major |
+| [60](spec/aep-60) | Akash HomeNode - MVP | 2026-04-30 | Major |
 | [67](spec/aep-67) | Console Bid PreCheck | 2026-04-30 | Major |
 | [35](spec/aep-35) | Realtime Pricing In Akash Console | 2026-05-15 | Minor |
 | [29](spec/aep-29) | Hardware Verification using Trusted Execution | 2026-05-30 | Major |
@@ -59,8 +58,10 @@
 | [41](spec/aep-41) | Standard Provider Attributes | 2026-07-31 | Minor |
 | [51](spec/aep-51) | Lease Change Request | 2026-07-31 | Minor |
 | [58](spec/aep-58) | Per Node Resources in Console | 2026-07-31 | Minor |
+| [83](spec/aep-83) | Confidential Compute via Kata Containers | 2026-07-31 | Major |
 | [65](spec/aep-65) | Confidential Computing | 2026-07-31 | Major |
 | [46](spec/aep-46) | Spot Instances | 2026-08-30 | Minor |
+| [49](spec/aep-49) | Virtual Machines | 2026-08-30 | Major |
 | [52](spec/aep-52) | Rollover Provider | 2026-08-30 | Minor |
 | [45](spec/aep-45) | Offchain Compute Inventory | 2026-08-31 | Minor |
 | [85](spec/aep-85) | Console: Buildpacks-Powered Deployments | 2026-09-30 | Major |

--- a/index.json
+++ b/index.json
@@ -536,8 +536,8 @@
     "type": "Standard",
     "category": "Core",
     "created": "2024-12-01T00:00:00.000Z",
-    "updated": "2025-01-11T00:00:00.000Z",
-    "estimated-completion": "2026-03-31T00:00:00.000Z",
+    "updated": "2026-05-01T00:00:00.000Z",
+    "estimated-completion": "2026-08-30T00:00:00.000Z",
     "roadmap": "major"
   },
   {
@@ -686,11 +686,11 @@
     "aep": 60,
     "title": "Akash HomeNode - MVP",
     "author": "Anil Murty (@anilmurty) Damir Simpovic (@shimpa1) Jigar Patel (@jigar-arc10) Deval Patel (@devalpatel67) Greg Osuri (@gosuri)",
-    "status": "Draft",
+    "status": "Final",
     "type": "Meta",
     "created": "2024-12-01T00:00:00.000Z",
-    "updated": "2025-07-24T00:00:00.000Z",
-    "estimated-completion": "2026-03-31T00:00:00.000Z",
+    "updated": "2026-05-01T00:00:00.000Z",
+    "completed": "2026-04-30T00:00:00.000Z",
     "roadmap": "major"
   },
   {
@@ -993,6 +993,8 @@
     "type": "Standard",
     "category": "Core",
     "created": "2026-04-14T00:00:00.000Z",
+    "updated": "2026-05-01T00:00:00.000Z",
+    "estimated-completion": "2026-07-31T00:00:00.000Z",
     "requires": [
       "29",
       "65"

--- a/spec/aep-49/README.md
+++ b/spec/aep-49/README.md
@@ -6,8 +6,8 @@ status: Draft
 type: Standard
 category: Core
 created: 2024-12-01
-updated: 2025-01-11
-estimated-completion: 2026-03-31
+updated: 2026-05-01
+estimated-completion: 2026-08-30
 roadmap: major
 ---
 

--- a/spec/aep-60/README.md
+++ b/spec/aep-60/README.md
@@ -2,11 +2,11 @@
 aep: 60
 title: "Akash HomeNode - MVP"
 author: Anil Murty (@anilmurty) Damir Simpovic (@shimpa1) Jigar Patel (@jigar-arc10) Deval Patel (@devalpatel67) Greg Osuri (@gosuri)
-status: Draft
+status: Final
 type: Meta
 created: 2024-12-01
-updated: 2025-07-24
-estimated-completion: 2026-03-31
+updated: 2026-05-01
+completed: 2026-04-30
 roadmap: major
 ---
 

--- a/spec/aep-83/README.md
+++ b/spec/aep-83/README.md
@@ -6,6 +6,8 @@ status: Draft
 type: Standard
 category: Core
 created: 2026-04-14
+updated: 2026-05-01
+estimated-completion: 2026-07-31
 requires: 29, 65
 roadmap: major
 ---


### PR DESCRIPTION
## Summary
- aep-49 (Virtual Machines): push estimated completion to 2026-08-30
- aep-60 (Akash HomeNode - MVP): mark completed on 2026-04-30, status Final
- aep-83 (Confidential Compute via Kata Containers): add estimated completion 2026-07-31

## Test plan
- [x] `node scripts/index.js` regenerates INDEX.md, ROADMAP.md, index.json cleanly
- [x] Roadmap entries reflect new dates