### PR TITLE
chore: update aep-86 spec and implementation using feedback.md and engineering meeting feedback

### DIFF
--- a/spec/aep-86/IMPLEMENTATION.md
+++ b/spec/aep-86/IMPLEMENTATION.md
@@ -74,6 +74,277 @@ During the [migration period](./README.md#migration-from-aep-9), a governance pa
 - `true`: market module uses `x/verification` for bid matching. `x/audit` matching is retained only
   for existing deployments created before activation.
 
+`x/market` keeps both keeper dependencies during Phase 1 and Phase 2. Bid filtering should be routed through a
+market-owned adapter that evaluates legacy `AttributesFilters`, new `VerificationRequirement`, or both. Mixed orders
+require both filters to pass after activation.
+
+### 1.7 Keeper Cycle Resolution
+
+`x/verification` needs read-only lease stats from `x/market`, and `x/market` needs read-only verification facts from
+`x/verification`. Avoid a concrete keeper construction cycle by using narrow interfaces and late binding:
+
+- `x/verification` receives `MarketStatsKeeper`, which only exposes `GetProviderLeaseStats`.
+- `x/market` receives `VerificationKeeper`, which only exposes bid-filtering queries.
+- App wiring constructs both keepers, then sets the interfaces. Neither module imports the other's concrete keeper type.
+
+### 1.8 Audit Escrow Payment Flow
+
+`MsgSubmitAttestation` remains auditor-signed only. Provider funds are collected through `MsgOpenAuditEscrow`, a
+provider-signed message that creates an `AuditEscrowRecord`. The submit handler consumes the escrow by `audit_escrow_id`
+and must not debit the provider account during `MsgSubmitAttestation`. `MsgOpenAuditEscrow` does not name an auditor.
+There is no auditor acceptance or claim transaction in v1. The first valid `MsgSubmitAttestation` that references an
+open, matching, unexpired escrow consumes it and records the submitting auditor.
+The attestation must include at least the escrow's requested capabilities, but it may include additional capabilities
+the auditor verified.
+
+AEP-86 v1 uses one `x/verification` module account to hold verification funds and typed `x/verification` KV records to
+track why each amount is held and how it can be released.
+
+The escrow prefixes in this AEP are KV-store prefixes for verification records. They are not separate bank module
+accounts. Audit escrow records and grace records use dynamic marshalled envelopes so the module can decode different
+verification lifecycle records cleanly. Auditor deposits and pending discrepancy state remain fields on
+`AttestationRecord` and `DiscrepancyEvent` in v1.
+
+The provider deposit cannot be redirected or slashed by an auditor alone. Provider-signed cancellation can only return
+provider-funded coins to the provider while the escrow is open and unconsumed. Any path that slashes the provider
+deposit to the community pool must be signed by governance authority with typed fault attribution and an evidence hash.
+
+Handler path:
+
+- `MsgOpenAuditEscrow`: validate provider registration, minimum fee, provider deposit parameter, and expiry. Transfer
+  `fee + provider_deposit` from provider to the `x/verification` module account. Store `AuditEscrowRecord` as `Open`,
+  with fee and provider deposit statuses set to escrowed, and enqueue expiry.
+- `MsgCancelAuditEscrow`: require provider signer, `Open` status, and `block_time < expires_at`. Return fee and provider
+  deposit to the provider, set status `Cancelled`, and set settlement reason `CancelledUnconsumed`.
+- `MsgSettleAuditEscrow`: require governance authority and an unconsumed escrow. The reason must be `ProviderFault` or
+  `NoFault`, and `fault_attribution` must match the reason. `NoFault` returns provider-funded coins to the provider.
+  `ProviderFault` returns the fee to the provider and slashes the provider deposit to the community pool. The handler
+  must reject missing evidence or ambiguous fault attribution. V1 does not pay an auditor from an unconsumed escrow unless
+  an attestation was submitted.
+- `MsgSubmitAttestation`: require `Open` status and `block_time < expires_at`, validate provider, tier, and requested
+  capabilities, then set status `Consumed`, record `consumed_by_auditor`, and move the fee lifecycle onto the
+  attestation record.
+
+### 1.9 Signing Key Enforcement Deferred
+
+AEP-86 v1 evidence may include observed software version, binary digest, and signature bytes, but the module does not
+implement on-chain signing enforcement. Do not add signing-key state, key-type definitions, governance messages,
+signing-key queries, or signature rejection rules in the v1 module. Those belong to a separate signing-key AEP or phase
+2 change.
+
+### 1.10 V1 Auditor Software Deliverable
+
+Activation requires a reference auditor CLI or agent that can collect audit inputs, evaluate tier checks, emit canonical
+evidence, consume audit escrows, submit attestations, and revoke attestations with typed reasons. Treat this as part of
+the AEP-86 v1 implementation scope, alongside the module and market wiring.
+
+The auditor software has two workflow phases:
+
+- Baseline phase: run the initial benchmark, record the provider state, and commit the baseline artifact through
+  `evidence_hash`.
+- Sustained validation phase: rerun checks during the TTL and compare current results to the baseline. Failed sustained
+  validation drives typed revocation or lower-tier replacement.
+
+### 1.11 Fund Settlement
+
+V1 should not add a generic delayed-settlement proposal path. Implement a shared settlement helper used by ordinary
+terminal states, `ResolveDiscrepancy`, `MsgSettleAuditEscrow` when the governance authority settles an unconsumed
+escrow, and discrepancy timeout handling. The helper updates explicit fee and deposit status fields and rejects
+ambiguous settlement requests that do not provide a concrete fault attribution or deterministic timeout rule.
+
+### 1.12 x/provider Maintenance Notices
+
+AEP-86 adds provider-to-tenant maintenance signaling to `x/provider`, not `x/verification`. The chain stores the
+provider's maintenance window and emits typed events. Tenant delivery is handled by clients, indexers, REST services,
+or Console after they map the provider event to active leases in `x/market`.
+
+The current provider module already owns provider identity and registration. Keep the maintenance state in that module
+so the signer check is local and the notification feature does not create another dependency from `x/verification`.
+No provider-module EndBlocker is required for phase 1. A maintenance window is treated as scheduled, active, elapsed,
+or closed by comparing the record to block time in query code. Queries must derive status from the record and block
+time instead of trusting the active-maintenance index alone.
+
+Required `x/provider` additions:
+
+- Add provider maintenance protobuf types to the provider chain SDK package, currently
+  `pkg.akt.dev/go/node/provider/v1beta4`.
+- Add `MsgOpenProviderMaintenance` and `MsgCloseProviderMaintenance` to the provider `Msg` service.
+- Add provider maintenance queries to the provider `Query` service.
+- Add typed events for open and close.
+- Add provider module params for maintenance duration and scheduling lookahead. If `x/provider` does not already have a
+  params record, this change must add one to provider genesis import and export.
+
+Suggested protobuf shape:
+
+```protobuf
+enum ProviderMaintenanceType {
+    provider_maintenance_type_unspecified = 0;
+    provider_maintenance_type_planned = 1;
+    provider_maintenance_type_emergency = 2;
+    provider_maintenance_type_security = 3;
+    provider_maintenance_type_network = 4;
+    provider_maintenance_type_capacity = 5;
+}
+
+enum ProviderMaintenanceStatus {
+    provider_maintenance_status_unspecified = 0;
+    provider_maintenance_status_scheduled = 1;
+    provider_maintenance_status_active = 2;
+    provider_maintenance_status_elapsed = 3;
+    provider_maintenance_status_closed = 4;
+}
+
+message ProviderMaintenanceRecord {
+    uint64 id = 1;
+    string provider = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+    ProviderMaintenanceType maintenance_type = 3;
+    google.protobuf.Timestamp starts_at = 4 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
+    google.protobuf.Timestamp expected_ends_at = 5 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
+    google.protobuf.Timestamp opened_at = 6 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
+    google.protobuf.Timestamp closed_at = 7 [(gogoproto.stdtime) = true];
+    bytes metadata_hash = 8;
+}
+
+message ProviderMaintenanceWithStatus {
+    ProviderMaintenanceRecord record = 1 [(gogoproto.nullable) = false];
+    ProviderMaintenanceStatus status = 2;
+}
+
+message ProviderMaintenanceParams {
+    google.protobuf.Duration maintenance_max_duration = 1
+        [(gogoproto.stdduration) = true, (gogoproto.nullable) = false];
+    google.protobuf.Duration maintenance_max_lookahead = 2
+        [(gogoproto.stdduration) = true, (gogoproto.nullable) = false];
+}
+
+message MsgOpenProviderMaintenance {
+    option (cosmos.msg.v1.signer) = "provider";
+    option (amino.name) = "akash/provider/v1beta4/MsgOpenProviderMaintenance";
+
+    string provider = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+    ProviderMaintenanceType maintenance_type = 2;
+    google.protobuf.Timestamp starts_at = 3 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
+    google.protobuf.Timestamp expected_ends_at = 4 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
+    bytes metadata_hash = 5;
+}
+message MsgOpenProviderMaintenanceResponse {
+    uint64 maintenance_id = 1;
+}
+
+message MsgCloseProviderMaintenance {
+    option (cosmos.msg.v1.signer) = "provider";
+    option (amino.name) = "akash/provider/v1beta4/MsgCloseProviderMaintenance";
+
+    string provider = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+    uint64 maintenance_id = 2;
+}
+message MsgCloseProviderMaintenanceResponse {}
+```
+
+Suggested query shape:
+
+```protobuf
+service Query {
+    rpc ProviderMaintenance(QueryProviderMaintenanceRequest) returns (QueryProviderMaintenanceResponse) {
+        option (google.api.http).get = "/akash/provider/v1beta4/providers/{provider}/maintenance/{maintenance_id}";
+    }
+
+    rpc ProviderMaintenances(QueryProviderMaintenancesRequest) returns (QueryProviderMaintenancesResponse) {
+        option (google.api.http).get = "/akash/provider/v1beta4/providers/{provider}/maintenance";
+    }
+}
+
+message QueryProviderMaintenanceRequest {
+    string provider = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+    uint64 maintenance_id = 2;
+}
+message QueryProviderMaintenanceResponse {
+    ProviderMaintenanceWithStatus maintenance = 1 [(gogoproto.nullable) = false];
+}
+
+message QueryProviderMaintenancesRequest {
+    string provider = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+    ProviderMaintenanceStatus status_filter = 2;
+    cosmos.base.query.v1beta1.PageRequest pagination = 3;
+}
+message QueryProviderMaintenancesResponse {
+    repeated ProviderMaintenanceWithStatus maintenance = 1 [(gogoproto.nullable) = false];
+    cosmos.base.query.v1beta1.PageResponse pagination = 2;
+}
+```
+
+Suggested events:
+
+```protobuf
+message EventProviderMaintenanceOpened {
+    uint64 maintenance_id = 1;
+    string provider = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+    ProviderMaintenanceType maintenance_type = 3;
+    google.protobuf.Timestamp starts_at = 4 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
+    google.protobuf.Timestamp expected_ends_at = 5 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
+    bytes metadata_hash = 6;
+}
+
+message EventProviderMaintenanceClosed {
+    uint64 maintenance_id = 1;
+    string provider = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+    google.protobuf.Timestamp closed_at = 3 [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
+}
+```
+
+Handler rules:
+
+- `MsgOpenProviderMaintenance` validates that `provider` is registered in `x/provider`.
+- The provider address is the signer.
+- `maintenance_type` must not be unspecified.
+- `expected_ends_at` must be after `starts_at`.
+- `expected_ends_at - starts_at` must be less than or equal to `maintenance_max_duration`.
+- `starts_at` must be no later than `block_time + maintenance_max_lookahead`.
+- V1 allows at most one scheduled or active maintenance window per provider. The keeper can enforce this with an
+  active-maintenance index keyed by provider address. When opening a new window, if the existing indexed record has
+  `block_time >= expected_ends_at`, clear the stale index and allow the new window.
+- `MsgCloseProviderMaintenance` validates that the record exists, belongs to the signer, and has not already been
+  closed. It sets `closed_at = block_time`, clears the active-maintenance index if it points at this record, and emits
+  `EventProviderMaintenanceClosed`.
+
+Suggested provider store additions:
+
+```text
+ProviderMaintenancePrefix | maintenance_id                 -> ProviderMaintenanceRecord
+ProviderMaintenanceByOwnerPrefix | provider | maintenance_id -> []byte
+ProviderActiveMaintenancePrefix | provider                 -> maintenance_id
+ProviderNextMaintenanceIDPrefix                           -> uint64
+ProviderParamsPrefix                                      -> ProviderMaintenanceParams
+```
+
+The exact byte prefixes must be chosen in the provider chain SDK package so they do not collide with the existing
+provider record prefix.
+
+Client alert flow:
+
+1. A provider tx emits `EventProviderMaintenanceOpened`.
+2. An indexer, REST service, WebSocket listener, or Console backend observes the event.
+3. The listener queries `x/market` active leases for the provider.
+4. The listener maps lease owners to tenant notification preferences outside consensus.
+5. Console or another tenant-facing client delivers the alert through the tenant's selected channel.
+6. Clients query `ProviderMaintenances` when loading a provider, lease, or deployment view so a missed event does not
+   hide an active or scheduled window.
+
+This feature does not require the chain to store email addresses, webhooks, Slack destinations, Discord destinations,
+Telegram destinations, or tenant acknowledgement state.
+
+Minimum tests:
+
+- Opening maintenance fails for an address that is not a registered provider.
+- Opening maintenance fails for unspecified type, invalid time order, excessive duration, excessive lookahead, or an
+  already scheduled or active provider window.
+- Opening a new maintenance window clears a stale active-maintenance index when the previous window has elapsed.
+- Opening maintenance stores the record, creates the provider indexes, and emits `EventProviderMaintenanceOpened`.
+- Closing maintenance fails for a different signer or an unknown record.
+- Closing maintenance sets `closed_at`, clears the active-maintenance index, and emits `EventProviderMaintenanceClosed`.
+- Queries return derived `Scheduled`, `Active`, `Elapsed`, and `Closed` statuses from block time and `closed_at`.
+- A client or integration test can map a maintenance event to active leases through existing `x/market` lease queries.
+
 ---
 
 ## 2. Store Key Design Rationale
@@ -85,6 +356,11 @@ Supplements [Store Layout and Indexing](./README.md#store-layout-and-indexing) w
 - **Attestation primary key** is `(provider, auditor)` because the most common query pattern is "get all
   attestations for a provider" (prefix scan on `0x02 | provider_addr`).
 - **Auditor secondary index** (`0x10`) enables the reverse lookup without duplicating attestation data.
+- **Audit escrow indexes** (`0x11`, `0x12`) allow provider and auditor escrow queries without scanning all escrows.
+  The auditor index is created only after an auditor consumes the escrow with `MsgSubmitAttestation`.
+- **Dynamic verification records** under `0x08` and `0x0A` use `VerificationStoreRecord` envelopes with `type_url`
+  and bytes so newly added escrow or verification lifecycle records can be decoded cleanly by registered decoders.
+  These are record prefixes. They do not imply separate module accounts.
 - **Time queues** use big-endian timestamps so that lexicographic ordering equals chronological ordering,
   allowing efficient `KVStorePrefixIterator` up to the current block time.
 - **Unbonding sequence** (`seq` in `0x23`) allows multiple concurrent unbonding entries for the same provider
@@ -98,6 +374,8 @@ When inserting a queue entry:
 - Snapshot hash posted -> remove old `0x22` entry (if any), add new with `compliance_deadline`
 - Bond withdrawal initiated -> add to `0x23` with `completion_time`
 - Auditor resignation/lapse -> add to `0x24` with `completion_time`
+- Audit escrow opened -> add to `0x26` with `expires_at`
+- Discrepancy grace created -> add to `0x27` with `expires_at`
 
 When processing a queue entry ([EndBlocker](./README.md#endblocker-design)):
 - Process the state transition
@@ -171,6 +449,10 @@ func TierBetter(a, b VerificationTier) bool {
 ```go
 // VerificationKeeper -- from x/verification, used by x/market for bid filtering
 type VerificationKeeper interface {
+    // IsVerificationActive returns the verification_module_active governance parameter.
+    // x/market uses this to decide whether VerificationRequirement is enforced.
+    IsVerificationActive(ctx sdk.Context) bool
+
     // GetProviderValidAttestations returns all Valid, non-expired attestations for a provider.
     // Does NOT filter by snapshot compliance -- caller must check separately.
     GetProviderValidAttestations(ctx sdk.Context, provider sdk.Address) ([]AttestationRecord, bool)
@@ -183,52 +465,88 @@ type VerificationKeeper interface {
     // from valid attestations. Returns TierUnspecified if no valid attestations exist.
     GetProviderBestTier(ctx sdk.Context, provider sdk.Address) VerificationTier
 
+    // GetProviderGraceTier returns the active discrepancy grace tier, if one exists.
+    // x/market uses this for tier filtering only when verification filtering is active.
+    GetProviderGraceTier(ctx sdk.Context, provider sdk.Address) (VerificationTier, bool)
+
     // ProviderHasCapability returns true if any valid attestation for this provider
     // includes the given capability flag.
     ProviderHasCapability(ctx sdk.Context, provider sdk.Address, cap CapabilityFlag) bool
+
+    // CountQualifiedAuditors returns the number of independent auditors with valid
+    // attestations at minTier or better. Named auditor requirements are checked separately.
+    CountQualifiedAuditors(
+        ctx sdk.Context,
+        provider sdk.Address,
+        minTier VerificationTier,
+    ) uint32
 }
 ```
 
 ### 3.4 Market Module Bid Filtering (x/market/handler/server.go)
 
-Replaces the current audit-based matching in `CreateBid`:
+Extends the current audit-based matching in `CreateBid`:
 
 ```go
-// CURRENT (to be replaced):
+// Existing legacy audit check remains in place during migration:
 //   provAttr, _ := ms.keepers.Audit.GetProviderAttributes(ctx, provider)
 //   provAttr = append([]atypes.AuditedProvider{{...}}, provAttr...)
 //   if !order.MatchRequirements(provAttr) { return nil, mv1.ErrAttributeMismatch }
 
-// NEW:
+// New verification check:
 verReq := order.VerificationRequirement()
+verificationActive := ms.keepers.Verification.IsVerificationActive(ctx)
 
-if verReq.MinTier != TierUnspecified {
-    bestTier := ms.keepers.Verification.GetProviderBestTier(ctx, provider)
-    if !TierAtLeast(bestTier, verReq.MinTier) {
-        return nil, mv1.ErrInsufficientVerificationTier
-    }
-
-    // L2+ providers must be snapshot-compliant for bid eligibility
-    if TierAtLeast(bestTier, TierVerified) {
+if verificationActive && verReq.MinTier != TierUnspecified {
+    // L2+ orders must reject snapshot-suspended providers even if a grace tier exists.
+    if TierAtLeast(verReq.MinTier, TierVerified) {
         if !ms.keepers.Verification.IsProviderSnapshotCompliant(ctx, provider) {
             return nil, mv1.ErrProviderSnapshotSuspended
         }
     }
-}
 
-for _, requiredCap := range verReq.RequiredCapabilities {
-    if !ms.keepers.Verification.ProviderHasCapability(ctx, provider, requiredCap) {
-        return nil, mv1.ErrMissingCapability
+    filterTier := ms.keepers.Verification.GetProviderBestTier(ctx, provider)
+    if graceTier, ok := ms.keepers.Verification.GetProviderGraceTier(ctx, provider); ok {
+        // A grace record preserves the pre-discrepancy tier for tier filtering only.
+        filterTier = graceTier
     }
-}
+    if !TierAtLeast(filterTier, verReq.MinTier) {
+        return nil, mv1.ErrInsufficientVerificationTier
+    }
 
-if len(verReq.RequiredAuditors) > 0 {
-    attestations, _ := ms.keepers.Verification.GetProviderValidAttestations(ctx, provider)
-    if !hasAttestationFromAny(attestations, verReq.RequiredAuditors) {
-        return nil, mv1.ErrRequiredAuditorNotFound
+    for _, requiredCap := range verReq.RequiredCapabilities {
+        if !ms.keepers.Verification.ProviderHasCapability(ctx, provider, requiredCap) {
+            return nil, mv1.ErrMissingCapability
+        }
+    }
+
+    if verReq.MinAuditorCount > 0 {
+        count := ms.keepers.Verification.CountQualifiedAuditors(
+            ctx,
+            provider,
+            verReq.MinTier,
+        )
+        if count < verReq.MinAuditorCount {
+            return nil, mv1.ErrInsufficientAuditorCount
+        }
+    }
+
+    if len(verReq.RequiredAuditors) > 0 {
+        attestations, _ := ms.keepers.Verification.GetProviderValidAttestations(ctx, provider)
+        if verReq.AuditorMode == AuditorSelectionModeAll {
+            if !hasAttestationFromAll(attestations, verReq.RequiredAuditors, verReq.MinTier) {
+                return nil, mv1.ErrRequiredAuditorNotFound
+            }
+        } else if !hasAttestationFromAny(attestations, verReq.RequiredAuditors, verReq.MinTier) {
+            return nil, mv1.ErrRequiredAuditorNotFound
+        }
     }
 }
 ```
+
+During migration, this verification check is called by the market-owned adapter only when
+`verification_module_active == true`. Legacy `AttributesFilters` continue to use `AuditKeeper`. If an order has both
+legacy attributes and verification requirements, the adapter requires both checks to pass.
 
 ### 3.5 VerificationRequirement (x/deployment proto addition)
 
@@ -248,6 +566,8 @@ message VerificationRequirement {
     VerificationTier min_tier = 1;                     // 0 = no requirement
     repeated CapabilityFlag required_capabilities = 2;
     repeated string required_auditors = 3;             // specific auditor addresses (optional)
+    AuditorSelectionMode auditor_mode = 4;             // any or all for required_auditors; unspecified means any
+    uint32 min_auditor_count = 5;                      // total independent auditors required
 }
 ```
 
@@ -332,6 +652,10 @@ enum AttestationStatus {
         [(gogoproto.enumvalue_customname) = "AttestationStatusRemoved"];
 }
 
+// Disputed attestations are stored as status=Voided with voided_reason=Discrepancy
+// and a pending DiscrepancyEvent. Replacement is a transition event before the
+// (provider, auditor) attestation record is overwritten, not a persisted status.
+
 enum VoidedReason {
     option (gogoproto.goproto_enum_prefix) = false;
 
@@ -358,6 +682,178 @@ enum FeeStatus {
         [(gogoproto.enumvalue_customname) = "FeeStatusReleasedToAuditor"];
     fee_status_returned_to_provider = 3
         [(gogoproto.enumvalue_customname) = "FeeStatusReturnedToProvider"];
+}
+
+enum DepositStatus {
+    option (gogoproto.goproto_enum_prefix) = false;
+
+    deposit_status_unspecified = 0
+        [(gogoproto.enumvalue_customname) = "DepositStatusUnspecified"];
+    deposit_status_escrowed = 1
+        [(gogoproto.enumvalue_customname) = "DepositStatusEscrowed"];
+    deposit_status_pending_discrepancy = 2
+        [(gogoproto.enumvalue_customname) = "DepositStatusPendingDiscrepancy"];
+    deposit_status_returned_to_auditor = 3
+        [(gogoproto.enumvalue_customname) = "DepositStatusReturnedToAuditor"];
+    deposit_status_slashed = 4
+        [(gogoproto.enumvalue_customname) = "DepositStatusSlashed"];
+}
+
+enum ProviderDepositStatus {
+    option (gogoproto.goproto_enum_prefix) = false;
+
+    provider_deposit_status_unspecified = 0
+        [(gogoproto.enumvalue_customname) = "ProviderDepositStatusUnspecified"];
+    provider_deposit_status_escrowed = 1
+        [(gogoproto.enumvalue_customname) = "ProviderDepositStatusEscrowed"];
+    provider_deposit_status_returned_to_provider = 2
+        [(gogoproto.enumvalue_customname) = "ProviderDepositStatusReturnedToProvider"];
+    provider_deposit_status_slashed = 3
+        [(gogoproto.enumvalue_customname) = "ProviderDepositStatusSlashed"];
+}
+
+enum FaultAttribution {
+    option (gogoproto.goproto_enum_prefix) = false;
+
+    fault_attribution_unspecified = 0
+        [(gogoproto.enumvalue_customname) = "FaultAttributionUnspecified"];
+    fault_attribution_provider_fault = 1
+        [(gogoproto.enumvalue_customname) = "FaultAttributionProviderFault"];
+    fault_attribution_auditor_fault = 2
+        [(gogoproto.enumvalue_customname) = "FaultAttributionAuditorFault"];
+    fault_attribution_shared_fault = 3
+        [(gogoproto.enumvalue_customname) = "FaultAttributionSharedFault"];
+    fault_attribution_no_fault = 4
+        [(gogoproto.enumvalue_customname) = "FaultAttributionNoFault"];
+    fault_attribution_inconclusive = 5
+        [(gogoproto.enumvalue_customname) = "FaultAttributionInconclusive"];
+}
+
+enum AttestationRevocationReason {
+    option (gogoproto.goproto_enum_prefix) = false;
+
+    attestation_revocation_reason_unspecified = 0
+        [(gogoproto.enumvalue_customname) = "AttestationRevocationReasonUnspecified"];
+    attestation_revocation_reason_provider_no_longer_qualifies = 1
+        [(gogoproto.enumvalue_customname) = "AttestationRevocationReasonProviderNoLongerQualifies"];
+    attestation_revocation_reason_snapshot_mismatch = 2
+        [(gogoproto.enumvalue_customname) = "AttestationRevocationReasonSnapshotMismatch"];
+    attestation_revocation_reason_software_identity_changed = 3
+        [(gogoproto.enumvalue_customname) = "AttestationRevocationReasonSoftwareIdentityChanged"];
+    attestation_revocation_reason_capability_misrepresented = 4
+        [(gogoproto.enumvalue_customname) = "AttestationRevocationReasonCapabilityMisrepresented"];
+    attestation_revocation_reason_provider_non_responsive = 5
+        [(gogoproto.enumvalue_customname) = "AttestationRevocationReasonProviderNonResponsive"];
+    attestation_revocation_reason_auditor_evidence_error = 6
+        [(gogoproto.enumvalue_customname) = "AttestationRevocationReasonAuditorEvidenceError"];
+    attestation_revocation_reason_auditor_operational_exit = 7
+        [(gogoproto.enumvalue_customname) = "AttestationRevocationReasonAuditorOperationalExit"];
+}
+
+enum GovernanceAttestationReason {
+    option (gogoproto.goproto_enum_prefix) = false;
+
+    governance_attestation_reason_unspecified = 0
+        [(gogoproto.enumvalue_customname) = "GovernanceAttestationReasonUnspecified"];
+    governance_attestation_reason_fraudulent_provider = 1
+        [(gogoproto.enumvalue_customname) = "GovernanceAttestationReasonFraudulentProvider"];
+    governance_attestation_reason_compromised_provider = 2
+        [(gogoproto.enumvalue_customname) = "GovernanceAttestationReasonCompromisedProvider"];
+    governance_attestation_reason_provider_non_cooperation = 3
+        [(gogoproto.enumvalue_customname) = "GovernanceAttestationReasonProviderNonCooperation"];
+    governance_attestation_reason_faulty_auditor = 4
+        [(gogoproto.enumvalue_customname) = "GovernanceAttestationReasonFaultyAuditor"];
+    governance_attestation_reason_negligent_auditor = 5
+        [(gogoproto.enumvalue_customname) = "GovernanceAttestationReasonNegligentAuditor"];
+    governance_attestation_reason_evidence_insufficient = 6
+        [(gogoproto.enumvalue_customname) = "GovernanceAttestationReasonEvidenceInsufficient"];
+    governance_attestation_reason_emergency_safety_action = 7
+        [(gogoproto.enumvalue_customname) = "GovernanceAttestationReasonEmergencySafetyAction"];
+}
+
+enum AuditEscrowSettlementReason {
+    option (gogoproto.goproto_enum_prefix) = false;
+
+    audit_escrow_settlement_reason_unspecified = 0
+        [(gogoproto.enumvalue_customname) = "AuditEscrowSettlementReasonUnspecified"];
+    audit_escrow_settlement_reason_cancelled_unconsumed = 1
+        [(gogoproto.enumvalue_customname) = "AuditEscrowSettlementReasonCancelledUnconsumed"];
+    audit_escrow_settlement_reason_expired_unconsumed = 2
+        [(gogoproto.enumvalue_customname) = "AuditEscrowSettlementReasonExpiredUnconsumed"];
+    audit_escrow_settlement_reason_provider_fault = 3
+        [(gogoproto.enumvalue_customname) = "AuditEscrowSettlementReasonProviderFault"];
+    audit_escrow_settlement_reason_no_fault = 4
+        [(gogoproto.enumvalue_customname) = "AuditEscrowSettlementReasonNoFault"];
+}
+
+enum DiscrepancyResolutionReason {
+    option (gogoproto.goproto_enum_prefix) = false;
+
+    discrepancy_resolution_reason_unspecified = 0
+        [(gogoproto.enumvalue_customname) = "DiscrepancyResolutionReasonUnspecified"];
+    discrepancy_resolution_reason_auditor_a_correct = 1
+        [(gogoproto.enumvalue_customname) = "DiscrepancyResolutionReasonAuditorACorrect"];
+    discrepancy_resolution_reason_auditor_b_correct = 2
+        [(gogoproto.enumvalue_customname) = "DiscrepancyResolutionReasonAuditorBCorrect"];
+    discrepancy_resolution_reason_both_auditors_wrong = 3
+        [(gogoproto.enumvalue_customname) = "DiscrepancyResolutionReasonBothAuditorsWrong"];
+    discrepancy_resolution_reason_provider_fault = 4
+        [(gogoproto.enumvalue_customname) = "DiscrepancyResolutionReasonProviderFault"];
+    discrepancy_resolution_reason_shared_fault = 5
+        [(gogoproto.enumvalue_customname) = "DiscrepancyResolutionReasonSharedFault"];
+    discrepancy_resolution_reason_evidence_inconclusive = 6
+        [(gogoproto.enumvalue_customname) = "DiscrepancyResolutionReasonEvidenceInconclusive"];
+    discrepancy_resolution_reason_governance_timeout_review = 7
+        [(gogoproto.enumvalue_customname) = "DiscrepancyResolutionReasonGovernanceTimeoutReview"];
+}
+
+enum ProviderBondSlashReason {
+    option (gogoproto.goproto_enum_prefix) = false;
+
+    provider_bond_slash_reason_unspecified = 0
+        [(gogoproto.enumvalue_customname) = "ProviderBondSlashReasonUnspecified"];
+    provider_bond_slash_reason_resource_misrepresentation = 1
+        [(gogoproto.enumvalue_customname) = "ProviderBondSlashReasonResourceMisrepresentation"];
+    provider_bond_slash_reason_capacity_overstatement = 2
+        [(gogoproto.enumvalue_customname) = "ProviderBondSlashReasonCapacityOverstatement"];
+    provider_bond_slash_reason_fraudulent_snapshot = 3
+        [(gogoproto.enumvalue_customname) = "ProviderBondSlashReasonFraudulentSnapshot"];
+    provider_bond_slash_reason_provider_compromise = 4
+        [(gogoproto.enumvalue_customname) = "ProviderBondSlashReasonProviderCompromise"];
+    provider_bond_slash_reason_sla_breach = 5
+        [(gogoproto.enumvalue_customname) = "ProviderBondSlashReasonSLABreach"];
+    provider_bond_slash_reason_non_cooperation_during_audit = 6
+        [(gogoproto.enumvalue_customname) = "ProviderBondSlashReasonNonCooperationDuringAudit"];
+}
+
+enum AuditEscrowStatus {
+    option (gogoproto.goproto_enum_prefix) = false;
+
+    audit_escrow_status_unspecified = 0
+        [(gogoproto.enumvalue_customname) = "AuditEscrowStatusUnspecified"];
+    audit_escrow_status_open = 1
+        [(gogoproto.enumvalue_customname) = "AuditEscrowStatusOpen"];
+    audit_escrow_status_consumed = 2
+        [(gogoproto.enumvalue_customname) = "AuditEscrowStatusConsumed"];
+    audit_escrow_status_cancelled = 3
+        [(gogoproto.enumvalue_customname) = "AuditEscrowStatusCancelled"];
+    audit_escrow_status_expired = 4
+        [(gogoproto.enumvalue_customname) = "AuditEscrowStatusExpired"];
+    audit_escrow_status_settled = 5
+        [(gogoproto.enumvalue_customname) = "AuditEscrowStatusSettled"];
+}
+
+enum VerificationGraceStatus {
+    option (gogoproto.goproto_enum_prefix) = false;
+
+    verification_grace_status_unspecified = 0
+        [(gogoproto.enumvalue_customname) = "VerificationGraceStatusUnspecified"];
+    verification_grace_status_active = 1
+        [(gogoproto.enumvalue_customname) = "VerificationGraceStatusActive"];
+    verification_grace_status_expired = 2
+        [(gogoproto.enumvalue_customname) = "VerificationGraceStatusExpired"];
+    verification_grace_status_terminated = 3
+        [(gogoproto.enumvalue_customname) = "VerificationGraceStatusTerminated"];
 }
 
 enum DiscrepancyStatus {
@@ -387,6 +883,18 @@ enum CapabilityFlag {
     capability_bare_metal = 4
         [(gogoproto.enumvalue_customname) = "CapabilityBareMetal"];
 }
+
+enum AuditorSelectionMode {
+    option (gogoproto.goproto_enum_prefix) = false;
+
+    auditor_selection_mode_unspecified = 0
+        [(gogoproto.enumvalue_customname) = "AuditorSelectionModeUnspecified"];
+    auditor_selection_mode_any = 1
+        [(gogoproto.enumvalue_customname) = "AuditorSelectionModeAny"];
+    auditor_selection_mode_all = 2
+        [(gogoproto.enumvalue_customname) = "AuditorSelectionModeAll"];
+}
+
 ```
 
 ### 4.2 state.proto
@@ -416,6 +924,8 @@ message AuditorRecord {
     google.protobuf.Timestamp renewal_deadline = 8
         [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
     uint64 discrepancy_count = 9;
+    google.protobuf.Timestamp bond_unbonding_completion_time = 10
+        [(gogoproto.nullable) = true, (gogoproto.stdtime) = true];
 }
 
 message AttestationRecord {
@@ -433,6 +943,36 @@ message AttestationRecord {
     AttestationStatus status = 10;
     VoidedReason voided_reason = 11;
     cosmos.base.v1beta1.Coin deposit = 12 [(gogoproto.nullable) = false]; // anti-griefing deposit
+    DepositStatus deposit_status = 13;
+    uint64 audit_escrow_id = 14;
+    FaultAttribution fault_attribution = 15;
+}
+
+message AuditEscrowRecord {
+    uint64 id = 1 [(gogoproto.customname) = "ID"];
+    string provider = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+    string consumed_by_auditor = 3 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+    VerificationTier requested_tier = 4;
+    repeated CapabilityFlag requested_capabilities = 5;
+    cosmos.base.v1beta1.Coin fee = 6 [(gogoproto.nullable) = false];
+    FeeStatus fee_status = 7;
+    cosmos.base.v1beta1.Coin provider_deposit = 8 [(gogoproto.nullable) = false];
+    ProviderDepositStatus provider_deposit_status = 9;
+    AuditEscrowStatus status = 10;
+    google.protobuf.Timestamp opened_at = 11
+        [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+    google.protobuf.Timestamp consumed_at = 12
+        [(gogoproto.nullable) = true, (gogoproto.stdtime) = true];
+    google.protobuf.Timestamp expires_at = 13
+        [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+    bytes metadata_hash = 14;
+    AuditEscrowSettlementReason settlement_reason = 15;
+    FaultAttribution fault_attribution = 16;
+}
+
+message VerificationStoreRecord {
+    string type_url = 1;
+    bytes value = 2;
 }
 
 message DiscrepancyEvent {
@@ -446,6 +986,22 @@ message DiscrepancyEvent {
         [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
     DiscrepancyStatus resolution_status = 8;
     uint64 resolution_proposal_id = 9;
+    uint64 grace_record_id = 10;
+    DiscrepancyResolutionReason resolution_reason = 11;
+    FaultAttribution fault_attribution = 12;
+    bytes resolution_evidence_hash = 13;
+}
+
+message ProviderVerificationGraceRecord {
+    uint64 id = 1 [(gogoproto.customname) = "ID"];
+    string provider = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+    VerificationTier preserved_tier = 3;
+    repeated uint64 source_discrepancy_ids = 4;
+    google.protobuf.Timestamp started_at = 5
+        [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+    google.protobuf.Timestamp expires_at = 6
+        [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+    VerificationGraceStatus status = 7;
 }
 
 message ProviderBondRecord {
@@ -575,28 +1131,33 @@ message Params {
     uint32 max_endblocker_snapshot_suspensions = 44;
     uint32 max_endblocker_unbonding_completions = 45;
     uint32 max_endblocker_discrepancy_timeouts = 46;
+    uint32 max_endblocker_audit_escrow_expiries = 47;
+    uint32 max_endblocker_grace_expiries = 48;
 
-    google.protobuf.Duration discrepancy_resolution_timeout = 47
+    google.protobuf.Duration discrepancy_resolution_timeout = 49
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-    cosmos.base.v1beta1.Coin attestation_deposit = 48 [(gogoproto.nullable) = false];
+    cosmos.base.v1beta1.Coin attestation_deposit = 50 [(gogoproto.nullable) = false];
+    google.protobuf.Duration discrepancy_grace_period = 51
+        [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
+    cosmos.base.v1beta1.Coin provider_audit_deposit = 52 [(gogoproto.nullable) = false];
 
-    bool verification_module_active = 49;
+    bool verification_module_active = 53;
 
-    google.protobuf.Duration contact_response_critical_l3 = 50
+    google.protobuf.Duration contact_response_critical_l3 = 54
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-    google.protobuf.Duration contact_response_critical_l2 = 51
+    google.protobuf.Duration contact_response_critical_l2 = 55
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-    google.protobuf.Duration contact_response_critical_l1 = 52
+    google.protobuf.Duration contact_response_critical_l1 = 56
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-    google.protobuf.Duration contact_response_critical_l0 = 53
+    google.protobuf.Duration contact_response_critical_l0 = 57
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-    google.protobuf.Duration contact_response_standard_l3 = 54
+    google.protobuf.Duration contact_response_standard_l3 = 58
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-    google.protobuf.Duration contact_response_standard_l2 = 55
+    google.protobuf.Duration contact_response_standard_l2 = 59
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-    google.protobuf.Duration contact_response_standard_l1 = 56
+    google.protobuf.Duration contact_response_standard_l1 = 60
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-    google.protobuf.Duration contact_response_standard_l0 = 57
+    google.protobuf.Duration contact_response_standard_l0 = 61
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
 }
 ```
@@ -638,14 +1199,52 @@ message MsgSubmitAttestation {
     bytes evidence_hash = 5;
     cosmos.base.v1beta1.Coin fee = 6 [(gogoproto.nullable) = false];
     cosmos.base.v1beta1.Coin deposit = 7 [(gogoproto.nullable) = false]; // anti-griefing deposit
+    uint64 audit_escrow_id = 8;
 }
 message MsgSubmitAttestationResponse {}
+
+message MsgOpenAuditEscrow {
+    option (cosmos.msg.v1.signer) = "provider";
+    option (amino.name) = "akash/verification/v1/MsgOpenAuditEscrow";
+    string provider = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+    VerificationTier requested_tier = 2;
+    repeated CapabilityFlag requested_capabilities = 3;
+    cosmos.base.v1beta1.Coin fee = 4 [(gogoproto.nullable) = false];
+    cosmos.base.v1beta1.Coin provider_deposit = 5 [(gogoproto.nullable) = false];
+    google.protobuf.Timestamp expires_at = 6
+        [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+    bytes metadata_hash = 7;
+}
+message MsgOpenAuditEscrowResponse {
+    uint64 audit_escrow_id = 1;
+}
+
+message MsgCancelAuditEscrow {
+    option (cosmos.msg.v1.signer) = "provider";
+    option (amino.name) = "akash/verification/v1/MsgCancelAuditEscrow";
+    string provider = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+    uint64 audit_escrow_id = 2;
+}
+message MsgCancelAuditEscrowResponse {}
+
+message MsgSettleAuditEscrow {
+    option (cosmos.msg.v1.signer) = "authority";
+    option (amino.name) = "akash/verification/v1/MsgSettleAuditEscrow";
+    string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+    uint64 audit_escrow_id = 2;
+    AuditEscrowSettlementReason reason = 3;
+    FaultAttribution fault_attribution = 4;
+    bytes evidence_hash = 5;
+}
+message MsgSettleAuditEscrowResponse {}
 
 message MsgRevokeAttestation {
     option (cosmos.msg.v1.signer) = "auditor";
     option (amino.name) = "akash/verification/v1/MsgRevokeAttestation";
     string provider = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
     string auditor = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+    AttestationRevocationReason reason = 3;
+    bytes evidence_hash = 4;
 }
 message MsgRevokeAttestationResponse {}
 
@@ -698,7 +1297,6 @@ message MsgRegisterAuditor {
     string auditor = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
     VerificationTier max_attestation_tier = 3;
     bytes metadata_hash = 4;
-    cosmos.base.v1beta1.Coin required_bond = 5 [(gogoproto.nullable) = false];
 }
 message MsgRegisterAuditorResponse {}
 
@@ -724,7 +1322,9 @@ message MsgRevokeProviderAttestation {
     string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
     string provider = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
     string auditor = 3 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-    string reason = 4;
+    GovernanceAttestationReason reason = 4;
+    FaultAttribution fault_attribution = 5;
+    bytes evidence_hash = 6;
 }
 message MsgRevokeProviderAttestationResponse {}
 
@@ -733,7 +1333,9 @@ message MsgRevokeAllProviderAttestations {
     option (amino.name) = "akash/verification/v1/MsgRevokeAllProviderAttestations";
     string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
     string provider = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-    string reason = 3;
+    GovernanceAttestationReason reason = 3;
+    FaultAttribution fault_attribution = 4;
+    bytes evidence_hash = 5;
 }
 message MsgRevokeAllProviderAttestationsResponse {}
 
@@ -742,7 +1344,9 @@ message MsgRevokeAuditorAttestations {
     option (amino.name) = "akash/verification/v1/MsgRevokeAuditorAttestations";
     string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
     string auditor = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-    string reason = 3;
+    GovernanceAttestationReason reason = 3;
+    FaultAttribution fault_attribution = 4;
+    bytes evidence_hash = 5;
 }
 message MsgRevokeAuditorAttestationsResponse {}
 
@@ -754,7 +1358,9 @@ message MsgResolveDiscrepancy {
     string vindicated_auditor = 3 [(cosmos_proto.scalar) = "cosmos.AddressString"];
     bool slash_auditor_a = 4;
     bool slash_auditor_b = 5;
-    string reason = 6;
+    DiscrepancyResolutionReason reason = 6;
+    FaultAttribution fault_attribution = 7;
+    bytes evidence_hash = 8;
 }
 message MsgResolveDiscrepancyResponse {}
 
@@ -768,7 +1374,8 @@ message MsgSlashProviderBond {
         (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
         (gogoproto.nullable)   = false
     ];
-    string reason = 4;
+    ProviderBondSlashReason reason = 4;
+    bytes evidence_hash = 5;
 }
 message MsgSlashProviderBondResponse {}
 
@@ -796,6 +1403,9 @@ service Msg {
     option (cosmos.msg.v1.service) = true;
 
     rpc PostAuditorBond(MsgPostAuditorBond) returns (MsgPostAuditorBondResponse);
+    rpc OpenAuditEscrow(MsgOpenAuditEscrow) returns (MsgOpenAuditEscrowResponse);
+    rpc CancelAuditEscrow(MsgCancelAuditEscrow) returns (MsgCancelAuditEscrowResponse);
+    rpc SettleAuditEscrow(MsgSettleAuditEscrow) returns (MsgSettleAuditEscrowResponse);
     rpc SubmitAttestation(MsgSubmitAttestation) returns (MsgSubmitAttestationResponse);
     rpc RevokeAttestation(MsgRevokeAttestation) returns (MsgRevokeAttestationResponse);
     rpc RemoveAttestation(MsgRemoveAttestation) returns (MsgRemoveAttestationResponse);
@@ -854,6 +1464,15 @@ service Query {
     }
     rpc Discrepancies(QueryDiscrepanciesRequest) returns (QueryDiscrepanciesResponse) {
         option (google.api.http).get = "/akash/verification/v1/discrepancies";
+    }
+    rpc AuditEscrow(QueryAuditEscrowRequest) returns (QueryAuditEscrowResponse) {
+        option (google.api.http).get = "/akash/verification/v1/audit-escrows/{id}";
+    }
+    rpc ProviderAuditEscrows(QueryProviderAuditEscrowsRequest) returns (QueryProviderAuditEscrowsResponse) {
+        option (google.api.http).get = "/akash/verification/v1/providers/{provider}/audit-escrows";
+    }
+    rpc ProviderVerificationGrace(QueryProviderVerificationGraceRequest) returns (QueryProviderVerificationGraceResponse) {
+        option (google.api.http).get = "/akash/verification/v1/providers/{provider}/grace";
     }
     rpc ProviderBond(QueryProviderBondRequest) returns (QueryProviderBondResponse) {
         option (google.api.http).get = "/akash/verification/v1/providers/{provider}/bond";
@@ -923,6 +1542,30 @@ message QueryDiscrepanciesRequest {
 message QueryDiscrepanciesResponse {
     repeated DiscrepancyEvent discrepancies = 1 [(gogoproto.nullable) = false];
     cosmos.base.query.v1beta1.PageResponse pagination = 2;
+}
+
+message QueryAuditEscrowRequest {
+    uint64 id = 1;
+}
+message QueryAuditEscrowResponse {
+    AuditEscrowRecord escrow = 1 [(gogoproto.nullable) = false];
+}
+
+message QueryProviderAuditEscrowsRequest {
+    string provider = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+    AuditEscrowStatus status_filter = 2;
+    cosmos.base.query.v1beta1.PageRequest pagination = 3;
+}
+message QueryProviderAuditEscrowsResponse {
+    repeated AuditEscrowRecord escrows = 1 [(gogoproto.nullable) = false];
+    cosmos.base.query.v1beta1.PageResponse pagination = 2;
+}
+
+message QueryProviderVerificationGraceRequest {
+    string provider = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+}
+message QueryProviderVerificationGraceResponse {
+    ProviderVerificationGraceRecord grace = 1 [(gogoproto.nullable) = false];
 }
 
 message QueryProviderBondRequest {
@@ -1001,6 +1644,7 @@ message EventAttestationSubmitted {
     repeated CapabilityFlag capabilities = 4;
     google.protobuf.Timestamp expires_at = 5
         [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+    uint64 audit_escrow_id = 6;
 }
 
 message EventAttestationExpired {
@@ -1009,10 +1653,20 @@ message EventAttestationExpired {
     VerificationTier tier = 3;
 }
 
+message EventAttestationReplaced {
+    string provider = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+    string auditor = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+    VerificationTier old_tier = 3;
+    VerificationTier new_tier = 4;
+    uint64 old_audit_escrow_id = 5;
+    uint64 new_audit_escrow_id = 6;
+}
+
 message EventAttestationRevoked {
     string provider = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
     string auditor = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
     string initiator = 3;
+    AttestationRevocationReason reason = 4;
 }
 
 message EventAttestationVoided {
@@ -1033,6 +1687,8 @@ message EventDiscrepancyDetected {
 message EventDiscrepancyResolved {
     uint64 discrepancy_id = 1;
     string vindicated_auditor = 2;
+    DiscrepancyResolutionReason reason = 3;
+    FaultAttribution fault_attribution = 4;
 }
 
 message EventDiscrepancyTimedOut {
@@ -1050,7 +1706,7 @@ message EventProviderBondPosted {
 message EventProviderBondSlashed {
     string provider = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
     cosmos.base.v1beta1.Coin slashed_amount = 2 [(gogoproto.nullable) = false];
-    string reason = 3;
+    ProviderBondSlashReason reason = 3;
 }
 
 message EventProviderBondWithdrawalInitiated {
@@ -1095,6 +1751,40 @@ message EventFeeReturnedToProvider {
     string provider = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
     cosmos.base.v1beta1.Coin amount = 2 [(gogoproto.nullable) = false];
 }
+
+message EventAuditEscrowOpened {
+    uint64 audit_escrow_id = 1;
+    string provider = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+    cosmos.base.v1beta1.Coin fee = 3 [(gogoproto.nullable) = false];
+    cosmos.base.v1beta1.Coin provider_deposit = 4 [(gogoproto.nullable) = false];
+}
+
+message EventAuditEscrowSettled {
+    uint64 audit_escrow_id = 1;
+    AuditEscrowSettlementReason reason = 2;
+    FaultAttribution fault_attribution = 3;
+}
+
+message EventDepositReturnedToAuditor {
+    string auditor = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+    cosmos.base.v1beta1.Coin amount = 2 [(gogoproto.nullable) = false];
+}
+
+message EventDepositSlashed {
+    string auditor = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+    cosmos.base.v1beta1.Coin amount = 2 [(gogoproto.nullable) = false];
+}
+
+message EventVerificationGraceStarted {
+    uint64 grace_record_id = 1;
+    string provider = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+    VerificationTier preserved_tier = 3;
+}
+
+message EventVerificationGraceEnded {
+    uint64 grace_record_id = 1;
+    VerificationGraceStatus status = 2;
+}
 ```
 
 ### 4.8 genesis.proto
@@ -1118,6 +1808,10 @@ message GenesisState {
     repeated ProviderBondRecord provider_bonds = 5 [(gogoproto.nullable) = false];
     repeated ProviderSnapshotRecord provider_snapshots = 6 [(gogoproto.nullable) = false];
     uint64 next_discrepancy_id = 7;
+    repeated AuditEscrowRecord audit_escrows = 8 [(gogoproto.nullable) = false];
+    uint64 next_audit_escrow_id = 9;
+    repeated ProviderVerificationGraceRecord verification_graces = 10 [(gogoproto.nullable) = false];
+    uint64 next_grace_record_id = 11;
 }
 ```
 
@@ -1150,6 +1844,14 @@ message GenesisState {
 | `ErrMissingCapability`               | 21   | `FAILED_PRECONDITION`    | Provider lacks required capability flag                    |
 | `ErrRequiredAuditorNotFound`         | 22   | `NOT_FOUND`              | No attestation from a required auditor                     |
 | `ErrInsufficientDeposit`             | 23   | `INVALID_ARGUMENT`       | Attestation deposit below governance minimum               |
+| `ErrAuditEscrowNotFound`             | 24   | `NOT_FOUND`              | Audit escrow ID not found                                  |
+| `ErrAuditEscrowNotConsumable`        | 25   | `FAILED_PRECONDITION`    | Audit escrow is expired, consumed, cancelled, or mismatched |
+| `ErrInsufficientProviderDeposit`     | 26   | `INVALID_ARGUMENT`       | Provider audit deposit below governance minimum            |
+| `ErrInvalidReason`                   | 27   | `INVALID_ARGUMENT`       | Typed reason is unspecified or incompatible with action    |
+| `ErrInvalidFaultAttribution`         | 28   | `INVALID_ARGUMENT`       | Fault attribution is missing or incompatible with settlement |
+| `ErrUnknownVerificationRecordType`   | 29   | `INVALID_ARGUMENT`       | Dynamic verification store record has no registered decoder |
+| `ErrInsufficientAuditorCount`        | 30   | `FAILED_PRECONDITION`    | Provider lacks required number of independent auditors      |
+| `ErrUnauthorizedAuditEscrowSettlement` | 31 | `PERMISSION_DENIED`      | Signer cannot use the requested audit escrow settlement path |
 
 ---
 
@@ -1159,18 +1861,20 @@ message GenesisState {
 x/verification
     reads from:
         x/provider   -- provider registration, registration timestamp
-        x/market     -- lease completion stats (provider lease history)
+        x/market     -- lease completion stats through MarketStatsKeeper
         x/bank       -- token transfers (bond deposits, fee escrow, withdrawals)
         x/gov        -- authority validation for governance messages
 
     read by:
-        x/market     -- bid filtering (VerificationKeeper interface)
+        x/market     -- bid filtering through VerificationKeeper interface
         x/incentive  -- incentive eligibility (AEP-53, future)
 ```
 
 ```
-Module initialization order: x/provider -> x/market -> x/verification
-(x/verification depends on x/provider and x/market keepers)
+Module initialization order: construct x/provider, x/market, and x/verification,
+then late-bind MarketStatsKeeper and VerificationKeeper interfaces.
+Do not pass concrete x/market keeper into x/verification and concrete x/verification
+keeper into x/market during construction.
 ```
 
 ---
@@ -1200,10 +1904,12 @@ The Inventory Service already exists in the provider codebase. This specificatio
 The binary is statically linked for all system libraries. For vendor hardware management libraries (NVIDIA NVML,
 AMD ROCm SMI), the binary may dynamically load them at runtime:
 
-1. Verify the vendor library's cryptographic signature before loading
-2. Treat vendor library output as one data source among multiple
-3. Cross-validate against direct hardware reads (PCIe configuration space, CPUID)
-4. Flag discrepancies in the snapshot
+1. Treat vendor library output as one data source among multiple
+2. Cross-validate against direct hardware reads (PCIe configuration space, CPUID)
+3. Flag discrepancies in the snapshot
+
+AEP-86 v1 does not define signature enforcement for dynamically loaded vendor libraries. That problem belongs with the
+separate signing-key AEP or phase 2 work.
 
 ### 5.3 gRPC Service
 
@@ -1230,25 +1936,51 @@ The snapshot payload format is implementation-defined but must include all field
 
 ---
 
-## 6. Module Registration and Genesis
+## 6. V1 Auditor Software
 
-### 6.1 Module Registration
+The v1 auditor software is a required deliverable for activation. It should live outside consensus code but use the same
+protobuf and query clients as `x/verification`.
+
+Minimum commands:
+
+- `collect`: query provider inventory with nonce, fetch chain facts, run benchmarks, and write raw artifacts.
+- `verify`: evaluate tier and capability checks from collected artifacts.
+- `evidence`: produce canonical evidence bytes and SHA-256 hash for `MsgSubmitAttestation`.
+- `submit`: consume `audit_escrow_id`, pay auditor deposit, and submit `MsgSubmitAttestation`.
+- `revoke`: run targeted checks during TTL and submit `MsgRevokeAttestation` with typed reason and evidence hash.
+
+The software should keep baseline and sustained validation artifacts separate:
+
+- Baseline artifacts are created during the initial attestation audit and describe the provider state and benchmark
+  results that justify the tier.
+- Sustained validation artifacts are created during the TTL and compare current results against the baseline. They are
+  the evidence source for revocation, replacement, discrepancy response, or renewal.
+
+The evidence encoder must be deterministic. Every field that affects tier, capability, settlement, deposit, or fault
+outcome must be typed. Free-form notes can be included, but they must not drive handler behavior.
+
+---
+
+## 7. Module Registration and Genesis
+
+### 7.1 Module Registration
 
 The `x/verification` module is registered in `app.go`:
 
 - Add `x/verification` to the module manager and begin/end blocker registration
 - Register the module's store key
-- Create the module account for escrow (bond and fee escrow)
-- Wire keeper dependencies: `ProviderKeeper`, `MarketKeeper`, `BankKeeper`, governance `authority`
+- Create the module account for escrow (bond, fee, provider deposit, and auditor deposit escrow)
+- Wire keeper dependencies: `ProviderKeeper`, `MarketStatsKeeper`, `BankKeeper`, governance `authority`
+- Expose `VerificationKeeper` to `x/market` through late binding after both keepers are constructed
 
-### 6.2 InitGenesis
+### 7.2 InitGenesis
 
 ```go
 func (k Keeper) InitGenesis(ctx sdk.Context, state GenesisState) {
     // 1. Validate and set params
     k.SetParams(ctx, state.Params)
 
-    // 2. Create module account for escrow (bonds + fees)
+    // 2. Create module account for escrow (bonds + fees + deposits)
     //    The module account must exist before any token transfers
     k.accountKeeper.GetModuleAccount(ctx, ModuleName)
 
@@ -1257,6 +1989,9 @@ func (k Keeper) InitGenesis(ctx sdk.Context, state GenesisState) {
         k.SetAuditorRecord(ctx, auditor)
         // Re-create renewal deadline queue entries
         k.insertRenewalQueue(ctx, auditor.Address, auditor.RenewalDeadline)
+        if auditor.BondStatus == BondStatusUnbonding && !auditor.BondUnbondingCompletionTime.IsZero() {
+            k.insertAuditorUnbondingQueue(ctx, auditor.Address, auditor.BondUnbondingCompletionTime)
+        }
     }
 
     // 4. Import attestation records
@@ -1297,10 +2032,31 @@ func (k Keeper) InitGenesis(ctx sdk.Context, state GenesisState) {
 
     // 7. Set next discrepancy ID
     k.SetNextDiscrepancyID(ctx, state.NextDiscrepancyId)
+
+    // 8. Import audit escrows and grace records
+    for _, escrow := range state.AuditEscrows {
+        k.SetAuditEscrowRecord(ctx, escrow)
+        k.setProviderAuditEscrowIndex(ctx, escrow.Provider, escrow.ID)
+        if escrow.ConsumedByAuditor != "" {
+            k.setAuditorAuditEscrowIndex(ctx, escrow.ConsumedByAuditor, escrow.ID)
+        }
+        if escrow.Status == AuditEscrowStatusOpen {
+            k.insertAuditEscrowExpiryQueue(ctx, escrow.ID, escrow.ExpiresAt)
+        }
+    }
+    for _, grace := range state.VerificationGraces {
+        k.SetProviderVerificationGraceRecord(ctx, grace)
+        k.setProviderGraceIndex(ctx, grace.Provider, grace.ID)
+        if grace.Status == VerificationGraceStatusActive {
+            k.insertGraceExpiryQueue(ctx, grace.ID, grace.ExpiresAt)
+        }
+    }
+    k.SetNextAuditEscrowID(ctx, state.NextAuditEscrowId)
+    k.SetNextGraceRecordID(ctx, state.NextGraceRecordId)
 }
 ```
 
-### 6.3 ExportGenesis
+### 7.3 ExportGenesis
 
 ```go
 func (k Keeper) ExportGenesis(ctx sdk.Context) GenesisState {
@@ -1312,79 +2068,123 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) GenesisState {
         ProviderBonds:      k.GetAllProviderBondRecords(ctx),
         ProviderSnapshots:  k.GetAllProviderSnapshotRecords(ctx),
         NextDiscrepancyId:  k.GetNextDiscrepancyID(ctx),
+        AuditEscrows:       k.GetAllAuditEscrowRecords(ctx),
+        NextAuditEscrowId:  k.GetNextAuditEscrowID(ctx),
+        VerificationGraces: k.GetAllProviderVerificationGraceRecords(ctx),
+        NextGraceRecordId:  k.GetNextGraceRecordID(ctx),
     }
 }
 ```
 
 ---
 
-## 7. Module Invariants
+## 8. Module Invariants
 
 The following invariants must hold at all times. These are suitable for registration via the Cosmos SDK
 `InvariantRegistry` and should be checked in integration tests.
 
-### 7.1 Escrow Balance Invariant
+### 8.1 Escrow Balance Invariant
 
 The module account balance must equal the sum of all escrowed funds:
 
 ```
 module_balance = sum(att.fee for att in attestations where att.fee_status == Escrowed)
-              + sum(att.deposit for att in attestations where att.status == Valid)
-              + sum(auditor.bond_amount for auditor in auditors where auditor.bond_status == Bonded or Frozen)
+              + sum(att.deposit for att in attestations
+                    where att.deposit_status == Escrowed or att.deposit_status == PendingDiscrepancy)
+              + sum(escrow.fee for escrow in audit_escrows
+                    where escrow.fee_status == Escrowed)
+              + sum(escrow.provider_deposit for escrow in audit_escrows
+                    where escrow.provider_deposit_status == Escrowed)
+              + sum(auditor.bond_amount for auditor in auditors
+                    where auditor.bond_status == Bonded or Frozen or Unbonding)
               + sum(bond.bonded_amount for bond in provider_bonds)
               + sum(entry.amount for entry in all unbonding_entries across all provider_bonds)
 ```
 
-### 7.2 Attestation Validity Invariant
+### 8.2 Attestation Validity Invariant
 
 No attestation with status `Valid` has `expires_at` in the past (relative to the last processed block time).
 
-### 7.3 Frozen Auditor Invariant
+### 8.3 Frozen Auditor Invariant
 
-Every auditor with `bond_status == Frozen` has at least one `DiscrepancyEvent` in `Pending` status where they
-are either `auditor_a` or `auditor_b`.
+Every auditor with `bond_status == Frozen` has at least one `DiscrepancyEvent` in `Pending` status where
+they are either `auditor_a` or `auditor_b`.
 
-### 7.4 Discrepancy Consistency Invariant
+### 8.4 Discrepancy Consistency Invariant
 
 For every `DiscrepancyEvent` in `Pending` status:
 - Both `auditor_a` and `auditor_b` have `bond_status == Frozen`
 - The attestation records referenced by the discrepancy have `status == Voided` and
   `voided_reason == Discrepancy`
+- The referenced attestation records have `fee_status == Escrowed` and
+  `deposit_status == PendingDiscrepancy`
 
-### 7.5 Snapshot Compliance Invariant
+For every `DiscrepancyEvent` in `TimedOut` status:
+- The referenced attestation records have `status == Voided` and `voided_reason == Discrepancy`
+- The referenced attestation records have `fee_status == ReturnedToProvider` and `deposit_status == Slashed`
+
+### 8.5 Snapshot Compliance Invariant
 
 No provider with `ProviderSnapshotRecord.suspended == true` has a valid attestation at Level 2 or above that is
 active for bid-matching purposes.
 
-### 7.6 Provider Bond Invariant
+### 8.6 Provider Bond Invariant
 
 For every provider with a valid attestation at Level 2 or above, the provider's `bonded_amount` is at least the
 minimum required for the attested tier (calculated from the provider's `ResourceSummary` and the tier's
 bond-per-resource governance parameters).
 
-### 7.7 Self-Attestation Invariant
+### 8.7 Self-Attestation Invariant
 
 No attestation record exists where `provider == auditor`.
 
-### 7.8 Auditor Authority Invariant
+### 8.8 Auditor Authority Invariant
 
 No valid attestation exists where the attested tier exceeds the auditor's `max_attestation_tier`.
 
+### 8.9 Audit Escrow Invariant
+
+Every attestation with `audit_escrow_id != 0` references an `AuditEscrowRecord` with `status == Consumed`, matching
+provider, matching `consumed_by_auditor`, and a fee at least equal to the attestation fee.
+
+### 8.10 Grace Record Invariant
+
+Every active `ProviderVerificationGraceRecord` has at least one source discrepancy with status `Pending` or `TimedOut`.
+
 ---
 
-## 8. CLI Commands
+## 9. CLI Commands
 
 Key commands for common operations. Full command set is auto-generated from proto service definitions.
 
-### 8.1 Transaction Commands
+### 9.1 Transaction Commands
 
 ```bash
 # Auditor: post bond after governance approval
 akash tx verification post-auditor-bond [amount] --from [auditor-key]
 
+# Provider: open an audit escrow
+akash tx verification open-audit-escrow \
+  --requested-tier [identified|verified|established|trusted] \
+  --fee [amount] \
+  --provider-deposit [amount] \
+  --expires-at [RFC3339] \
+  --from [provider-key]
+
+# Provider: cancel an unconsumed audit escrow
+akash tx verification cancel-audit-escrow [audit-escrow-id] --from [provider-key]
+
+# Governance authority: settle an unconsumed audit escrow dispute
+akash tx verification settle-audit-escrow [audit-escrow-id] \
+  --reason [provider_fault|no_fault] \
+  --fault-attribution [provider_fault|no_fault] \
+  --evidence-hash [hex-encoded-hash] \
+  --from [authority-key]
+
 # Auditor: submit attestation for a provider
 akash tx verification submit-attestation \
   --provider [provider-addr] \
+  --audit-escrow-id [id] \
   --tier [identified|verified|established|trusted] \
   --capabilities [tee_hardware_attestation,confidential_computing,...] \
   --evidence-hash [hex-encoded-hash] \
@@ -1393,7 +2193,11 @@ akash tx verification submit-attestation \
   --from [auditor-key]
 
 # Auditor: revoke own attestation
-akash tx verification revoke-attestation --provider [provider-addr] --from [auditor-key]
+akash tx verification revoke-attestation \
+  --provider [provider-addr] \
+  --reason [typed-reason] \
+  --evidence-hash [hex-encoded-hash] \
+  --from [auditor-key]
 
 # Provider: post economic bond
 akash tx verification post-provider-bond [amount] --from [provider-key]
@@ -1405,11 +2209,22 @@ akash tx verification post-snapshot-hash \
   --snapshot-timestamp [RFC3339] \
   --from [provider-key]
 
+# Provider: open a provider-wide maintenance window
+akash tx provider open-maintenance \
+  --type [planned|emergency|security|network|capacity] \
+  --starts-at [RFC3339] \
+  --expected-ends-at [RFC3339] \
+  --metadata-hash [hex-encoded-hash] \
+  --from [provider-key]
+
+# Provider: close a maintenance window
+akash tx provider close-maintenance [maintenance-id] --from [provider-key]
+
 # Provider: remove an attestation on self
 akash tx verification remove-attestation --auditor [auditor-addr] --from [provider-key]
 ```
 
-### 8.2 Query Commands
+### 9.2 Query Commands
 
 ```bash
 # Query all attestations for a provider
@@ -1432,6 +2247,13 @@ akash query verification params
 
 # Query pending discrepancies
 akash query verification discrepancies --status pending
+
+# Query an audit escrow
+akash query verification audit-escrow [id]
+
+# Query maintenance windows for a provider
+akash query provider maintenances [provider-addr] --status [scheduled|active|elapsed|closed]
+
+# Query one maintenance window
+akash query provider maintenance [provider-addr] [maintenance-id]
 ```
-
-

--- a/spec/aep-86/IMPLEMENTATION.md
+++ b/spec/aep-86/IMPLEMENTATION.md
@@ -424,23 +424,19 @@ type LeaseStats struct {
 
 ### 3.2 Tier Comparison Convention
 
-> **WARNING: Inverted numeric ordering**. The `VerificationTier` enum uses lower numeric values for higher trust:
-> `TierTrusted=1` (L0, highest trust) through `TierIdentified=4` (L3, lowest trust). This means `tier <= threshold`
-> checks "is this tier at least as good as the threshold", which reads counter-intuitively. All tier comparisons
-> MUST use the helper functions below to prevent off-by-one errors.
+Tier enum values are ordered by trust (`TierIdentified=1` is the lowest attested tier, `TierTrusted=4` is the
+highest). Use these helpers rather than raw operators so call sites stay consistent and `TierUnspecified` is handled.
 
 ```go
 // TierAtLeast returns true if 'have' is at least as trusted as 'need'.
 // Both must be valid tiers (not TierUnspecified).
-// Example: TierAtLeast(TierVerified, TierEstablished) returns false (L2 < L1)
-// Example: TierAtLeast(TierTrusted, TierVerified) returns true (L0 >= L2)
 func TierAtLeast(have, need VerificationTier) bool {
-    return have != TierUnspecified && have <= need
+    return have != TierUnspecified && have >= need
 }
 
 // TierBetter returns true if 'a' is strictly more trusted than 'b'.
 func TierBetter(a, b VerificationTier) bool {
-    return a != TierUnspecified && a < b
+    return a != TierUnspecified && a > b
 }
 ```
 
@@ -458,10 +454,10 @@ type VerificationKeeper interface {
     GetProviderValidAttestations(ctx sdk.Context, provider sdk.Address) ([]AttestationRecord, bool)
 
     // IsProviderSnapshotCompliant returns true if the provider is NOT snapshot-suspended.
-    // Returns true if the provider has no snapshot record (L4 providers don't need one).
+    // Returns true if the provider has no snapshot record (L0 providers don't need one).
     IsProviderSnapshotCompliant(ctx sdk.Context, provider sdk.Address) bool
 
-    // GetProviderBestTier returns the best (lowest numeric enum value = highest trust) tier
+    // GetProviderBestTier returns the best (highest numeric enum value = highest trust) tier
     // from valid attestations. Returns TierUnspecified if no valid attestations exist.
     GetProviderBestTier(ctx sdk.Context, provider sdk.Address) VerificationTier
 
@@ -589,20 +585,20 @@ import "gogoproto/gogo.proto";
 option go_package = "pkg.akt.dev/go/node/verification/v1";
 
 // VerificationTier represents provider verification levels.
-// Lower numeric value = higher trust. L4 (Permissionless) has no attestation.
+// Higher numeric value = higher trust. TierUnspecified (L0, Permissionless) means no attestation.
 enum VerificationTier {
     option (gogoproto.goproto_enum_prefix) = false;
 
     verification_tier_unspecified = 0
-        [(gogoproto.enumvalue_customname) = "TierUnspecified"];
-    verification_tier_trusted = 1
-        [(gogoproto.enumvalue_customname) = "TierTrusted"];       // L0
-    verification_tier_established = 2
-        [(gogoproto.enumvalue_customname) = "TierEstablished"];   // L1
-    verification_tier_verified = 3
+        [(gogoproto.enumvalue_customname) = "TierUnspecified"];   // L0
+    verification_tier_identified = 1
+        [(gogoproto.enumvalue_customname) = "TierIdentified"];    // L1
+    verification_tier_verified = 2
         [(gogoproto.enumvalue_customname) = "TierVerified"];      // L2
-    verification_tier_identified = 4
-        [(gogoproto.enumvalue_customname) = "TierIdentified"];    // L3
+    verification_tier_established = 3
+        [(gogoproto.enumvalue_customname) = "TierEstablished"];   // L3
+    verification_tier_trusted = 4
+        [(gogoproto.enumvalue_customname) = "TierTrusted"];       // L4
 }
 
 enum AuditorStatus {
@@ -1057,37 +1053,37 @@ import "google/protobuf/duration.proto";
 option go_package = "pkg.akt.dev/go/node/verification/v1";
 
 message Params {
-    cosmos.base.v1beta1.Coin bond_l3 = 1 [(gogoproto.nullable) = false];
+    cosmos.base.v1beta1.Coin bond_l1 = 1 [(gogoproto.nullable) = false];
     cosmos.base.v1beta1.Coin bond_l2 = 2 [(gogoproto.nullable) = false];
-    cosmos.base.v1beta1.Coin bond_l1 = 3 [(gogoproto.nullable) = false];
-    cosmos.base.v1beta1.Coin bond_l0 = 4 [(gogoproto.nullable) = false];
+    cosmos.base.v1beta1.Coin bond_l3 = 3 [(gogoproto.nullable) = false];
+    cosmos.base.v1beta1.Coin bond_l4 = 4 [(gogoproto.nullable) = false];
 
-    google.protobuf.Duration ttl_l3 = 5
+    google.protobuf.Duration ttl_l1 = 5
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
     google.protobuf.Duration ttl_l2 = 6
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-    google.protobuf.Duration ttl_l1 = 7
+    google.protobuf.Duration ttl_l3 = 7
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-    google.protobuf.Duration ttl_l0 = 8
+    google.protobuf.Duration ttl_l4 = 8
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
 
-    cosmos.base.v1beta1.Coin min_fee_l3 = 9 [(gogoproto.nullable) = false];
+    cosmos.base.v1beta1.Coin min_fee_l1 = 9 [(gogoproto.nullable) = false];
     cosmos.base.v1beta1.Coin min_fee_l2 = 10 [(gogoproto.nullable) = false];
-    cosmos.base.v1beta1.Coin min_fee_l1 = 11 [(gogoproto.nullable) = false];
-    cosmos.base.v1beta1.Coin min_fee_l0 = 12 [(gogoproto.nullable) = false];
+    cosmos.base.v1beta1.Coin min_fee_l3 = 11 [(gogoproto.nullable) = false];
+    cosmos.base.v1beta1.Coin min_fee_l4 = 12 [(gogoproto.nullable) = false];
 
     uint32 discrepancy_threshold = 13;
 
     google.protobuf.Duration auditor_unbonding_period = 14
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
 
-    google.protobuf.Duration renewal_period_l3 = 15
+    google.protobuf.Duration renewal_period_l1 = 15
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
     google.protobuf.Duration renewal_period_l2 = 16
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-    google.protobuf.Duration renewal_period_l1 = 17
+    google.protobuf.Duration renewal_period_l3 = 17
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-    google.protobuf.Duration renewal_period_l0 = 18
+    google.protobuf.Duration renewal_period_l4 = 18
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
 
     google.protobuf.Duration snapshot_hash_interval = 19
@@ -1096,34 +1092,34 @@ message Params {
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
 
     cosmos.base.v1beta1.Coin bond_gpu_l2 = 21 [(gogoproto.nullable) = false];
-    cosmos.base.v1beta1.Coin bond_gpu_l1 = 22 [(gogoproto.nullable) = false];
-    cosmos.base.v1beta1.Coin bond_gpu_l0 = 23 [(gogoproto.nullable) = false];
+    cosmos.base.v1beta1.Coin bond_gpu_l3 = 22 [(gogoproto.nullable) = false];
+    cosmos.base.v1beta1.Coin bond_gpu_l4 = 23 [(gogoproto.nullable) = false];
     cosmos.base.v1beta1.Coin bond_vcpu_l2 = 24 [(gogoproto.nullable) = false];
-    cosmos.base.v1beta1.Coin bond_vcpu_l1 = 25 [(gogoproto.nullable) = false];
-    cosmos.base.v1beta1.Coin bond_vcpu_l0 = 26 [(gogoproto.nullable) = false];
+    cosmos.base.v1beta1.Coin bond_vcpu_l3 = 25 [(gogoproto.nullable) = false];
+    cosmos.base.v1beta1.Coin bond_vcpu_l4 = 26 [(gogoproto.nullable) = false];
     cosmos.base.v1beta1.Coin bond_mem_gb_l2 = 27 [(gogoproto.nullable) = false];
-    cosmos.base.v1beta1.Coin bond_mem_gb_l1 = 28 [(gogoproto.nullable) = false];
-    cosmos.base.v1beta1.Coin bond_mem_gb_l0 = 29 [(gogoproto.nullable) = false];
+    cosmos.base.v1beta1.Coin bond_mem_gb_l3 = 28 [(gogoproto.nullable) = false];
+    cosmos.base.v1beta1.Coin bond_mem_gb_l4 = 29 [(gogoproto.nullable) = false];
     cosmos.base.v1beta1.Coin bond_storage_tb_l2 = 30 [(gogoproto.nullable) = false];
-    cosmos.base.v1beta1.Coin bond_storage_tb_l1 = 31 [(gogoproto.nullable) = false];
-    cosmos.base.v1beta1.Coin bond_storage_tb_l0 = 32 [(gogoproto.nullable) = false];
+    cosmos.base.v1beta1.Coin bond_storage_tb_l3 = 31 [(gogoproto.nullable) = false];
+    cosmos.base.v1beta1.Coin bond_storage_tb_l4 = 32 [(gogoproto.nullable) = false];
 
     google.protobuf.Duration provider_bond_unbonding_period = 33
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
 
     google.protobuf.Duration min_age_l2 = 34
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-    google.protobuf.Duration min_age_l1 = 35
+    google.protobuf.Duration min_age_l3 = 35
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-    google.protobuf.Duration min_age_l0 = 36
+    google.protobuf.Duration min_age_l4 = 36
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-    uint32 min_lease_completion_bps_l1 = 37;
-    uint32 min_lease_completion_bps_l0 = 38;
-    google.protobuf.Duration clean_history_window_l1 = 39
+    uint32 min_lease_completion_bps_l3 = 37;
+    uint32 min_lease_completion_bps_l4 = 38;
+    google.protobuf.Duration clean_history_window_l3 = 39
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-    google.protobuf.Duration clean_history_window_l0 = 40
+    google.protobuf.Duration clean_history_window_l4 = 40
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-    google.protobuf.Duration min_l1_duration_for_l0 = 41
+    google.protobuf.Duration min_l3_duration_for_l4 = 41
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
     uint32 min_leases_for_completion_rate = 42;
 
@@ -1143,21 +1139,21 @@ message Params {
 
     bool verification_module_active = 53;
 
-    google.protobuf.Duration contact_response_critical_l3 = 54
+    google.protobuf.Duration contact_response_critical_l1 = 54
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
     google.protobuf.Duration contact_response_critical_l2 = 55
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-    google.protobuf.Duration contact_response_critical_l1 = 56
+    google.protobuf.Duration contact_response_critical_l3 = 56
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-    google.protobuf.Duration contact_response_critical_l0 = 57
+    google.protobuf.Duration contact_response_critical_l4 = 57
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-    google.protobuf.Duration contact_response_standard_l3 = 58
+    google.protobuf.Duration contact_response_standard_l1 = 58
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
     google.protobuf.Duration contact_response_standard_l2 = 59
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-    google.protobuf.Duration contact_response_standard_l1 = 60
+    google.protobuf.Duration contact_response_standard_l3 = 60
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
-    google.protobuf.Duration contact_response_standard_l0 = 61
+    google.protobuf.Duration contact_response_standard_l4 = 61
         [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
 }
 ```
@@ -1833,7 +1829,7 @@ message GenesisState {
 | `ErrInsufficientProviderAge`         | 10   | `FAILED_PRECONDITION`    | Provider registration too recent for attested tier         |
 | `ErrInsufficientLeaseCompletionRate` | 11   | `FAILED_PRECONDITION`    | Lease completion rate below threshold                      |
 | `ErrSlashingHistoryViolation`        | 12   | `FAILED_PRECONDITION`    | Provider has slashing events within lookback window        |
-| `ErrInsufficientL1History`           | 13   | `FAILED_PRECONDITION`    | Provider lacks required continuous L1+ attestation for L0  |
+| `ErrInsufficientL3History`           | 13   | `FAILED_PRECONDITION`    | Provider lacks required continuous L3+ attestation for L4  |
 | `ErrAttestationNotFound`             | 14   | `NOT_FOUND`              | Attestation (provider, auditor) not found                  |
 | `ErrDiscrepancyNotFound`             | 15   | `NOT_FOUND`              | Discrepancy ID not found                                   |
 | `ErrBondWithdrawalExceedsMinimum`    | 16   | `FAILED_PRECONDITION`    | Withdrawal would leave bond below minimum for active tiers |

--- a/spec/aep-86/README.md
+++ b/spec/aep-86/README.md
@@ -33,7 +33,7 @@ This AEP defines:
 
 1. **[Verification Tiers](./README.md#verification-tiers)** -- Five levels (Level 0 through Level 4) representing
    progressively deeper verification of a provider's infrastructure, performance, reliability, and operational maturity.
-   Level 0 is the highest trust; Level 4 is permissionless (unverified).
+   Level 0 is permissionless (unverified); Level 4 is the highest trust.
 
 2. **[Auditor Role](./README.md#auditor-role)** -- Governance-approved entities that evaluate providers and submit
    on-chain attestations. Auditors post bonds that scale with the highest tier they are authorized to attest and charge
@@ -72,7 +72,7 @@ Tiers represent the depth of verification a provider has undergone. The chain st
 provider; it does not compute a single effective tier. Interpretation of attestations is the responsibility of the
 application layer (Console, SDL matching, incentive modules).
 
-#### Level 4 -- Permissionless
+#### Level 0 -- Permissionless
 
 Trust statement: _"This provider is registered on the network."_
 
@@ -84,7 +84,7 @@ Requirements:
 - Valid on-chain provider registration (`MsgCreateProvider`)
 - Provider daemon is reachable (status endpoint responds)
 
-#### Level 3 -- Identified
+#### Level 1 -- Identified
 
 Trust statement: _"The provider reports its software identity, and we know who operates it."_
 
@@ -93,7 +93,7 @@ trust boundary.
 
 Requirements:
 
-- All Level 4 requirements
+- All Level 0 requirements
 - Signed code (phase 2 enforcement target) -- the provider should run an officially signed release of the provider
   software. The software version, binary digest, and observed signature are recorded in auditor evidence for AEP-86 v1.
   Signature enforcement is deferred to a separate signing-key AEP or phase 2.
@@ -101,17 +101,17 @@ Requirements:
 
   | Tier             | Acceptable Identity Types                                                              |
   | ---------------- | -------------------------------------------------------------------------------------- |
-  | L3 (Identified)  | Business registration, domain ownership, or DID-based credential                       |
+  | L1 (Identified)  | Business registration, domain ownership, or DID-based credential                       |
   | L2 (Verified)    | Business registration or DID-based credential (domain ownership alone is insufficient) |
-  | L1 (Established) | Business registration or DID-based credential                                          |
-  | L0 (Trusted)     | Business registration required                                                         |
+  | L3 (Established) | Business registration or DID-based credential                                          |
+  | L4 (Trusted)     | Business registration required                                                         |
 
   The auditor records the identity type verified in their off-chain evidence (referenced by `evidence_hash`).
   Signed identity attestation stored on-chain.
 
 - Contact channel -- verified communication endpoint for incident response. Provider must respond to
-  critical incidents within `contact_response_critical_l3` and standard provider-operational inquiries within
-  `contact_response_standard_l3` (governance parameters). See
+  critical incidents within `contact_response_critical_l1` and standard provider-operational inquiries within
+  `contact_response_standard_l1` (governance parameters). See
   [Contact Responsiveness](./README.md#contact-responsiveness).
 - Stated location -- claimed geographic region/jurisdiction (self-reported; verified at higher tiers)
 
@@ -124,7 +124,7 @@ network quality, and physical location have been verified.
 
 Requirements:
 
-- All Level 3 requirements
+- All Level 1 requirements
 - Resource delivery accuracy -- provisioned CPU, RAM, GPU memory, and storage match bid quantities. Validated via
   automated resource audit (deploy test workload, measure actual vs. claimed).
 - Network quality baseline -- bandwidth and latency meet minimum thresholds. Validated via automated benchmarks from
@@ -134,7 +134,7 @@ Requirements:
 - Inventory consistency -- on-chain attributes match the provider's
   [Inventory Service](./README.md#inventory-service) snapshots. Auditors reconcile snapshot data against on-chain
   attributes; discrepancies flag downgrade.
-- Contact responsiveness -- stricter response windows than Level 3. Provider must respond to critical incidents
+- Contact responsiveness -- stricter response windows than Level 1. Provider must respond to critical incidents
   within `contact_response_critical_l2` and standard provider-operational inquiries within
   `contact_response_standard_l2`. See
   [Contact Responsiveness](./README.md#contact-responsiveness).
@@ -148,7 +148,7 @@ Requirements:
 - Snapshot hash compliance -- provider must be actively posting inventory snapshot hashes on-chain and must not be
   in suspended state. See [Snapshot Hash Enforcement](./README.md#snapshot-hash-enforcement).
 
-#### Level 1 -- Established
+#### Level 3 -- Established
 
 Trust statement: _"This provider is reliably available and consistently performs."_
 
@@ -166,30 +166,30 @@ Requirements:
 - Resource delivery under load -- audit probes run while provider has active leases to detect overcommitment.
 - Data isolation verification -- automated cross-tenant isolation tests (network namespace, filesystem, process isolation).
 - Contact responsiveness -- stricter response windows than Level 2. Provider must respond to critical incidents
-  within `contact_response_critical_l1` and standard provider-operational inquiries within
-  `contact_response_standard_l1`. See
+  within `contact_response_critical_l3` and standard provider-operational inquiries within
+  `contact_response_standard_l3`. See
   [Contact Responsiveness](./README.md#contact-responsiveness).
 - Higher economic bond -- increased AKT collateral scaled to capacity; longer unbonding period.
 - Clean history -- no slashing events or unresolved disputes in lookback window.
 
-**Application-layer policy**: Level 1 should require 2+ independent auditor attestations at Level 1 or better.
+**Application-layer policy**: Level 3 should require 2+ independent auditor attestations at Level 3 or better.
 Tenants can enforce this with `verification.min_auditor_count: 2`. If they also need attestations from specific named
 auditors, they can set `verification.auditors` and choose `verification.auditor_mode: any` or
 `verification.auditor_mode: all` (see [SDL Syntax](./README.md#sdl-syntax)).
 
-#### Level 0 -- Trusted
+#### Level 4 -- Trusted
 
 Trust statement: _"This provider is externally audited and offers maximum assurance."_
 
-The highest level of provider assurance. Requires everything from Level 1 plus independent third-party validation of
+The highest level of provider assurance. Requires everything from Level 3 plus independent third-party validation of
 physical infrastructure and operational practices.
 
 Requirements:
 
-- All Level 1 requirements
+- All Level 3 requirements
 - Third-party infrastructure audit -- independent verification of physical data center, power redundancy, cooling, and
   physical security. Audit by governance-approved auditor; audit report hash stored on-chain. Periodic re-audit required.
-- Extended compliance history -- minimum governance-configurable continuous Level 1 compliance (e.g., 180 days).
+- Extended compliance history -- minimum governance-configurable continuous Level 3 compliance (e.g., 180 days).
 - Maximum economic bond -- highest AKT collateral tier, scaled to capacity.
 - SLA commitment -- provider publishes availability and performance SLA parameters. The SLA document hash is
   included in the auditor's off-chain evidence (referenced by `evidence_hash`). The auditor verifies that the
@@ -197,18 +197,18 @@ Requirements:
   enforced via the existing [`SlashProviderBond`](./README.md#slashproviderbond) governance action when reported
   by auditors or tenants.
 - Contact responsiveness -- strictest response windows. Provider must respond to critical incidents within
-  `contact_response_critical_l0` and standard provider-operational inquiries within
-  `contact_response_standard_l0`. See
+  `contact_response_critical_l4` and standard provider-operational inquiries within
+  `contact_response_standard_l4`. See
   [Contact Responsiveness](./README.md#contact-responsiveness).
 - Governance endorsement (optional, supplementary) -- positive attestation from established network participants.
 
-**Application-layer policy**: Level 0 should require 2+ independent auditor attestations at Level 0.
+**Application-layer policy**: Level 4 should require 2+ independent auditor attestations at Level 4.
 This can be enforced with `verification.min_auditor_count: 2`, optionally combined with named auditor requirements as
-described in [Level 1](./README.md#level-1----established).
+described in [Level 3](./README.md#level-1----established).
 
 ### Verification Tier Summary
 
-| Dimension                  | L4 (Permissionless) |           L3 (Identified)           |             L2 (Verified)             |           L1 (Established)           |            L0 (Trusted)            |
+| Dimension                  | L0 (Permissionless) |           L1 (Identified)           |             L2 (Verified)             |           L3 (Established)           |            L4 (Trusted)            |
 | -------------------------- | :-----------------: | :---------------------------------: | :-----------------------------------: | :----------------------------------: | :--------------------------------: |
 | Signed code                |         --          |              Required               |               Required                |               Required               |              Required              |
 | Operator identity          |         --          |              Required               |               Required                |               Required               |              Required              |
@@ -249,10 +249,10 @@ lowering a provider's verification tier.
 
 | Tier             |       Critical Incident        |   Standard Provider Inquiry    |
 | ---------------- | :----------------------------: | :----------------------------: |
-| L3 (Identified)  | `contact_response_critical_l3` | `contact_response_standard_l3` |
+| L1 (Identified)  | `contact_response_critical_l1` | `contact_response_standard_l1` |
 | L2 (Verified)    | `contact_response_critical_l2` | `contact_response_standard_l2` |
-| L1 (Established) | `contact_response_critical_l1` | `contact_response_standard_l1` |
-| L0 (Trusted)     | `contact_response_critical_l0` | `contact_response_standard_l0` |
+| L3 (Established) | `contact_response_critical_l3` | `contact_response_standard_l3` |
+| L4 (Trusted)     | `contact_response_critical_l4` | `contact_response_standard_l4` |
 
 All response time thresholds are [governance parameters](./README.md#governance-parameters). See
 [Initial Governance Parameter Values](./README.md#initial-governance-parameter-values) for suggested defaults.
@@ -1025,7 +1025,7 @@ Canonical v1 schema:
     },
     "tier": {
       "type": "string",
-      "enum": ["L0", "L1", "L2", "L3"]
+      "enum": ["L1", "L2", "L3", "L4"]
     },
     "capability": {
       "type": "string",
@@ -1181,14 +1181,14 @@ Auditors are added exclusively via [governance proposals](./README.md#governance
 auditor includes:
 
 - Auditor address
-- Maximum attestation tier -- the highest tier this auditor is authorized to attest. An auditor approved for Level 1
-  can attest Levels 3, 2, and 1, but not Level 0.
+- Maximum attestation tier -- the highest tier this auditor is authorized to attest. An auditor approved for Level 3
+  can attest Levels 3, 2, and 1, but not Level 4.
 - Organization name and credentials (metadata hash referencing off-chain documentation)
 
 On governance approval, the module derives the required bond from `max_attestation_tier` and the current auditor bond
 parameters. The auditor must post at least that amount via `MsgPostAuditorBond` to become Active.
 
-To upgrade an auditor's maximum attestation tier (e.g., from Level 2 to Level 0), a new governance proposal is required.
+To upgrade an auditor's maximum attestation tier (e.g., from Level 2 to Level 4), a new governance proposal is required.
 The auditor must post additional bond to cover the difference.
 
 #### Auditor Bond
@@ -1197,10 +1197,10 @@ The bond is held in an escrow account and scales with the auditor's maximum atte
 
 | Max Attestation Authority | Bond Requirement                          |
 | ------------------------- | ----------------------------------------- |
-| Level 3 (Identified)      | `bond_l3` (governance parameter, lowest)  |
-| Level 2 (Verified)        | `bond_l2` > `bond_l3`                     |
-| Level 1 (Established)     | `bond_l1` > `bond_l2`                     |
-| Level 0 (Trusted)         | `bond_l0` (governance parameter, highest) |
+| Level 1 (Identified)      | `bond_l1` (governance parameter, lowest)  |
+| Level 2 (Verified)        | `bond_l2` > `bond_l1`                     |
+| Level 3 (Established)     | `bond_l3` > `bond_l2`                     |
+| Level 4 (Trusted)         | `bond_l4` (governance parameter, highest) |
 
 Bond states: `Bonded`, `Frozen`, `Unbonding`.
 
@@ -1343,7 +1343,7 @@ On submission, the module:
 ### On-Chain Prerequisite Enforcement
 
 The chain enforces a subset of tier prerequisites that are objectively verifiable from on-chain state. This
-prevents obviously invalid attestations from being stored (e.g., a Level 1 attestation for a provider registered
+prevents obviously invalid attestations from being stored (e.g., a Level 3 attestation for a provider registered
 yesterday) and reduces the burden on the [cross-validation](./README.md#cross-validation) mechanism for catching
 clear violations.
 
@@ -1352,26 +1352,26 @@ network quality, physical location, performance benchmarks, data isolation, etc.
 
 #### Enforceable Prerequisites by Tier
 
-| Prerequisite                           | Data Source                                                                |    L3    |      L2       |              L1               |                   L0                   |
+| Prerequisite                           | Data Source                                                                |    L1    |      L2       |              L3               |                   L4                   |
 | -------------------------------------- | -------------------------------------------------------------------------- | :------: | :-----------: | :---------------------------: | :------------------------------------: |
 | Provider registered on-chain           | `x/provider` store                                                         | Required |   Required    |           Required            |                Required                |
 | Provider bond posted at tier-minimum   | `x/verification` [provider bond](./README.md#provider-economic-bond) store |    --    |   Required    |           Required            |                Required                |
-| Provider registration age >= threshold | `x/provider` registration timestamp                                        |    --    | `min_age_l2`  |         `min_age_l1`          |              `min_age_l0`              |
-| Lease completion rate >= threshold     | `x/market` lease state counters                                            |    --    |      --       | `min_lease_completion_bps_l1` |     `min_lease_completion_bps_l0`      |
-| No active slashing events in window    | `x/verification` provider bond store                                       |    --    |      --       |   `clean_history_window_l1`   |       `clean_history_window_l0`        |
+| Provider registration age >= threshold | `x/provider` registration timestamp                                        |    --    | `min_age_l2`  |         `min_age_l3`          |              `min_age_l4`              |
+| Lease completion rate >= threshold     | `x/market` lease state counters                                            |    --    |      --       | `min_lease_completion_bps_l3` |     `min_lease_completion_bps_l4`      |
+| No active slashing events in window    | `x/verification` provider bond store                                       |    --    |      --       |   `clean_history_window_l3`   |       `clean_history_window_l4`        |
 | Snapshot hash compliance               | `x/verification` [snapshot](./README.md#snapshot-hash-enforcement) store   |    --    | Not suspended |         Not suspended         |             Not suspended              |
-| Continuous prior-tier attestation      | `x/verification` attestation history                                       |    --    |      --       |              --               | Valid L1+ for `min_l1_duration_for_l0` |
+| Continuous prior-tier attestation      | `x/verification` attestation history                                       |    --    |      --       |              --               | Valid L3+ for `min_l3_duration_for_l4` |
 
 #### Validation Flow
 
 When [`MsgSubmitAttestation`](./README.md#attestation-submission) is processed, step 4 performs the following checks
 based on the attested tier:
 
-**For all tiers (L3 through L0):**
+**For all tiers (L1 through L4):**
 
 - Query `x/provider` to confirm the provider is registered on-chain. Reject with `ErrProviderNotRegistered` if not found.
 
-**For Level 2 and above (L2, L1, L0):**
+**For Level 2 and above (L2, L3, L4):**
 
 - Query the [provider bond](./README.md#provider-economic-bond) record. Reject with `ErrInsufficientProviderBond` if
   the bonded amount is less than the tier-required minimum (calculated from the provider's `ResourceSummary` and the
@@ -1381,7 +1381,7 @@ based on the attested tier:
 - Compute the provider's registration age as `block_time - registration_time`. Reject with `ErrProviderTooNew` if
   the age is less than the tier's `min_age` parameter.
 
-**For Level 1 and above (L1, L0):**
+**For Level 3 and above (L3, L4):**
 
 - Query `x/market` for the provider's lease completion stats over the lookback window. If the provider has at least
   `min_leases_for_completion_rate` total leases in the window, compute the completion rate as
@@ -1391,12 +1391,12 @@ based on the attested tier:
 - Check the provider bond record for slashing events. Reject with `ErrSlashingHistory` if `last_slash_time` is within
   the tier's `clean_history_window`.
 
-**For Level 0 only:**
+**For Level 4 only:**
 
-- Scan the provider's attestation history to verify that the provider has had a continuous valid attestation at Level 1
-  or better for at least `min_l1_duration_for_l0`. "Continuous" means there exists at least one valid L1+ attestation
+- Scan the provider's attestation history to verify that the provider has had a continuous valid attestation at Level 3
+  or better for at least `min_l3_duration_for_l4`. "Continuous" means there exists at least one valid L3+ attestation
   at all times during the lookback period, considering attestation creation and expiry timestamps. Reject with
-  `ErrInsufficientL1History` if not met.
+  `ErrInsufficientL3History` if not met.
 
 #### Cross-Module Keeper Interfaces
 
@@ -1431,10 +1431,10 @@ Attestations expire automatically. Higher tiers require more frequent re-audit:
 
 | Tier    | TTL                                                 |
 | ------- | --------------------------------------------------- |
-| Level 3 | Longest (governance parameter, e.g., 365 days)      |
+| Level 1 | Longest (governance parameter, e.g., 365 days)      |
 | Level 2 | Shorter (governance parameter, e.g., 180 days)      |
-| Level 1 | Shorter still (governance parameter, e.g., 90 days) |
-| Level 0 | Shortest (governance parameter, e.g., 90 days)      |
+| Level 3 | Shorter still (governance parameter, e.g., 90 days) |
+| Level 4 | Shortest (governance parameter, e.g., 90 days)      |
 
 On expiry, the attestation status becomes `Expired`, the escrowed fee is released to the auditor, the auditor deposit is
 returned, and the attestation is no longer considered valid. Expiry is processed by the
@@ -1598,7 +1598,7 @@ the cross-validation rule triggers:
 3. **Escrowed fees remain escrowed and auditor deposits become `PendingDiscrepancy`**, so neither party gets an
    immediate payout before fault is known
 4. **Provider receives a bounded discrepancy grace period** if no provider fault is known yet. During the grace period,
-   bid filtering may use the provider's pre-discrepancy effective tier so a provider is not immediately dropped to L4
+   bid filtering may use the provider's pre-discrepancy effective tier so a provider is not immediately dropped to L0
    for an auditor conflict they may not have caused.
 5. A `DiscrepancyEvent` is emitted on-chain recording both auditor addresses, both tier claims, the provider, and
    a timestamp.
@@ -1736,10 +1736,10 @@ auditor's maximum attestation authority: higher authority requires more frequent
 
 | Max Attestation Authority | Renewal Period                                                       |
 | ------------------------- | -------------------------------------------------------------------- |
-| Level 3 (Identified)      | `renewal_period_l3` (governance parameter, longest, e.g., 24 months) |
+| Level 1 (Identified)      | `renewal_period_l1` (governance parameter, longest, e.g., 24 months) |
 | Level 2 (Verified)        | `renewal_period_l2` (governance parameter, e.g., 18 months)          |
-| Level 1 (Established)     | `renewal_period_l1` (governance parameter, e.g., 12 months)          |
-| Level 0 (Trusted)         | `renewal_period_l0` (governance parameter, shortest, e.g., 6 months) |
+| Level 3 (Established)     | `renewal_period_l3` (governance parameter, e.g., 12 months)          |
+| Level 4 (Trusted)         | `renewal_period_l4` (governance parameter, shortest, e.g., 6 months) |
 
 On successful renewal (governance proposal passes), the auditor's `renewal_deadline` is reset to the current time plus
 the applicable renewal period.
@@ -1836,7 +1836,7 @@ Effect:
 
 - All valid attestations on this provider are voided (status: `Voided`, reason: `GovernanceAction`)
 - Escrowed fees and deposits are settled according to `fault_attribution`
-- Provider is effectively Level 4 (Permissionless)
+- Provider is effectively Level 0 (Permissionless)
 - No automatic action against any of the auditors involved
 
 When `fault_attribution` is `ProviderFault`, the auditors are paid for completed work and auditor deposits are returned.
@@ -1976,12 +1976,12 @@ required_bond = sum(
 Each `bond_per_*[tier]` is a [governance parameter](./README.md#governance-parameters). Higher tiers require higher
 per-unit bonds:
 
-| Resource       | L2 (Verified)        | L1 (Established)         | L0 (Trusted)             |
+| Resource       | L2 (Verified)        | L3 (Established)         | L4 (Trusted)             |
 | -------------- | -------------------- | ------------------------ | ------------------------ |
-| Per GPU        | `bond_gpu_l2`        | `bond_gpu_l1` (>= 2x L2) | `bond_gpu_l0` (>= 4x L2) |
-| Per vCPU       | `bond_vcpu_l2`       | `bond_vcpu_l1`           | `bond_vcpu_l0`           |
-| Per GB memory  | `bond_mem_gb_l2`     | `bond_mem_gb_l1`         | `bond_mem_gb_l0`         |
-| Per TB storage | `bond_storage_tb_l2` | `bond_storage_tb_l1`     | `bond_storage_tb_l0`     |
+| Per GPU        | `bond_gpu_l2`        | `bond_gpu_l3` (>= 2x L2) | `bond_gpu_l4` (>= 4x L2) |
+| Per vCPU       | `bond_vcpu_l2`       | `bond_vcpu_l3`           | `bond_vcpu_l4`           |
+| Per GB memory  | `bond_mem_gb_l2`     | `bond_mem_gb_l3`         | `bond_mem_gb_l4`         |
+| Per TB storage | `bond_storage_tb_l2` | `bond_storage_tb_l3`     | `bond_storage_tb_l4`     |
 
 #### Bond Messages
 
@@ -2044,7 +2044,7 @@ This module is separate from the existing `x/audit` module and runs alongside it
 AuditorRecord {
   address: AccAddress
   status: Active | Frozen | Lapsed | Resigned | Removed
-  max_attestation_tier: VerificationTier (TierTrusted through TierIdentified)
+  max_attestation_tier: VerificationTier (TierIdentified through TierTrusted)
   bond_amount: Coin
   bond_status: Bonded | Frozen | Unbonding
   bond_unbonding_completion_time: Timestamp (nullable)
@@ -2057,16 +2057,16 @@ AuditorRecord {
 
 #### Attestation Record
 
-> **Note**: Attestation records exist only for tiers L0-L3 (TierTrusted through TierIdentified). Level 4
-> (Permissionless) is the implicit state of any provider without a valid attestation -- there is no L4 attestation
-> record. In query responses, `TierUnspecified` (enum value 0) represents "no attestation" (effectively L4).
+> **Note**: Attestation records exist only for tiers L1-L4 (TierIdentified through TierTrusted). Level 0
+> (Permissionless) is the implicit state of any provider without a valid attestation -- there is no L0 attestation
+> record. In query responses, `TierUnspecified` (enum value 0) represents "no attestation" (effectively L0).
 
 ```
 AttestationRecord {
   provider: AccAddress
   auditor: AccAddress
   audit_escrow_id: uint64
-  tier: VerificationTier (TierTrusted through TierIdentified)
+  tier: VerificationTier (TierIdentified through TierTrusted)
   capabilities: []CapabilityFlag
   evidence_hash: bytes
   fee: Coin
@@ -2205,48 +2205,48 @@ See [Initial Governance Parameter Values](./README.md#initial-governance-paramet
 
 | Parameter                                                          | Description                                                                                                         |
 | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| `bond_l3`                                                          | Minimum auditor bond for Level 3 attestation authority                                                              |
-| `bond_l2`                                                          | Minimum auditor bond for Level 2 attestation authority                                                              |
 | `bond_l1`                                                          | Minimum auditor bond for Level 1 attestation authority                                                              |
-| `bond_l0`                                                          | Minimum auditor bond for Level 0 attestation authority                                                              |
-| `ttl_l3`                                                           | Attestation TTL for Level 3                                                                                         |
-| `ttl_l2`                                                           | Attestation TTL for Level 2                                                                                         |
+| `bond_l2`                                                          | Minimum auditor bond for Level 2 attestation authority                                                              |
+| `bond_l3`                                                          | Minimum auditor bond for Level 3 attestation authority                                                              |
+| `bond_l4`                                                          | Minimum auditor bond for Level 4 attestation authority                                                              |
 | `ttl_l1`                                                           | Attestation TTL for Level 1                                                                                         |
-| `ttl_l0`                                                           | Attestation TTL for Level 0                                                                                         |
-| `min_fee_l3`                                                       | Minimum audit fee for Level 3 attestation                                                                           |
-| `min_fee_l2`                                                       | Minimum audit fee for Level 2 attestation                                                                           |
+| `ttl_l2`                                                           | Attestation TTL for Level 2                                                                                         |
+| `ttl_l3`                                                           | Attestation TTL for Level 3                                                                                         |
+| `ttl_l4`                                                           | Attestation TTL for Level 4                                                                                         |
 | `min_fee_l1`                                                       | Minimum audit fee for Level 1 attestation                                                                           |
-| `min_fee_l0`                                                       | Minimum audit fee for Level 0 attestation                                                                           |
+| `min_fee_l2`                                                       | Minimum audit fee for Level 2 attestation                                                                           |
+| `min_fee_l3`                                                       | Minimum audit fee for Level 3 attestation                                                                           |
+| `min_fee_l4`                                                       | Minimum audit fee for Level 4 attestation                                                                           |
 | `discrepancy_threshold`                                            | Maximum tier level difference before [cross-validation](./README.md#cross-validation) triggers (default: 1)         |
 | `auditor_unbonding_period`                                         | Duration of auditor bond unbonding                                                                                  |
-| `renewal_period_l3`                                                | Auditor [renewal](./README.md#renewal) period for Level 3 max authority                                             |
+| `renewal_period_l1`                                                | Auditor [renewal](./README.md#renewal) period for Level 1 max authority                                             |
 | `renewal_period_l2`                                                | Auditor renewal period for Level 2 max authority                                                                    |
-| `renewal_period_l1`                                                | Auditor renewal period for Level 1 max authority                                                                    |
-| `renewal_period_l0`                                                | Auditor renewal period for Level 0 max authority                                                                    |
+| `renewal_period_l3`                                                | Auditor renewal period for Level 3 max authority                                                                    |
+| `renewal_period_l4`                                                | Auditor renewal period for Level 4 max authority                                                                    |
 | `snapshot_hash_interval`                                           | Maximum time between required [snapshot hash](./README.md#on-chain-snapshot-hashes) postings                        |
 | `max_snapshot_age`                                                 | Maximum age of snapshot timestamp relative to block time                                                            |
-| `bond_gpu_l2` / `bond_gpu_l1` / `bond_gpu_l0`                      | [Provider bond](./README.md#provider-economic-bond) per GPU at each tier                                            |
-| `bond_vcpu_l2` / `bond_vcpu_l1` / `bond_vcpu_l0`                   | Provider bond per vCPU at each tier                                                                                 |
-| `bond_mem_gb_l2` / `bond_mem_gb_l1` / `bond_mem_gb_l0`             | Provider bond per GB memory at each tier                                                                            |
-| `bond_storage_tb_l2` / `bond_storage_tb_l1` / `bond_storage_tb_l0` | Provider bond per TB storage at each tier                                                                           |
+| `bond_gpu_l2` / `bond_gpu_l3` / `bond_gpu_l4`                      | [Provider bond](./README.md#provider-economic-bond) per GPU at each tier                                            |
+| `bond_vcpu_l2` / `bond_vcpu_l3` / `bond_vcpu_l4`                   | Provider bond per vCPU at each tier                                                                                 |
+| `bond_mem_gb_l2` / `bond_mem_gb_l3` / `bond_mem_gb_l4`             | Provider bond per GB memory at each tier                                                                            |
+| `bond_storage_tb_l2` / `bond_storage_tb_l3` / `bond_storage_tb_l4` | Provider bond per TB storage at each tier                                                                           |
 | `provider_bond_unbonding_period`                                   | Duration of provider bond unbonding                                                                                 |
 | `min_age_l2`                                                       | Minimum provider registration age for Level 2 [on-chain enforcement](./README.md#on-chain-prerequisite-enforcement) |
-| `min_age_l1`                                                       | Minimum provider registration age for Level 1                                                                       |
-| `min_age_l0`                                                       | Minimum provider registration age for Level 0                                                                       |
-| `min_lease_completion_bps_l1`                                      | Minimum lease completion rate (basis points) for Level 1                                                            |
-| `min_lease_completion_bps_l0`                                      | Minimum lease completion rate (basis points) for Level 0                                                            |
-| `clean_history_window_l1`                                          | Lookback window for clean slashing history (Level 1)                                                                |
-| `clean_history_window_l0`                                          | Lookback window for clean slashing history (Level 0)                                                                |
-| `min_l1_duration_for_l0`                                           | Minimum continuous Level 1+ attestation duration before Level 0                                                     |
+| `min_age_l3`                                                       | Minimum provider registration age for Level 3                                                                       |
+| `min_age_l4`                                                       | Minimum provider registration age for Level 4                                                                       |
+| `min_lease_completion_bps_l3`                                      | Minimum lease completion rate (basis points) for Level 3                                                            |
+| `min_lease_completion_bps_l4`                                      | Minimum lease completion rate (basis points) for Level 4                                                            |
+| `clean_history_window_l3`                                          | Lookback window for clean slashing history (Level 3)                                                                |
+| `clean_history_window_l4`                                          | Lookback window for clean slashing history (Level 4)                                                                |
+| `min_l3_duration_for_l4`                                           | Minimum continuous Level 3+ attestation duration before Level 4                                                     |
 | `min_leases_for_completion_rate`                                   | Minimum lease count before completion rate is enforced                                                              |
-| `contact_response_critical_l3`                                     | Maximum response time for critical incidents at Level 3                                                             |
-| `contact_response_critical_l2`                                     | Maximum response time for critical incidents at Level 2                                                             |
 | `contact_response_critical_l1`                                     | Maximum response time for critical incidents at Level 1                                                             |
-| `contact_response_critical_l0`                                     | Maximum response time for critical incidents at Level 0                                                             |
-| `contact_response_standard_l3`                                     | Maximum response time for standard provider-controlled operational inquiries at Level 3                             |
-| `contact_response_standard_l2`                                     | Maximum response time for standard provider-controlled operational inquiries at Level 2                             |
+| `contact_response_critical_l2`                                     | Maximum response time for critical incidents at Level 2                                                             |
+| `contact_response_critical_l3`                                     | Maximum response time for critical incidents at Level 3                                                             |
+| `contact_response_critical_l4`                                     | Maximum response time for critical incidents at Level 4                                                             |
 | `contact_response_standard_l1`                                     | Maximum response time for standard provider-controlled operational inquiries at Level 1                             |
-| `contact_response_standard_l0`                                     | Maximum response time for standard provider-controlled operational inquiries at Level 0                             |
+| `contact_response_standard_l2`                                     | Maximum response time for standard provider-controlled operational inquiries at Level 2                             |
+| `contact_response_standard_l3`                                     | Maximum response time for standard provider-controlled operational inquiries at Level 3                             |
+| `contact_response_standard_l4`                                     | Maximum response time for standard provider-controlled operational inquiries at Level 4                             |
 | `provider_maintenance_max_duration`                                | Maximum length of one provider maintenance window in `x/provider`                                                   |
 | `provider_maintenance_max_lookahead`                               | Maximum time in the future a provider can schedule a maintenance window in `x/provider`                             |
 | `max_endblocker_attestation_expiries`                              | Maximum attestation expiries processed per block by [EndBlocker](./README.md#endblocker-design)                     |
@@ -2265,47 +2265,47 @@ See [Initial Governance Parameter Values](./README.md#initial-governance-paramet
 
 | Parameter                              | Value              | Rationale                                                                      |
 | -------------------------------------- | ------------------ | ------------------------------------------------------------------------------ |
-| `bond_l3`                              | 1,000 AKT          | Low barrier for L3 auditors                                                    |
+| `bond_l1`                              | 1,000 AKT          | Low barrier for L1 auditors                                                    |
 | `bond_l2`                              | 5,000 AKT          | Moderate for L2                                                                |
-| `bond_l1`                              | 25,000 AKT         | Significant for L1                                                             |
-| `bond_l0`                              | 100,000 AKT        | Highest assurance                                                              |
-| `ttl_l3`                               | 365 days           | Annual re-audit                                                                |
+| `bond_l3`                              | 25,000 AKT         | Significant for L3                                                             |
+| `bond_l4`                              | 100,000 AKT        | Highest assurance                                                              |
+| `ttl_l1`                               | 365 days           | Annual re-audit                                                                |
 | `ttl_l2`                               | 180 days           | Semi-annual                                                                    |
-| `ttl_l1`                               | 90 days            | Quarterly                                                                      |
-| `ttl_l0`                               | 90 days            | Quarterly                                                                      |
-| `min_fee_l3`                           | 10 AKT             | Nominal                                                                        |
+| `ttl_l3`                               | 90 days            | Quarterly                                                                      |
+| `ttl_l4`                               | 90 days            | Quarterly                                                                      |
+| `min_fee_l1`                           | 10 AKT             | Nominal                                                                        |
 | `min_fee_l2`                           | 50 AKT             | Covers automated audit cost                                                    |
-| `min_fee_l1`                           | 200 AKT            | Covers deeper evaluation                                                       |
-| `min_fee_l0`                           | 1,000 AKT          | Covers on-site audit                                                           |
+| `min_fee_l3`                           | 200 AKT            | Covers deeper evaluation                                                       |
+| `min_fee_l4`                           | 1,000 AKT          | Covers on-site audit                                                           |
 | `discrepancy_threshold`                | 1                  | Trigger on >1 tier difference                                                  |
 | `auditor_unbonding_period`             | 21 days            | Standard Cosmos unbonding                                                      |
-| `renewal_period_l3`                    | 24 months          | Longest renewal cycle                                                          |
+| `renewal_period_l1`                    | 24 months          | Longest renewal cycle                                                          |
 | `renewal_period_l2`                    | 18 months          |                                                                                |
-| `renewal_period_l1`                    | 12 months          |                                                                                |
-| `renewal_period_l0`                    | 6 months           | Most frequent re-approval                                                      |
+| `renewal_period_l3`                    | 12 months          |                                                                                |
+| `renewal_period_l4`                    | 6 months           | Most frequent re-approval                                                      |
 | `snapshot_hash_interval`               | 24 hours           | Daily freshness                                                                |
 | `max_snapshot_age`                     | 1 hour             | Snapshot must be recent                                                        |
-| `bond_gpu_l2` / `l1` / `l0`            | 50 / 100 / 200 AKT | Per GPU                                                                        |
-| `bond_vcpu_l2` / `l1` / `l0`           | 0.5 / 1 / 2 AKT    | Per vCPU                                                                       |
-| `bond_mem_gb_l2` / `l1` / `l0`         | 0.25 / 0.5 / 1 AKT | Per GB memory                                                                  |
-| `bond_storage_tb_l2` / `l1` / `l0`     | 2 / 4 / 8 AKT      | Per TB storage                                                                 |
+| `bond_gpu_l2` / `l3` / `l4`            | 50 / 100 / 200 AKT | Per GPU                                                                        |
+| `bond_vcpu_l2` / `l3` / `l4`           | 0.5 / 1 / 2 AKT    | Per vCPU                                                                       |
+| `bond_mem_gb_l2` / `l3` / `l4`         | 0.25 / 0.5 / 1 AKT | Per GB memory                                                                  |
+| `bond_storage_tb_l2` / `l3` / `l4`     | 2 / 4 / 8 AKT      | Per TB storage                                                                 |
 | `provider_bond_unbonding_period`       | 21 days            | Standard unbonding                                                             |
 | `min_age_l2`                           | 30 days            |                                                                                |
-| `min_age_l1`                           | 120 days           |                                                                                |
-| `min_age_l0`                           | 300 days           |                                                                                |
-| `min_lease_completion_bps_l1` / `l0`   | 9800 (98%)         | High completion threshold                                                      |
-| `clean_history_window_l1`              | 90 days            |                                                                                |
-| `clean_history_window_l0`              | 180 days           |                                                                                |
-| `min_l1_duration_for_l0`               | 180 days           | 6 months at L1 before L0                                                       |
+| `min_age_l3`                           | 120 days           |                                                                                |
+| `min_age_l4`                           | 300 days           |                                                                                |
+| `min_lease_completion_bps_l3` / `l4`   | 9800 (98%)         | High completion threshold                                                      |
+| `clean_history_window_l3`              | 90 days            |                                                                                |
+| `clean_history_window_l4`              | 180 days           |                                                                                |
+| `min_l3_duration_for_l4`               | 180 days           | 6 months at L3 before L4                                                       |
 | `min_leases_for_completion_rate`       | 10                 | Avoids 1/1 = 100% gaming                                                       |
-| `contact_response_critical_l3`         | 72 hours           | Lenient; proves channel is monitored                                           |
+| `contact_response_critical_l1`         | 72 hours           | Lenient; proves channel is monitored                                           |
 | `contact_response_critical_l2`         | 24 hours           | Business-day response                                                          |
-| `contact_response_critical_l1`         | 4 hours            | Near-real-time for established operators                                       |
-| `contact_response_critical_l0`         | 1 hour             | Highest-trust providers must be highly responsive                              |
-| `contact_response_standard_l3`         | 7 days             | Generous window for non-urgent provider-controlled inquiries                   |
+| `contact_response_critical_l3`         | 4 hours            | Near-real-time for established operators                                       |
+| `contact_response_critical_l4`         | 1 hour             | Highest-trust providers must be highly responsive                              |
+| `contact_response_standard_l1`         | 7 days             | Generous window for non-urgent provider-controlled inquiries                   |
 | `contact_response_standard_l2`         | 72 hours           |                                                                                |
-| `contact_response_standard_l1`         | 24 hours           |                                                                                |
-| `contact_response_standard_l0`         | 4 hours            |                                                                                |
+| `contact_response_standard_l3`         | 24 hours           |                                                                                |
+| `contact_response_standard_l4`         | 4 hours            |                                                                                |
 | `provider_maintenance_max_duration`    | 7 days             | Allows long planned windows without making stale notices permanent             |
 | `provider_maintenance_max_lookahead`   | 90 days            | Lets tenants see planned maintenance without turning the store into a calendar |
 | `max_endblocker_attestation_expiries`  | 100                | Per-block processing cap                                                       |
@@ -2546,8 +2546,8 @@ VerificationKeeper:
   does NOT filter by snapshot compliance -- the caller must check `IsProviderSnapshotCompliant` separately. This
   separation ensures the verification module reports facts while the market module applies bid-time policy.
 - `IsProviderSnapshotCompliant` returns `false` if the provider's `ProviderSnapshotRecord.suspended` is `true`.
-- `GetProviderBestTier` returns the best (lowest numeric enum value = highest trust) tier from valid attestations.
-  Returns `TierUnspecified` if no valid attestations exist (effectively Level 4).
+- `GetProviderBestTier` returns the best (highest numeric enum value = highest trust) tier from valid attestations.
+  Returns `TierUnspecified` if no valid attestations exist (effectively Level 0).
 - `GetProviderGraceTier` returns the active discrepancy grace tier, if one exists. `x/market` uses this tier for tier
   filtering only when verification filtering is active. It must still enforce snapshot compliance, bond requirements,
   capability requirements, and named auditor requirements.

--- a/spec/aep-86/README.md
+++ b/spec/aep-86/README.md
@@ -1,7 +1,7 @@
 ---
 aep: 86
 title: "Provider Verifications"
-author: Artur Troian (@troian)
+author: Artur Troian (@troian) Joseph Chalabi (@chalabi2)
 status: Draft
 type: Standard
 category: Core
@@ -16,6 +16,7 @@ This approach is binary (audited or not), does not scale, depends on human accre
 graduated signal to tenants about the depth of verification a provider has undergone.
 
 Tenants deploying workloads on a decentralized compute marketplace need confidence that:
+
 - The hardware is genuine (not spoofed)
 - Provisioned resources match what was bid
 - The provider is reliably available
@@ -79,34 +80,37 @@ No verification has been performed. The provider has registered on-chain and its
 attributes are self-reported and unverified.
 
 Requirements:
+
 - Valid on-chain provider registration (`MsgCreateProvider`)
 - Provider daemon is reachable (status endpoint responds)
 
 #### Level 3 -- Identified
 
-Trust statement: _"The provider runs verified software, and we know who operates it."_
+Trust statement: _"The provider reports its software identity, and we know who operates it."_
 
-The provider is running cryptographically signed provider software and the operator behind it is known. This is
-the first meaningful trust boundary.
+The provider reports its provider software identity and the operator behind it is known. This is the first meaningful
+trust boundary.
 
 Requirements:
+
 - All Level 4 requirements
-- Signed code -- the provider must be running an officially signed release of the provider software. The software
-  signature is verified on-chain or by the auditor during attestation. The provider must continue running signed
-  software to retain this verification level; running unsigned or modified builds is grounds for attestation revocation.
+- Signed code (phase 2 enforcement target) -- the provider should run an officially signed release of the provider
+  software. The software version, binary digest, and observed signature are recorded in auditor evidence for AEP-86 v1.
+  Signature enforcement is deferred to a separate signing-key AEP or phase 2.
 - Operator identity -- linked to a verifiable entity. The acceptable identity types vary by tier:
 
-  | Tier | Acceptable Identity Types |
-  |------|---------------------------|
-  | L3 (Identified) | Business registration, domain ownership, or DID-based credential |
-  | L2 (Verified) | Business registration or DID-based credential (domain ownership alone is insufficient) |
-  | L1 (Established) | Business registration or DID-based credential |
-  | L0 (Trusted) | Business registration required |
+  | Tier             | Acceptable Identity Types                                                              |
+  | ---------------- | -------------------------------------------------------------------------------------- |
+  | L3 (Identified)  | Business registration, domain ownership, or DID-based credential                       |
+  | L2 (Verified)    | Business registration or DID-based credential (domain ownership alone is insufficient) |
+  | L1 (Established) | Business registration or DID-based credential                                          |
+  | L0 (Trusted)     | Business registration required                                                         |
 
   The auditor records the identity type verified in their off-chain evidence (referenced by `evidence_hash`).
   Signed identity attestation stored on-chain.
+
 - Contact channel -- verified communication endpoint for incident response. Provider must respond to
-  critical incidents within `contact_response_critical_l3` and standard inquiries within
+  critical incidents within `contact_response_critical_l3` and standard provider-operational inquiries within
   `contact_response_standard_l3` (governance parameters). See
   [Contact Responsiveness](./README.md#contact-responsiveness).
 - Stated location -- claimed geographic region/jurisdiction (self-reported; verified at higher tiers)
@@ -119,6 +123,7 @@ Self-reported attributes have been independently validated through automated tes
 network quality, and physical location have been verified.
 
 Requirements:
+
 - All Level 3 requirements
 - Resource delivery accuracy -- provisioned CPU, RAM, GPU memory, and storage match bid quantities. Validated via
   automated resource audit (deploy test workload, measure actual vs. claimed).
@@ -130,7 +135,8 @@ Requirements:
   [Inventory Service](./README.md#inventory-service) snapshots. Auditors reconcile snapshot data against on-chain
   attributes; discrepancies flag downgrade.
 - Contact responsiveness -- stricter response windows than Level 3. Provider must respond to critical incidents
-  within `contact_response_critical_l2` and standard inquiries within `contact_response_standard_l2`. See
+  within `contact_response_critical_l2` and standard provider-operational inquiries within
+  `contact_response_standard_l2`. See
   [Contact Responsiveness](./README.md#contact-responsiveness).
 - Minimum economic bond -- AKT locked as provider collateral, scaled to provider capacity. Slashable on proven resource
   misrepresentation. See [Provider Economic Bond](./README.md#provider-economic-bond).
@@ -150,6 +156,7 @@ Time-proven reliability separates serious operators from casual participants. Th
 performance over an extended period.
 
 Requirements:
+
 - All Level 2 requirements
 - Extended availability -- minimum governance-configurable rolling uptime above threshold (e.g., 90 days at 99%+).
 - Lease completion rate -- above governance-configurable threshold (e.g., 98%). Ratio of provider-completed vs.
@@ -159,16 +166,16 @@ Requirements:
 - Resource delivery under load -- audit probes run while provider has active leases to detect overcommitment.
 - Data isolation verification -- automated cross-tenant isolation tests (network namespace, filesystem, process isolation).
 - Contact responsiveness -- stricter response windows than Level 2. Provider must respond to critical incidents
-  within `contact_response_critical_l1` and standard inquiries within `contact_response_standard_l1`. See
+  within `contact_response_critical_l1` and standard provider-operational inquiries within
+  `contact_response_standard_l1`. See
   [Contact Responsiveness](./README.md#contact-responsiveness).
 - Higher economic bond -- increased AKT collateral scaled to capacity; longer unbonding period.
 - Clean history -- no slashing events or unresolved disputes in lookback window.
 
 **Application-layer policy**: Level 1 should require 2+ independent auditor attestations at Level 1 or better.
-Tenants can enforce multi-auditor requirements by specifying multiple required auditor addresses in the SDL/manifest
-`verification.auditors` list (see [SDL Syntax](./README.md#sdl-syntax)). The existing `required_auditors` field
-in `VerificationRequirement` supports this -- a tenant listing two auditor addresses requires attestations from
-both.
+Tenants can enforce this with `verification.min_auditor_count: 2`. If they also need attestations from specific named
+auditors, they can set `verification.auditors` and choose `verification.auditor_mode: any` or
+`verification.auditor_mode: all` (see [SDL Syntax](./README.md#sdl-syntax)).
 
 #### Level 0 -- Trusted
 
@@ -178,6 +185,7 @@ The highest level of provider assurance. Requires everything from Level 1 plus i
 physical infrastructure and operational practices.
 
 Requirements:
+
 - All Level 1 requirements
 - Third-party infrastructure audit -- independent verification of physical data center, power redundancy, cooling, and
   physical security. Audit by governance-approved auditor; audit report hash stored on-chain. Periodic re-audit required.
@@ -189,54 +197,62 @@ Requirements:
   enforced via the existing [`SlashProviderBond`](./README.md#slashproviderbond) governance action when reported
   by auditors or tenants.
 - Contact responsiveness -- strictest response windows. Provider must respond to critical incidents within
-  `contact_response_critical_l0` and standard inquiries within `contact_response_standard_l0`. See
+  `contact_response_critical_l0` and standard provider-operational inquiries within
+  `contact_response_standard_l0`. See
   [Contact Responsiveness](./README.md#contact-responsiveness).
 - Governance endorsement (optional, supplementary) -- positive attestation from established network participants.
 
 **Application-layer policy**: Level 0 should require 2+ independent auditor attestations at Level 0.
-This can be enforced via the SDL `verification.auditors` list as described in
-[Level 1](./README.md#level-1----established).
+This can be enforced with `verification.min_auditor_count: 2`, optionally combined with named auditor requirements as
+described in [Level 1](./README.md#level-1----established).
 
 ### Verification Tier Summary
 
-| Dimension                     | L4 (Permissionless) | L3 (Identified)              | L2 (Verified)                      | L1 (Established)                    | L0 (Trusted)                        |
-|-------------------------------|:-------------------:|:----------------------------:|:----------------------------------:|:-----------------------------------:|:-----------------------------------:|
-| Signed code                   | --                  | Required                     | Required                           | Required                            | Required                            |
-| Operator identity             | --                  | Required                     | Required                           | Required                            | Required                            |
-| Resource delivery accuracy    | --                  | --                           | Automated test                     | Under-load audit                    | Under-load audit                    |
-| Network quality               | --                  | --                           | Baseline check                     | Continuous benchmark                | Continuous benchmark                |
-| Physical location             | --                  | Self-reported                | Verified (geo + network)           | Verified                            | Audited on-site                     |
-| Inventory consistency         | --                  | --                           | Machine-reconciled                 | Machine-reconciled                  | Machine-reconciled                  |
-| Economic bond                 | --                  | --                           | Minimum                            | Higher                              | Maximum                             |
-| Uptime track record           | --                  | --                           | 30-day minimum                     | 90-day, 99%+                        | 180-day continuous                  |
-| Lease completion rate         | --                  | --                           | --                                 | 98%+                                | 98%+                                |
-| Data isolation                | --                  | --                           | --                                 | Automated test                      | Automated test                      |
-| Continuous audits             | --                  | --                           | --                                 | Periodic pass                       | Periodic pass                       |
-| Contact responsiveness        | --                  | 72 hours critical / 7 days standard | 24 hours critical / 72 hours standard | 4 hours critical / 24 hours standard | 1 hour critical / 4 hours standard |
-| Third-party physical audit    | --                  | --                           | --                                 | --                                  | Required                            |
-| On-chain SLA                  | --                  | --                           | --                                 | --                                  | Required                            |
-| Snapshot hash compliance      | --                  | --                           | Required                           | Required                            | Required                            |
+| Dimension                  | L4 (Permissionless) |           L3 (Identified)           |             L2 (Verified)             |           L1 (Established)           |            L0 (Trusted)            |
+| -------------------------- | :-----------------: | :---------------------------------: | :-----------------------------------: | :----------------------------------: | :--------------------------------: |
+| Signed code                |         --          |              Required               |               Required                |               Required               |              Required              |
+| Operator identity          |         --          |              Required               |               Required                |               Required               |              Required              |
+| Resource delivery accuracy |         --          |                 --                  |            Automated test             |           Under-load audit           |          Under-load audit          |
+| Network quality            |         --          |                 --                  |            Baseline check             |         Continuous benchmark         |        Continuous benchmark        |
+| Physical location          |         --          |            Self-reported            |       Verified (geo + network)        |               Verified               |          Audited on-site           |
+| Inventory consistency      |         --          |                 --                  |          Machine-reconciled           |          Machine-reconciled          |         Machine-reconciled         |
+| Economic bond              |         --          |                 --                  |                Minimum                |                Higher                |              Maximum               |
+| Uptime track record        |         --          |                 --                  |            30-day minimum             |             90-day, 99%+             |         180-day continuous         |
+| Lease completion rate      |         --          |                 --                  |                  --                   |                 98%+                 |                98%+                |
+| Data isolation             |         --          |                 --                  |                  --                   |            Automated test            |           Automated test           |
+| Continuous audits          |         --          |                 --                  |                  --                   |            Periodic pass             |           Periodic pass            |
+| Contact responsiveness     |         --          | 72 hours critical / 7 days standard | 24 hours critical / 72 hours standard | 4 hours critical / 24 hours standard | 1 hour critical / 4 hours standard |
+| Third-party physical audit |         --          |                 --                  |                  --                   |                  --                  |              Required              |
+| On-chain SLA               |         --          |                 --                  |                  --                   |                  --                  |              Required              |
+| Snapshot hash compliance   |         --          |                 --                  |               Required                |               Required               |              Required              |
 
 ### Contact Responsiveness
 
-Providers must maintain verified communication channels and respond within tier-specific time windows. Response
-time requirements escalate with verification tier, reflecting the operational maturity expected at each level.
+Providers must maintain verified communication channels, respond within tier-specific time windows, and publish
+provider-controlled maintenance notices on chain. Response time requirements escalate with verification tier,
+reflecting the operational maturity expected at each level.
+
+This section covers communication that the provider can actually control: active workload incidents, provider
+endpoint access, configuration questions, security concerns involving the provider environment, capacity changes,
+and planned or emergency maintenance. Marketplace-owned accounting issues, including payment timing, fee accounting,
+pricing disputes, and other market settlement behavior, are not provider SLA items and must not be used as grounds for
+lowering a provider's verification tier.
 
 #### Incident Severity Levels
 
-| Severity   | Definition                                                                      | Examples                                                           |
-|------------|---------------------------------------------------------------------------------|--------------------------------------------------------------------|
-| **Critical** | Service-affecting incident impacting active tenant workloads or network security | Node outage, data loss, security breach, network partition          |
-| **Standard** | Non-urgent operational inquiry or minor issue                                   | Configuration question, billing inquiry, planned maintenance coordination |
+| Severity     | Definition                                                                       | Examples                                                                  |
+| ------------ | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| **Critical** | Service-affecting incident impacting active tenant workloads or network security | Node outage, data loss, security breach, network partition                |
+| **Standard** | Non-urgent provider-controlled operational inquiry or minor issue                | Configuration question, provider endpoint question, maintenance follow-up |
 
 #### Response Time Requirements by Tier
 
-| Tier              | Critical Incident              | Standard Inquiry                |
-|-------------------|:------------------------------:|:-------------------------------:|
-| L3 (Identified)   | `contact_response_critical_l3` | `contact_response_standard_l3`  |
-| L2 (Verified)     | `contact_response_critical_l2` | `contact_response_standard_l2`  |
-| L1 (Established)  | `contact_response_critical_l1` | `contact_response_standard_l1`  |
-| L0 (Trusted)      | `contact_response_critical_l0` | `contact_response_standard_l0`  |
+| Tier             |       Critical Incident        |   Standard Provider Inquiry    |
+| ---------------- | :----------------------------: | :----------------------------: |
+| L3 (Identified)  | `contact_response_critical_l3` | `contact_response_standard_l3` |
+| L2 (Verified)    | `contact_response_critical_l2` | `contact_response_standard_l2` |
+| L1 (Established) | `contact_response_critical_l1` | `contact_response_standard_l1` |
+| L0 (Trusted)     | `contact_response_critical_l0` | `contact_response_standard_l0` |
 
 All response time thresholds are [governance parameters](./README.md#governance-parameters). See
 [Initial Governance Parameter Values](./README.md#initial-governance-parameter-values) for suggested defaults.
@@ -261,46 +277,159 @@ Non-response or exceeding the tier-specific response window is grounds for attes
 attestation. Repeated non-response during an attestation's TTL is grounds for auditor-initiated revocation via
 `MsgRevokeAttestation`.
 
-### Signed Code Verification
+#### Provider Maintenance Notices
 
-Provider software releases must be cryptographically signed. The signing scheme uses a governance-managed key set
-stored on-chain.
+AEP-86 adds provider-signed maintenance notices to `x/provider`. The notice is intentionally narrow: it tells the
+chain and tenant-facing clients that the provider has a scheduled or emergency operational window. It does not try to
+deliver email, Slack, Discord, Telegram, or webhook messages from consensus. The chain records the source of truth and
+emits typed events. Clients, indexers, REST services, and Console use those events and queries to notify tenants through
+their selected delivery channels.
 
-#### Signing Key Set
+V1 supports provider-wide maintenance windows only. A maintenance window applies to all active leases on the provider.
+This is the required path for planned maintenance coordination in phase 1. Per-lease, per-region, or free-form provider
+messaging can be added later if needed, but they are not required for the phase 1 rollout.
 
-The `x/verification` module maintains a `SigningKeySet` -- a list of public keys authorized to sign provider
-software releases. Keys are managed via governance:
+Maintenance window types:
 
-- **Key registration**: A governance proposal adds a new signing public key with an activation timestamp and an
-  optional expiry timestamp.
-- **Key rotation**: A new key is registered via governance before the old key's expiry. Multiple keys may be valid
-  simultaneously during rotation windows.
-- **Key revocation**: A governance proposal sets a key's expiry to the current time, immediately invalidating it.
+| Type        | Meaning                                                                                         |
+| ----------- | ----------------------------------------------------------------------------------------------- |
+| `Planned`   | Scheduled maintenance that the provider can announce before the window begins                   |
+| `Emergency` | Unplanned work needed to protect active workloads, provider availability, or network safety     |
+| `Security`  | Security-related maintenance, patching, credential rotation, or incident containment            |
+| `Network`   | Network maintenance, routing changes, upstream provider work, or connectivity remediation       |
+| `Capacity`  | Capacity-affecting provider work, such as host replacement, rack work, or resource pool changes |
 
-#### Verification Flow
-
-1. The provider software binary includes an embedded signature over its content, signed by one of the authorized
-   signing keys.
-2. During attestation, the auditor verifies the provider's running binary signature against the on-chain
-   `SigningKeySet`. The auditor queries the set, confirms at least one valid (activated, not expired) key matches
-   the binary's signature.
-3. The `software_signature` field in [`ResourceSummary`](./README.md#provider-snapshot-record) records the
-   signature of the running binary. The `software_version` field records the version string.
-4. Running unsigned or modified builds, or builds signed with a revoked/expired key, is grounds for refusing
-   attestation or revoking an existing attestation.
-
-#### Key Set State
+Provider messages:
 
 ```
-SigningKey {
-  public_key: bytes
-  activated_at: Timestamp
-  expires_at: Timestamp (nullable -- null means no expiry)
-  revoked: bool
+MsgOpenProviderMaintenance {
+  provider: AccAddress
+  maintenance_type: ProviderMaintenanceType
+  starts_at: Timestamp
+  expected_ends_at: Timestamp
+  metadata_hash: bytes
+}
+
+MsgCloseProviderMaintenance {
+  provider: AccAddress
+  maintenance_id: uint64
 }
 ```
 
-The key set is stored in the `x/verification` module state and is queryable by any participant.
+`provider` is the signer. `metadata_hash` is optional and may point to an off-chain maintenance note, runbook, or
+incident record. The on-chain message should not include tenant personal data, private incident details, or long
+free-form text.
+
+Open rules:
+
+1. The signer must be the registered provider owner.
+2. `maintenance_type` must be one of the defined maintenance types.
+3. `expected_ends_at` must be after `starts_at`.
+4. The window duration must be no greater than `provider_maintenance_max_duration`.
+5. `starts_at` must be no farther in the future than `provider_maintenance_max_lookahead`.
+6. V1 permits at most one scheduled or active maintenance window per provider. A provider that needs to correct a
+   notice should close the existing window and open a new one. An elapsed window that was not explicitly closed does
+   not block a new window.
+
+Close rules:
+
+1. Only the provider that opened the maintenance window can close it.
+2. Closing records `closed_at` and emits a close event.
+3. If a provider does not close a window, clients treat the window as elapsed after `expected_ends_at`. No EndBlocker
+   state transition is required for phase 1.
+
+Provider maintenance state:
+
+```
+ProviderMaintenanceRecord {
+  id: uint64
+  provider: AccAddress
+  maintenance_type: ProviderMaintenanceType
+  starts_at: Timestamp
+  expected_ends_at: Timestamp
+  opened_at: Timestamp
+  closed_at: Timestamp (nullable)
+  metadata_hash: bytes
+}
+```
+
+Derived status is computed from `closed_at`, `starts_at`, `expected_ends_at`, and block time:
+
+| Derived Status | Condition                                                             |
+| -------------- | --------------------------------------------------------------------- |
+| `Scheduled`    | `closed_at` is empty and `block_time < starts_at`                     |
+| `Active`       | `closed_at` is empty and `starts_at <= block_time < expected_ends_at` |
+| `Elapsed`      | `closed_at` is empty and `block_time >= expected_ends_at`             |
+| `Closed`       | `closed_at` is set                                                    |
+
+The provider module emits typed events when a maintenance window is opened or closed:
+
+```
+EventProviderMaintenanceOpened {
+  maintenance_id: uint64
+  provider: AccAddress
+  maintenance_type: ProviderMaintenanceType
+  starts_at: Timestamp
+  expected_ends_at: Timestamp
+  metadata_hash: bytes
+}
+
+EventProviderMaintenanceClosed {
+  maintenance_id: uint64
+  provider: AccAddress
+  closed_at: Timestamp
+}
+```
+
+Tenant alert path:
+
+1. Provider signs and broadcasts `MsgOpenProviderMaintenance`.
+2. `x/provider` validates the provider, stores the `ProviderMaintenanceRecord`, and emits
+   `EventProviderMaintenanceOpened`.
+3. A client, indexer, REST service, or Console listener observes the event.
+4. The listener queries `x/market` for active leases on that provider and maps those leases to tenants.
+5. The tenant-facing client creates an alert and delivers it through the tenant's configured channel, such as Console,
+   email, webhook, Slack, Discord, or Telegram.
+6. Clients also query active and scheduled maintenance records when loading provider or lease views so missed events do
+   not hide an active maintenance window.
+
+The chain does not store tenant notification preferences and does not record whether a tenant saw an alert.
+Notification delivery failures are client or indexer issues, not provider consensus faults. The provider's on-chain duty
+is to publish the maintenance window in time when the provider controls the event and to close it when the window ends.
+
+Maintenance notices do not automatically excuse SLA breaches, failed lease completion, or lower-tier attestation
+outcomes. They are evidence that auditors, tenants, and governance can evaluate alongside incident reports, lease
+history, and provider behavior.
+
+Provider communication parameters:
+
+| Parameter                            | Description                                                             |
+| ------------------------------------ | ----------------------------------------------------------------------- |
+| `provider_maintenance_max_duration`  | Maximum length of one provider maintenance window                       |
+| `provider_maintenance_max_lookahead` | Maximum time in the future a provider can schedule a maintenance window |
+
+### Signed Code Verification
+
+Provider software releases should be cryptographically signed, but AEP-86 v1 does not implement signing enforcement.
+The auditor evidence document may record observed software version, binary digest, and signature bytes. The chain records
+the evidence hash, but it does not maintain signing keys, define supported key types, or reject attestations based on
+signature validity.
+
+This is intentionally deferred. The first implementation should focus on blockchain behavior, attestation state, escrow,
+governance, and market filtering. A separate signing-key AEP or phase 2 change must define the signing system before
+signature verification becomes enforceable.
+
+The deferred signing AEP must define at least:
+
+- Supported public key and signature types.
+- How public keys are registered, rotated, revoked, queried, and exported in genesis.
+- How an auditor or chain client pulls a public key from chain state and verifies a signed provider artifact.
+- The exact artifact covered by the signature. For v1 planning, the signature scope is the provider or inventory
+  artifact itself, not arbitrary dynamically loaded libraries.
+- How to handle unsigned artifacts, unknown keys, revoked keys, modified artifacts, and verification failures.
+
+AEP-86 v1 evidence may include observed signing fields for future compatibility, but those fields are not consensus
+enforced and must not be treated as a complete signing-key implementation.
 
 ### Capability Flags
 
@@ -324,13 +453,21 @@ Defined capability flags:
 - **Bare Metal** -- Provider offers bare-metal (non-virtualized) compute. Verified by the auditor via inventory
   snapshot [virtualization detection](./README.md#virtualization-detection) showing no hypervisor present.
 
-Additional capability flags may be added via governance parameter updates without requiring a chain upgrade, as the
-on-chain representation uses an extensible enum.
+AEP-86 v1 treats `CapabilityFlag` as a fixed protobuf enum. Adding a new named capability requires a software upgrade
+that updates protobuf definitions, validation semantics, SDL names, CLI and UI rendering, evidence requirements, and
+auditor software checks. Governance may tune parameters for existing capabilities, but governance cannot add a new
+capability identifier without an upgrade in v1.
 
 [Cross-validation](./README.md#cross-validation) (discrepancy detection) applies only to the tier component of
 attestations, not to capability flags. Two auditors may attest the same provider at the same tier but with different
 capability flags without triggering a discrepancy. Tenants who require specific capabilities should prefer providers
 with multiple independent auditor attestations confirming that capability.
+
+This is intentional for v1 because `capabilities` are positive assertions only. A missing capability flag means "this
+auditor did not attest this capability," not "this auditor proved the capability is absent." Without negative capability
+assertions, the chain cannot distinguish a real contradiction from two auditors checking different optional surfaces. A
+future AEP can add explicit `Verified`, `Denied`, and `NotEvaluated` capability assertions and then include capability
+disagreements in cross-validation.
 
 ### Inventory Service
 
@@ -358,8 +495,8 @@ source of provider capabilities, replacing the previous model of self-reported a
 #### Threat Model
 
 The fundamental challenge of inventory reporting is that the provider controls the machine generating the report.
-Even with signed code, the operating system, hypervisor, and firmware can lie about the hardware present. The
-Inventory Service is designed around the assumption that any single data source can be compromised, and that
+Even with a known inventory artifact, the operating system, hypervisor, and firmware can lie about the hardware
+present. The Inventory Service is designed around the assumption that any single data source can be compromised, and that
 defense requires multiple independent layers.
 
 ##### Attack Vectors
@@ -368,7 +505,7 @@ The following interception points exist between the inventory binary and the act
 to hardest to exploit:
 
 1. **Dynamic linker interception (LD_PRELOAD)** -- The provider sets environment variables to inject a shared library
-   that intercepts libc calls (`open`, `read`, `ioctl`) before they reach the kernel. The signed binary calls
+   that intercepts libc calls (`open`, `read`, `ioctl`) before they reach the kernel. The inventory binary calls
    `fopen("/proc/cpuinfo")` and receives fabricated data.
 
 2. **Fake sysfs/procfs** -- The provider mounts overlayfs on `/proc` or `/sys` with modified files, or uses bind
@@ -377,8 +514,8 @@ to hardest to exploit:
 3. **Kernel module syscall hooking** -- The provider loads a kernel module that intercepts syscalls at the kernel
    level. Even if the binary bypasses libc, the kernel itself returns fake data.
 
-4. **Hypervisor spoofing** -- The provider runs the signed software inside a virtual machine. The hypervisor
-   intercepts privileged instructions (including CPUID) and presents a fake hardware topology. The signed binary
+4. **Hypervisor spoofing** -- The provider runs the inventory software inside a virtual machine. The hypervisor
+   intercepts privileged instructions (including CPUID) and presents a fake hardware topology. The inventory binary
    has no way to distinguish VM-presented hardware from physical hardware.
 
 5. **Firmware/BIOS modification** -- The provider modifies SMBIOS/DMI tables in the BIOS to report different
@@ -395,7 +532,7 @@ beyond the economic benefit.
 ##### Defense Layers
 
 | Layer                                        | Mechanism                                                              | Vectors Defeated                                                            |
-|----------------------------------------------|------------------------------------------------------------------------|-----------------------------------------------------------------------------|
+| -------------------------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | 1. Static binary                             | Statically compiled, no dynamic library loading                        | LD_PRELOAD, dynamic linker injection                                        |
 | 2. Direct hardware reads                     | Read hardware registers directly, bypassing OS filesystem abstractions | Fake sysfs/procfs, some kernel module attacks                               |
 | 3. Multi-source cross-validation             | Report the same property from multiple independent data sources        | Single-source spoofing (faking one source but not all)                      |
@@ -413,28 +550,27 @@ hardware assurance can require it.
 
 #### Binary Requirements
 
-The Inventory Service binary is distributed as part of the signed provider software (the same signed code required
-for Level 3+). It must meet the following requirements:
+The Inventory Service binary is distributed as part of the provider software artifact. It must meet the following
+requirements:
 
 - **Statically linked for system libraries** -- all system dependencies (libc, etc.) are compiled in; the binary
   makes direct syscalls to the kernel, bypassing libc entirely. This eliminates LD_PRELOAD and dynamic linker
   interception for system-level calls. **Exception for vendor hardware management libraries**: the binary may
-  dynamically load vendor-provided management libraries (e.g., NVIDIA NVML, AMD ROCm SMI) at runtime, provided
-  the library's cryptographic signature is verified against the governance-managed
-  [signing key set](./README.md#signed-code-verification) before loading. Vendor library data is treated as one
-  data source among multiple; discrepancies between vendor library output and direct hardware reads (e.g., PCIe
-  configuration space) are flagged in the snapshot.
-- **Signed and versioned** -- the binary's cryptographic signature is verifiable against the governance-managed
-  [signing key set](./README.md#signed-code-verification). The software version and signature are included in
-  every inventory snapshot.
+  dynamically load vendor-provided management libraries (e.g., NVIDIA NVML, AMD ROCm SMI) at runtime. AEP-86 v1 does
+  not define signature enforcement for dynamically loaded libraries. Vendor library data is treated as one data source
+  among multiple; discrepancies between vendor library output and direct hardware reads (e.g., PCIe configuration
+  space) are flagged in the snapshot.
+- **Versioned and signature-observed** -- the binary reports its software version, binary digest, and observed signature
+  in every inventory snapshot when available. AEP-86 v1 records these fields for evidence compatibility, but signing-key
+  verification is deferred to a separate signing-key AEP or phase 2.
 - **Direct hardware register reads** -- in addition to reading OS interfaces (`/proc`, `/sys`), the binary reads
   hardware properties directly from hardware registers where possible (see
   [Multi-Source Data Collection](./README.md#multi-source-data-collection) below). Both values are reported in the
   snapshot. For GPU hardware, direct PCIe configuration space reads provide vendor ID, device ID, and BAR
   configuration independently of vendor management libraries.
 
-Whether the Inventory Service is a separate signed binary or part of the main provider daemon binary is an
-implementation detail.
+Whether the Inventory Service is a separate binary or part of the main provider daemon binary is an implementation
+detail.
 
 #### Transport and Access
 
@@ -460,7 +596,7 @@ An inventory snapshot includes:
   data sources (see [Multi-Source Data Collection](./README.md#multi-source-data-collection)).
 - **Resource allocation** -- currently allocated resources (CPU, memory, GPU, storage) across active leases.
 - **Available resources** -- unallocated resources available for new workloads.
-- **Software version** -- provider software version and its cryptographic signature.
+- **Software version** -- provider software version and observed cryptographic signature bytes.
 - **Virtualization status** -- whether the binary detected it is running inside a virtual machine, and the
   detection method and hypervisor identity if detected (see
   [Virtualization Detection](./README.md#virtualization-detection)).
@@ -484,45 +620,45 @@ possible:
 
 **CPU:**
 
-| Source | Method | Notes |
-|--------|--------|-------|
-| CPUID instruction | Direct CPU execution (ring 3) | Reports model, family, stepping, feature flags, topology. On bare metal, cannot be intercepted by the OS kernel. In a VM, the hypervisor can intercept. |
-| `/proc/cpuinfo` | OS filesystem | Kernel-reported view. Fakeable via procfs overlay or kernel module. |
-| DMI/SMBIOS tables | Firmware-provided (`/sys/firmware/dmi/`) | BIOS-reported CPU socket information. Fakeable via firmware modification. |
-| Topology enumeration | CPUID leaf 0x0B / 0x1F | Direct enumeration of cores, threads, packages. |
+| Source               | Method                                   | Notes                                                                                                                                                   |
+| -------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CPUID instruction    | Direct CPU execution (ring 3)            | Reports model, family, stepping, feature flags, topology. On bare metal, cannot be intercepted by the OS kernel. In a VM, the hypervisor can intercept. |
+| `/proc/cpuinfo`      | OS filesystem                            | Kernel-reported view. Fakeable via procfs overlay or kernel module.                                                                                     |
+| DMI/SMBIOS tables    | Firmware-provided (`/sys/firmware/dmi/`) | BIOS-reported CPU socket information. Fakeable via firmware modification.                                                                               |
+| Topology enumeration | CPUID leaf 0x0B / 0x1F                   | Direct enumeration of cores, threads, packages.                                                                                                         |
 
 **GPU:**
 
-| Source | Method | Notes |
-|--------|--------|-------|
-| PCIe configuration space | Direct read via sysfs PCI or `/dev/mem` | Reads PCI vendor ID, device ID, subsystem ID from hardware. Harder to fake than sysfs device entries. |
-| Vendor management library (e.g., NVML) | Vendor-provided API | Reports model, serial number, memory, temperature. For NVIDIA: NVML. For AMD: ROCm SMI. |
-| `/sys/class/drm/` | OS filesystem | Kernel DRM subsystem view. Fakeable via sysfs overlay. |
+| Source                                 | Method                                  | Notes                                                                                                 |
+| -------------------------------------- | --------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| PCIe configuration space               | Direct read via sysfs PCI or `/dev/mem` | Reads PCI vendor ID, device ID, subsystem ID from hardware. Harder to fake than sysfs device entries. |
+| Vendor management library (e.g., NVML) | Vendor-provided API                     | Reports model, serial number, memory, temperature. For NVIDIA: NVML. For AMD: ROCm SMI.               |
+| `/sys/class/drm/`                      | OS filesystem                           | Kernel DRM subsystem view. Fakeable via sysfs overlay.                                                |
 
 **Memory:**
 
-| Source | Method | Notes |
-|--------|--------|-------|
-| SPD data via SMBus/I2C | Direct read from DIMM EEPROM | Reports actual physical DIMM capacity, speed, manufacturer from the memory module itself. Requires SMBus access. |
-| `/proc/meminfo` | OS filesystem | Kernel-reported total and available memory. Fakeable. |
-| DMI/SMBIOS tables | Firmware-provided | BIOS-reported memory array information. |
-| EDAC sysfs | `/sys/devices/system/edac/mc/` | Error detection and correction subsystem memory controller view. |
+| Source                 | Method                         | Notes                                                                                                            |
+| ---------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| SPD data via SMBus/I2C | Direct read from DIMM EEPROM   | Reports actual physical DIMM capacity, speed, manufacturer from the memory module itself. Requires SMBus access. |
+| `/proc/meminfo`        | OS filesystem                  | Kernel-reported total and available memory. Fakeable.                                                            |
+| DMI/SMBIOS tables      | Firmware-provided              | BIOS-reported memory array information.                                                                          |
+| EDAC sysfs             | `/sys/devices/system/edac/mc/` | Error detection and correction subsystem memory controller view.                                                 |
 
 **Storage:**
 
-| Source | Method | Notes |
-|--------|--------|-------|
-| SMART data | ATA/NVMe passthrough commands | Reads drive model, capacity, serial number, health directly from the storage controller. |
-| NVMe admin commands | Direct NVMe identify controller/namespace | For NVMe drives, reads capacity and capabilities from the drive firmware. |
-| `/sys/block/` | OS filesystem | Kernel block device view. Fakeable. |
+| Source              | Method                                    | Notes                                                                                    |
+| ------------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------- |
+| SMART data          | ATA/NVMe passthrough commands             | Reads drive model, capacity, serial number, health directly from the storage controller. |
+| NVMe admin commands | Direct NVMe identify controller/namespace | For NVMe drives, reads capacity and capabilities from the drive firmware.                |
+| `/sys/block/`       | OS filesystem                             | Kernel block device view. Fakeable.                                                      |
 
 **Network:**
 
-| Source | Method | Notes |
-|--------|--------|-------|
-| Ethtool ioctl | Direct NIC query | Reads link speed, driver, firmware version from the network interface controller. |
-| `/sys/class/net/` | OS filesystem | Kernel network device view. Fakeable. |
-| PCIe configuration space | Direct read | NIC vendor ID, device ID, BAR configuration. |
+| Source                   | Method           | Notes                                                                             |
+| ------------------------ | ---------------- | --------------------------------------------------------------------------------- |
+| Ethtool ioctl            | Direct NIC query | Reads link speed, driver, firmware version from the network interface controller. |
+| `/sys/class/net/`        | OS filesystem    | Kernel network device view. Fakeable.                                             |
+| PCIe configuration space | Direct read      | NIC vendor ID, device ID, BAR configuration.                                      |
 
 The snapshot includes the value from each source for every property. Where sources agree, this is a positive trust
 signal. Where they disagree, the discrepancy is explicitly flagged with all values included, allowing auditors to
@@ -564,6 +700,7 @@ All inventory queries support a challenge-response mechanism to prevent snapshot
 3. The querier verifies the signature against the provider's known on-chain key and confirms the nonce matches.
 
 This ensures:
+
 - The snapshot was generated after the query was issued (prevents caching old snapshots)
 - The snapshot has not been modified in transit (signature verification)
 - The snapshot was generated by the claimed provider (key binding)
@@ -587,6 +724,7 @@ creates an immutable, timestamped audit trail of the provider's self-reported st
 - `snapshot_timestamp`: snapshot generation time (must be within `max_snapshot_age` of block time)
 
 On submission:
+
 1. Validate the provider is registered on-chain
 2. Validate `snapshot_timestamp` is within `[block_time - max_snapshot_age, block_time]` (prevents stale snapshots)
 3. Store or replace the `ProviderSnapshotRecord`
@@ -635,12 +773,390 @@ Auditors query the Inventory Service as part of their evaluation:
   for refusing attestation or attesting at a lower tier.
 - **Periodic checks** -- auditors may call the Inventory Service at any time during the attestation's TTL to verify
   that the provider continues to meet the requirements of their attested tier. If a periodic check reveals that the
-  provider no longer qualifies (e.g., resource capacity has decreased below claimed levels, signed code is no longer
-  running, new multi-source discrepancies have appeared), the auditor should revoke their attestation via
+  provider no longer qualifies (e.g., resource capacity has decreased below claimed levels, observed software identity
+  changed unexpectedly, new multi-source discrepancies have appeared), the auditor should revoke their attestation via
   `MsgRevokeAttestation`.
 - **Cross-referencing over time** -- auditors compare inventory snapshots taken at different times, correlated with
   on-chain events (lease creation, termination). Available resources should decrease when new leases are created and
   increase when leases end. Inconsistencies indicate overcommitment or manipulation.
+
+### V1 Auditor Software
+
+AEP-86 v1 requires a reference auditor software package before activation. The software does not replace the approved
+auditor role, but it makes the mechanical parts of an audit repeatable and gives `evidence_hash` a concrete shape.
+
+The v1 auditor software must provide:
+
+- **Collection commands** for inventory challenge-response, snapshot hash matching, software identity observation,
+  provider bond lookup, provider age lookup, lease completion stats, snapshot suspension state, and benchmark execution.
+- **Verification commands** that evaluate on-chain prerequisites, inventory consistency, virtualization findings,
+  resource delivery checks, network baseline checks, requested capability flags, and tier eligibility.
+- **Evidence generation** using a canonical schema and deterministic serialization. The resulting evidence document is
+  stored off-chain by the auditor, and its hash is submitted in `MsgSubmitAttestation`.
+- **Submission support** that consumes a provider-funded audit escrow, attaches the evidence hash, pays the auditor's
+  attestation deposit, and submits `MsgSubmitAttestation`.
+- **Revocation support** that reruns the relevant checks during an attestation TTL and submits
+  `MsgRevokeAttestation` with a typed reason and evidence hash when the provider no longer qualifies.
+
+#### Auditor Software Phases
+
+The auditor software has two audit phases in v1:
+
+1. **Attestation baseline phase**: the auditor benchmarks the provider during the initial audit, records the state of
+   the benchmark as the provider's baseline, and includes the benchmark artifact in the evidence document. This
+   baseline is the reference point for the submitted attestation.
+2. **Sustained validation phase**: during the attestation TTL, the auditor reruns the relevant checks and compares the
+   current results to the baseline. If the provider no longer sustains the baseline within tier thresholds, the auditor
+   revokes the attestation or replaces it with a lower-tier attestation using a typed reason and evidence hash.
+
+This phase split is separate from the chain migration phases. The chain stores only the attestation, hashes, escrow
+state, and settlement state. The detailed baseline and sustained-validation artifacts live off-chain and are committed
+through `evidence_hash`.
+
+#### Evidence Document
+
+The evidence document must be schema-versioned and canonical. Free-form notes may exist, but all fields that affect
+tier, capability, fee, deposit, or fault outcomes must be typed.
+
+Canonical v1 schema:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "akash.audit.evidence.v1",
+  "title": "Akash AEP-86 Auditor Evidence",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "chain_id",
+    "provider",
+    "auditor",
+    "audit_escrow_id",
+    "target_tier",
+    "attested_tier",
+    "attested_capabilities",
+    "collected_at",
+    "block_height",
+    "snapshot_hash",
+    "inventory_nonce",
+    "software",
+    "network_baseline",
+    "sustained_validation",
+    "checks",
+    "fault_context"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "akash.audit.evidence.v1"
+    },
+    "chain_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "provider": {
+      "$ref": "#/$defs/akash_address"
+    },
+    "auditor": {
+      "$ref": "#/$defs/akash_address"
+    },
+    "audit_escrow_id": {
+      "$ref": "#/$defs/uint64_string"
+    },
+    "target_tier": {
+      "$ref": "#/$defs/tier"
+    },
+    "attested_tier": {
+      "$ref": "#/$defs/tier"
+    },
+    "attested_capabilities": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/capability"
+      }
+    },
+    "collected_at": {
+      "$ref": "#/$defs/timestamp"
+    },
+    "block_height": {
+      "$ref": "#/$defs/uint64_string"
+    },
+    "snapshot_hash": {
+      "$ref": "#/$defs/sha256"
+    },
+    "inventory_nonce": {
+      "$ref": "#/$defs/base64"
+    },
+    "software": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "binary_hash", "verification_status"],
+      "properties": {
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "binary_hash": {
+          "$ref": "#/$defs/sha256"
+        },
+        "signature": {
+          "$ref": "#/$defs/base64"
+        },
+        "verification_status": {
+          "$ref": "#/$defs/software_verification_status"
+        }
+      }
+    },
+    "network_baseline": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mbps_down", "mbps_up", "latency_ms_p95", "proof_ref"],
+      "properties": {
+        "mbps_down": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "mbps_up": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "latency_ms_p95": {
+          "type": "number",
+          "minimum": 0
+        },
+        "proof_ref": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "sustained_validation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "baseline_id",
+        "window",
+        "last_checked_at",
+        "status",
+        "proof_ref"
+      ],
+      "properties": {
+        "baseline_id": {
+          "$ref": "#/$defs/sha256"
+        },
+        "window": {
+          "type": "string",
+          "enum": ["attestation_ttl"]
+        },
+        "last_checked_at": {
+          "$ref": "#/$defs/timestamp"
+        },
+        "status": {
+          "$ref": "#/$defs/validation_status"
+        },
+        "proof_ref": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "checks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "status", "proof_ref"],
+        "properties": {
+          "name": {
+            "$ref": "#/$defs/check_name"
+          },
+          "status": {
+            "$ref": "#/$defs/check_status"
+          },
+          "proof_ref": {
+            "$ref": "#/$defs/sha256"
+          },
+          "observed_at": {
+            "$ref": "#/$defs/timestamp"
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/$defs/typed_value"
+            }
+          }
+        }
+      }
+    },
+    "fault_context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fault_attribution", "reason"],
+      "properties": {
+        "fault_attribution": {
+          "$ref": "#/$defs/fault_attribution"
+        },
+        "reason": {
+          "$ref": "#/$defs/reason"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "akash_address": {
+      "type": "string",
+      "pattern": "^akash1[0-9a-z]+$"
+    },
+    "uint64_string": {
+      "type": "string",
+      "pattern": "^[0-9]+$"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[A-Fa-f0-9]{64}$"
+    },
+    "base64": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "tier": {
+      "type": "string",
+      "enum": ["L0", "L1", "L2", "L3"]
+    },
+    "capability": {
+      "type": "string",
+      "enum": [
+        "tee_hardware_attestation",
+        "confidential_computing",
+        "persistent_storage",
+        "bare_metal"
+      ]
+    },
+    "software_verification_status": {
+      "type": "string",
+      "enum": [
+        "observed_only",
+        "not_implemented_v1",
+        "unsigned_binary",
+        "not_applicable"
+      ]
+    },
+    "validation_status": {
+      "type": "string",
+      "enum": [
+        "baseline_established",
+        "pass",
+        "fail",
+        "not_applicable",
+        "not_evaluated"
+      ]
+    },
+    "check_status": {
+      "type": "string",
+      "enum": ["pass", "fail", "not_applicable", "not_evaluated"]
+    },
+    "check_name": {
+      "type": "string",
+      "enum": [
+        "provider_registered_on_chain",
+        "provider_bond_sufficient",
+        "provider_age_sufficient",
+        "lease_completion_sufficient",
+        "no_recent_slashing",
+        "snapshot_not_suspended",
+        "snapshot_hash_matches_chain",
+        "inventory_nonce_matches",
+        "inventory_signature_valid",
+        "software_identity_recorded",
+        "resource_delivery_verified",
+        "network_baseline_verified",
+        "location_verified",
+        "identity_verified",
+        "virtualization_status_verified",
+        "capability_verified",
+        "contact_responsiveness_checked",
+        "data_isolation_verified",
+        "physical_audit_verified",
+        "sustained_baseline_checked"
+      ]
+    },
+    "fault_attribution": {
+      "type": "string",
+      "enum": [
+        "unspecified",
+        "provider_fault",
+        "auditor_fault",
+        "shared_fault",
+        "no_fault",
+        "inconclusive"
+      ]
+    },
+    "reason": {
+      "type": "string",
+      "enum": [
+        "unspecified",
+        "provider_no_longer_qualifies",
+        "snapshot_mismatch",
+        "software_identity_changed",
+        "capability_misrepresented",
+        "provider_non_responsive",
+        "auditor_evidence_error",
+        "auditor_operational_exit",
+        "fraudulent_provider",
+        "compromised_provider",
+        "provider_non_cooperation",
+        "faulty_auditor",
+        "negligent_auditor",
+        "evidence_insufficient",
+        "emergency_safety_action",
+        "cancelled_unconsumed",
+        "expired_unconsumed",
+        "auditor_a_correct",
+        "auditor_b_correct",
+        "both_auditors_wrong",
+        "provider_fault",
+        "shared_fault",
+        "evidence_inconclusive",
+        "governance_timeout_review",
+        "resource_misrepresentation",
+        "capacity_overstatement",
+        "fraudulent_snapshot",
+        "provider_compromise",
+        "sla_breach",
+        "non_cooperation_during_audit"
+      ]
+    },
+    "typed_value": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    }
+  }
+}
+```
+
+Benchmark proof references must point to evidence artifacts, such as raw benchmark output, workload identifiers, vantage
+point identifiers, timestamps, and hashes of the workloads used. Numeric measurements without a `proof_ref` are not
+sufficient evidence for Level 2 or above.
+
+The auditor software should be built as a constrained CLI or agent with audit logs. Recommended commands are
+`collect`, `verify`, `evidence`, `submit`, and `revoke`. The implementation guide should treat this as a first-class
+deliverable alongside `x/verification`, not a later tool.
 
 ### Auditor Role
 
@@ -668,9 +1184,9 @@ auditor includes:
 - Maximum attestation tier -- the highest tier this auditor is authorized to attest. An auditor approved for Level 1
   can attest Levels 3, 2, and 1, but not Level 0.
 - Organization name and credentials (metadata hash referencing off-chain documentation)
-- Required bond amount (determined by max attestation tier)
 
-On governance approval, the auditor must post their bond via `MsgPostAuditorBond` to become Active.
+On governance approval, the module derives the required bond from `max_attestation_tier` and the current auditor bond
+parameters. The auditor must post at least that amount via `MsgPostAuditorBond` to become Active.
 
 To upgrade an auditor's maximum attestation tier (e.g., from Level 2 to Level 0), a new governance proposal is required.
 The auditor must post additional bond to cover the difference.
@@ -680,7 +1196,7 @@ The auditor must post additional bond to cover the difference.
 The bond is held in an escrow account and scales with the auditor's maximum attestation authority:
 
 | Max Attestation Authority | Bond Requirement                          |
-|---------------------------|-------------------------------------------|
+| ------------------------- | ----------------------------------------- |
 | Level 3 (Identified)      | `bond_l3` (governance parameter, lowest)  |
 | Level 2 (Verified)        | `bond_l2` > `bond_l3`                     |
 | Level 1 (Established)     | `bond_l1` > `bond_l2`                     |
@@ -690,15 +1206,108 @@ Bond states: `Bonded`, `Frozen`, `Unbonding`.
 
 #### Audit Fee
 
-Providers pay auditors an on-chain fee for performing an audit. The fee is transferred atomically as part of the
-[attestation submission](./README.md#attestation-submission) transaction.
+Providers pay auditors an on-chain fee for performing an audit. The provider does not sign
+`MsgSubmitAttestation`. Instead, the provider pre-funds an audit escrow through a separate provider-signed request, and
+the auditor consumes that escrow when submitting the attestation.
 
 - Governance sets a **minimum fee** per tier level (governance parameter). This prevents race-to-bottom pricing that
   could incentivize cursory evaluations.
-- Above the minimum, fees are market-determined. Auditors set their own rates; providers choose their auditor.
-- Fees are **escrowed** until the attestation reaches its natural TTL expiry. On natural expiry, the escrowed fee is
-  released to the auditor. If the attestation is voided (by discrepancy or governance action), the fee is returned to
-  the provider.
+- Above the minimum, fees are market-determined. Providers choose what fee to offer, and auditors choose which funded
+  requests they are willing to audit.
+- Fees are **escrowed** when the provider opens the audit request. If the request expires unused, the provider reclaims
+  the escrow. Once an auditor consumes the escrow by submitting an attestation, the fee follows the attestation fee
+  lifecycle. If the attestation is voided, fee disposition is determined by typed reason and fault attribution, not by
+  `Voided` status alone.
+
+#### Audit Escrow Flow
+
+The provider opens an audit escrow before the auditor submits an attestation:
+
+```
+MsgOpenAuditEscrow {
+  provider: AccAddress
+  requested_tier: VerificationTier
+  requested_capabilities: []CapabilityFlag
+  fee: Coin
+  provider_deposit: Coin
+  expires_at: Timestamp
+  metadata_hash: bytes
+}
+```
+
+- `provider` is the signer and funds the escrow.
+- No auditor is specified when the escrow is opened. Open audit escrows are a provider-funded pool of requests that any
+  active auditor authorized for the requested tier may consume by submitting a valid attestation.
+- `fee` must be at least the governance minimum for `requested_tier`.
+- `provider_deposit` is a provider-side audit request deposit. It can be zero if governance sets no provider-side
+  deposit for the tier.
+- `expires_at` bounds how long an auditor can consume the escrow. If it expires unused, the provider can reclaim it.
+- `metadata_hash` points to the off-chain commercial audit agreement or request details, if any.
+
+Audit escrow lifecycle is explicit:
+
+| Status      | Meaning                                                         |
+| ----------- | --------------------------------------------------------------- |
+| `Open`      | Funded by the provider and available for any authorized auditor |
+| `Consumed`  | Auditor submitted an attestation that consumed the fee          |
+| `Cancelled` | Escrow was cancelled by the provider before it was consumed     |
+| `Expired`   | Escrow expired unused                                           |
+| `Settled`   | Fee and provider deposit have reached final disposition         |
+
+There is no auditor claim or acceptance transaction in v1. An auditor either submits a valid attestation that consumes
+an open escrow, or the escrow remains open until the provider cancels it or it expires. This avoids giving an auditor a
+cheap way to reserve provider funds without completing the audit.
+
+Audit escrow close and settlement rules:
+
+| Reason                | Allowed signer       | Fee outcome                                              | Provider deposit outcome  |
+| --------------------- | -------------------- | -------------------------------------------------------- | ------------------------- |
+| `CancelledUnconsumed` | Provider             | Returned to provider                                     | Returned to provider      |
+| `ExpiredUnconsumed`   | EndBlocker           | Returned to provider                                     | Returned to provider      |
+| `ProviderFault`       | Governance authority | Returned to provider unless an attestation was submitted | Slashed to community pool |
+| `NoFault`             | Governance authority | Returned to provider                                     | Returned to provider      |
+
+The provider cancellation path is a narrow `MsgCancelAuditEscrow` signed by the provider. It only applies while the
+escrow is `Open` and unconsumed. A governance-only `MsgSettleAuditEscrow` may settle an unconsumed escrow when the
+provider-side deposit is disputed, using `ProviderFault` or `NoFault`. That message must include matching fault
+attribution and an evidence hash. The handler must not infer provider fault from an auditor saying work was started off
+chain.
+
+```
+MsgCancelAuditEscrow {
+  provider: AccAddress
+  audit_escrow_id: uint64
+}
+
+MsgSettleAuditEscrow {
+  authority: AccAddress
+  audit_escrow_id: uint64
+  reason: AuditEscrowSettlementReason
+  fault_attribution: FaultAttribution
+  evidence_hash: bytes
+}
+```
+
+The auditor then submits `MsgSubmitAttestation` with `audit_escrow_id`. The module validates that the escrow is `Open`,
+funded, unexpired, and matches the provider, requested tier, and requested capabilities. The attestation must include at
+least the requested capabilities; extra attested capabilities are allowed. The submitting auditor consumes the escrow
+directly. The audit fee is consumed from the escrow, not debited from the provider account during
+`MsgSubmitAttestation`.
+
+The auditor's anti-griefing attestation deposit remains separate from provider-side escrow. It is paid by the auditor in
+`MsgSubmitAttestation` because it is the auditor's discrepancy liability. Provider-funded deposits and auditor-funded
+attestation deposits have separate status fields and settlement rules.
+
+Provider deposit settlement:
+
+- Returned to the provider when the escrow is cancelled before consumption, expires without being consumed or
+  settled by governance, or settles with `NoFault`.
+- Slashed to the community pool only when governance assigns a typed `ProviderFault` outcome. Examples include the
+  provider blocking the audit, submitting knowingly false materials, or withdrawing after auditor work has begun off
+  chain without cause. V1 does not pay an auditor from an unconsumed escrow unless an attestation was submitted.
+- Returned or slashed by a typed settlement reason. V1 does not introduce a generic open-ended holding state for audit
+  escrow disputes. If fault cannot be assigned, the handler uses the no-fault return path. If funds move away from the
+  original funder, that movement must come from governance with explicit fault attribution.
 
 #### Attestation Submission
 
@@ -706,25 +1315,30 @@ An auditor submits an attestation via `MsgSubmitAttestation`:
 
 - `provider`: provider address being attested
 - `auditor`: auditor address (must be Active, authorized for the attested tier)
+- `audit_escrow_id`: provider-funded audit escrow consumed by this attestation
 - `tier`: the verification tier being attested (must be <= auditor's max attestation tier)
 - `capabilities`: list of [capability flags](./README.md#capability-flags) the auditor has verified for this provider
 - `evidence_hash`: hash of off-chain audit report / evidence documentation
-- `fee`: audit fee amount (must be >= governance minimum for this tier)
+- `fee`: audit fee amount to consume from the audit escrow (must be >= governance minimum for this tier)
+- `deposit`: auditor-funded anti-griefing deposit
 
 On submission, the module:
+
 1. Validates the auditor is Active and authorized for the attested tier
 2. Validates the auditor address differs from the provider address (self-audit prevention)
-3. Validates the fee meets the governance minimum for this tier
-4. Validates [on-chain prerequisites](./README.md#on-chain-prerequisite-enforcement) for the attested tier
-5. Transfers the fee from provider to escrow
-6. If the same auditor has an existing attestation for this provider, the old attestation is replaced and the old
-   escrowed fee is released to the auditor
-7. Stores the new attestation with a TTL based on tier, including the attested capability flags
-8. Adds an entry to the attestation expiry queue for [EndBlocker](./README.md#endblocker-design) processing
-9. Checks for discrepancy: scans all valid attestations for this provider from different auditors. If any existing
-   attestation differs by more than the `discrepancy_threshold` (default: 1 tier level) from the new attestation,
-   triggers [cross-validation](./README.md#cross-validation). Discrepancy detection applies only to the tier
-   component, not capability flags.
+3. Loads and validates the `AuditEscrowRecord` and marks it `Consumed`
+4. Validates the fee meets the governance minimum for this tier and is covered by the audit escrow
+5. Validates the auditor deposit meets the governance minimum
+6. Validates [on-chain prerequisites](./README.md#on-chain-prerequisite-enforcement) for the attested tier
+7. Escrows the fee and auditor deposit under the attestation record
+8. If the same auditor has an existing attestation for this provider, the old attestation is replaced, the old escrowed
+   fee is released to the auditor, the old auditor deposit is returned, and `EventAttestationReplaced` is emitted
+9. Stores the new attestation with a TTL based on tier, including the attested capability flags
+10. Adds an entry to the attestation expiry queue for [EndBlocker](./README.md#endblocker-design) processing
+11. Checks for discrepancy: scans all valid attestations for this provider from different auditors. If any existing
+    attestation differs by more than the `discrepancy_threshold` (default: 1 tier level) from the new attestation,
+    triggers [cross-validation](./README.md#cross-validation). Discrepancy detection applies only to the tier
+    component, not capability flags.
 
 ### On-Chain Prerequisite Enforcement
 
@@ -739,7 +1353,7 @@ network quality, physical location, performance benchmarks, data isolation, etc.
 #### Enforceable Prerequisites by Tier
 
 | Prerequisite                           | Data Source                                                                |    L3    |      L2       |              L1               |                   L0                   |
-|----------------------------------------|----------------------------------------------------------------------------|:--------:|:-------------:|:-----------------------------:|:--------------------------------------:|
+| -------------------------------------- | -------------------------------------------------------------------------- | :------: | :-----------: | :---------------------------: | :------------------------------------: |
 | Provider registered on-chain           | `x/provider` store                                                         | Required |   Required    |           Required            |                Required                |
 | Provider bond posted at tier-minimum   | `x/verification` [provider bond](./README.md#provider-economic-bond) store |    --    |   Required    |           Required            |                Required                |
 | Provider registration age >= threshold | `x/provider` registration timestamp                                        |    --    | `min_age_l2`  |         `min_age_l1`          |              `min_age_l0`              |
@@ -754,9 +1368,11 @@ When [`MsgSubmitAttestation`](./README.md#attestation-submission) is processed, 
 based on the attested tier:
 
 **For all tiers (L3 through L0):**
+
 - Query `x/provider` to confirm the provider is registered on-chain. Reject with `ErrProviderNotRegistered` if not found.
 
 **For Level 2 and above (L2, L1, L0):**
+
 - Query the [provider bond](./README.md#provider-economic-bond) record. Reject with `ErrInsufficientProviderBond` if
   the bonded amount is less than the tier-required minimum (calculated from the provider's `ResourceSummary` and the
   tier's bond-per-resource [governance parameters](./README.md#governance-parameters)).
@@ -766,6 +1382,7 @@ based on the attested tier:
   the age is less than the tier's `min_age` parameter.
 
 **For Level 1 and above (L1, L0):**
+
 - Query `x/market` for the provider's lease completion stats over the lookback window. If the provider has at least
   `min_leases_for_completion_rate` total leases in the window, compute the completion rate as
   `completed_leases / total_leases * 10000` (basis points). Reject with `ErrInsufficientLeaseCompletion` if below
@@ -775,6 +1392,7 @@ based on the attested tier:
   the tier's `clean_history_window`.
 
 **For Level 0 only:**
+
 - Scan the provider's attestation history to verify that the provider has had a continuous valid attestation at Level 1
   or better for at least `min_l1_duration_for_l0`. "Continuous" means there exists at least one valid L1+ attestation
   at all times during the lookback period, considering attestation creation and expiry timestamps. Reject with
@@ -794,6 +1412,7 @@ MarketKeeper (from x/market):
 ```
 
 `LeaseStats`:
+
 ```
 LeaseStats {
   total_leases: uint64
@@ -811,43 +1430,162 @@ completion rate is calculated as: `(total_leases - terminated_by_provider) / tot
 Attestations expire automatically. Higher tiers require more frequent re-audit:
 
 | Tier    | TTL                                                 |
-|---------|-----------------------------------------------------|
+| ------- | --------------------------------------------------- |
 | Level 3 | Longest (governance parameter, e.g., 365 days)      |
 | Level 2 | Shorter (governance parameter, e.g., 180 days)      |
 | Level 1 | Shorter still (governance parameter, e.g., 90 days) |
 | Level 0 | Shortest (governance parameter, e.g., 90 days)      |
 
-On expiry, the attestation status becomes `Expired`, the escrowed fee is released to the auditor, and the attestation
-is no longer considered valid. Expiry is processed by the [EndBlocker](./README.md#endblocker-design) via the
-attestation expiry queue.
+On expiry, the attestation status becomes `Expired`, the escrowed fee is released to the auditor, the auditor deposit is
+returned, and the attestation is no longer considered valid. Expiry is processed by the
+[EndBlocker](./README.md#endblocker-design) via the attestation expiry queue.
 
 #### Attestation Revocation
 
 An auditor may revoke their own attestation at any time via `MsgRevokeAttestation`. This immediately voids the
-attestation. The escrowed fee is released to the auditor (the auditor performed the work; revocation is an act of
-diligence, not a failure).
+attestation. When the reason is provider-side or no-fault, the escrowed fee is released to the auditor because the
+auditor performed the work and revocation is an act of diligence. When the auditor revokes because their own evidence
+or process was wrong, the fee is returned to the provider.
+
+```
+MsgRevokeAttestation {
+  provider: AccAddress
+  auditor: AccAddress
+  reason: AttestationRevocationReason
+  evidence_hash: bytes
+}
+```
+
+`MsgRevokeAttestation` must include a typed revocation reason and a revocation evidence hash. This keeps ongoing
+monitoring auditable and prevents "silent" tier drops that have no machine-readable explanation.
+
+V1 revocation settlement is deterministic:
+
+| Reason                      | Fault attribution          | Fee outcome          | Auditor deposit outcome |
+| --------------------------- | -------------------------- | -------------------- | ----------------------- |
+| `ProviderNoLongerQualifies` | Provider fault or no fault | Released to auditor  | Returned to auditor     |
+| `SnapshotMismatch`          | Provider fault or no fault | Released to auditor  | Returned to auditor     |
+| `SoftwareIdentityChanged`   | Provider fault or no fault | Released to auditor  | Returned to auditor     |
+| `CapabilityMisrepresented`  | Provider fault or no fault | Released to auditor  | Returned to auditor     |
+| `ProviderNonResponsive`     | Provider fault or no fault | Released to auditor  | Returned to auditor     |
+| `AuditorEvidenceError`      | Auditor fault              | Returned to provider | Slashed                 |
+| `AuditorOperationalExit`    | No fault                   | Returned to provider | Returned to auditor     |
 
 A provider may remove any attestation on themselves via `MsgRemoveAttestation`. The escrowed fee is released to the
-auditor (the auditor performed the work; the provider chose to remove the attestation).
+auditor and the auditor deposit is returned (the auditor performed the work; the provider chose to remove the
+attestation).
+
+### Typed Reasons and Fault Attribution
+
+Free-form `reason: string` is not used for settlement or slashing decisions. Messages may include an optional notes
+field for human context, but state transitions, fee release, deposit return, and slashing must use typed enums.
+
+```
+FaultAttribution =
+  Unspecified
+  ProviderFault
+  AuditorFault
+  SharedFault
+  NoFault
+  Inconclusive
+
+AttestationRevocationReason =
+  Unspecified
+  ProviderNoLongerQualifies
+  SnapshotMismatch
+  SoftwareIdentityChanged
+  CapabilityMisrepresented
+  ProviderNonResponsive
+  AuditorEvidenceError
+  AuditorOperationalExit
+
+GovernanceAttestationReason =
+  Unspecified
+  FraudulentProvider
+  CompromisedProvider
+  ProviderNonCooperation
+  FaultyAuditor
+  NegligentAuditor
+  EvidenceInsufficient
+  EmergencySafetyAction
+
+AuditEscrowSettlementReason =
+  Unspecified
+  CancelledUnconsumed
+  ExpiredUnconsumed
+  ProviderFault
+  NoFault
+
+DiscrepancyResolutionReason =
+  Unspecified
+  AuditorACorrect
+  AuditorBCorrect
+  BothAuditorsWrong
+  ProviderFault
+  SharedFault
+  EvidenceInconclusive
+  GovernanceTimeoutReview
+
+ProviderBondSlashReason =
+  Unspecified
+  ResourceMisrepresentation
+  CapacityOverstatement
+  FraudulentSnapshot
+  ProviderCompromise
+  SLABreach
+  NonCooperationDuringAudit
+```
+
+Reason enums answer "what happened." `FaultAttribution` answers "who should bear the economic outcome." Both are
+required when a governance action can move fees, deposits, or bonds. The settlement helper rejects any action that uses
+`Unspecified` or leaves `FaultAttribution` ambiguous when funds would otherwise be released or slashed.
 
 #### Fee Disposition Summary
 
-The audit fee is released to the auditor in all cases where the attestation reaches a terminal state normally. It
-is returned to the provider only when the attestation is voided, indicating the attestation itself was invalid.
-The auditor performed evaluation work regardless of who initiates termination; returning the fee on provider-initiated
-removal would create a perverse incentive (providers could obtain free audits by removing attestations before TTL
-expiry).
+The audit fee is released to the auditor in all cases where the attestation reaches a terminal state normally. Voided
+attestations use typed fault attribution. The handler must not treat `Voided` as an automatic provider refund.
 
-| Terminal Status | Triggered By | Fee Goes To | Rationale |
-|---|---|---|---|
-| `Expired` | TTL reached (EndBlocker) | Auditor | Auditor performed work; attestation ran its full course |
-| `Revoked` | Auditor via `MsgRevokeAttestation` | Auditor | Auditor performed diligent monitoring |
-| `Removed` | Provider via `MsgRemoveAttestation` | Auditor | Auditor performed work; provider voluntarily removed |
-| `Voided` (Discrepancy) | Cross-validation trigger | Provider | Auditor judgment was disputed |
-| `Voided` (Governance) | Governance action | Provider | Governance determined the attestation was invalid |
-| `Voided` (BondWithdrawn) | Provider bond withdrawal | Provider | Provider chose to withdraw bond support |
-| `Voided` (BondSlashed) | Provider bond slashed | Provider | Provider's misrepresentation caused the void |
-| Replaced | Same auditor submits new attestation | Auditor (old fee) | Auditor performed work on prior evaluation |
+Required inputs for fee and deposit settlement:
+
+- `terminal_status`: expired, revoked, removed, or voided
+- `terminal_transition`: replacement or pending discrepancy, when applicable
+- `voided_reason`: discrepancy, governance action, bond withdrawn, or bond slashed
+- `typed_reason`: the action-specific reason enum
+- `fault_attribution`: provider fault, auditor fault, shared fault, no fault, or inconclusive
+- `elapsed_ttl`: optional input for prorated fee release if governance enables proration later
+
+Default v1 disposition:
+
+| Terminal Status                 | Triggered By                         | Fault Attribution                            | Fee Goes To                                  | Deposit Outcome                                          |
+| ------------------------------- | ------------------------------------ | -------------------------------------------- | -------------------------------------------- | -------------------------------------------------------- |
+| `Expired`                       | TTL reached (EndBlocker)             | No fault                                     | Auditor                                      | Auditor deposit returned                                 |
+| `Revoked`                       | Auditor via `MsgRevokeAttestation`   | Provider fault or no fault monitoring reason | Auditor                                      | Auditor deposit returned                                 |
+| `Revoked`                       | Auditor via `MsgRevokeAttestation`   | `AuditorEvidenceError`                       | Provider                                     | Auditor deposit slashed                                  |
+| `Revoked`                       | Auditor via `MsgRevokeAttestation`   | `AuditorOperationalExit`                     | Provider                                     | Auditor deposit returned                                 |
+| `Removed`                       | Provider via `MsgRemoveAttestation`  | No fault                                     | Auditor                                      | Auditor deposit returned                                 |
+| `Voided` (Pending discrepancy)  | Cross-validation trigger             | Unknown                                      | Remains escrowed until resolution or timeout | Auditor deposits marked `PendingDiscrepancy`             |
+| `Voided` (Discrepancy resolved) | Governance resolution                | Auditor fault                                | Provider for faulty attestation              | Faulty auditor deposit slashed                           |
+| `Voided` (Discrepancy resolved) | Governance resolution                | Provider fault or no fault for auditor       | Auditor for vindicated work                  | Vindicated auditor deposit returned                      |
+| `Voided` (Discrepancy resolved) | Governance resolution                | Shared fault                                 | Provider                                     | Auditor deposit slashed                                  |
+| `Voided` (Governance)           | Governance action                    | Provider fault                               | Auditor                                      | Auditor deposit returned                                 |
+| `Voided` (Governance)           | Governance action                    | No fault                                     | Auditor                                      | Auditor deposit returned                                 |
+| `Voided` (Governance)           | Governance action                    | Auditor fault                                | Provider                                     | Auditor deposit slashed if the action names that auditor |
+| `Voided` (Governance)           | Governance action                    | Shared fault                                 | Provider                                     | Auditor deposit slashed if the action names that auditor |
+| `Voided` (BondWithdrawn)        | Provider bond withdrawal             | Provider fault by default                    | Auditor                                      | Auditor deposit returned                                 |
+| `Voided` (BondSlashed)          | Provider bond slashed                | Provider fault                               | Auditor                                      | Auditor deposit returned                                 |
+| Replacement transition          | Same auditor submits new attestation | No fault                                     | Auditor for old fee                          | Old auditor deposit returned                             |
+
+The settlement helper must update both `fee_status` and `deposit_status` and emit events for each transfer or slash.
+`Inconclusive` can be recorded for governance context, but v1 fund settlement requires a concrete fault attribution or
+a deterministic timeout rule.
+
+V1 does not persist separate `Disputed` or `Replaced` attestation statuses. A disputed attestation is represented as
+`status = Voided`, `voided_reason = Discrepancy`, and a pending `DiscrepancyEvent`. A replacement is represented as an
+immediate settlement transition emitted as `EventAttestationReplaced`, then the `(provider, auditor)` attestation record
+is overwritten by the new valid attestation.
+
+For v1, `SharedFault` uses the auditor-fault fee path for the attestation fee. Provider-side punishment happens through
+provider bond slashing or provider audit deposit settlement, not by adding a new fee-splitting status.
 
 ### Cross-Validation
 
@@ -857,17 +1595,22 @@ the cross-validation rule triggers:
 
 1. **Both conflicting attestations are voided** (status: `Voided`, reason: `Discrepancy`)
 2. **Both auditors' bonds are frozen** (cannot unbond, cannot issue new attestations until resolved)
-3. **Escrowed fees for both voided attestations are returned to the provider**
-4. **Provider falls back** to any remaining valid attestations from other auditors. If none remain, the provider is
-   effectively Level 4 (Permissionless).
+3. **Escrowed fees remain escrowed and auditor deposits become `PendingDiscrepancy`**, so neither party gets an
+   immediate payout before fault is known
+4. **Provider receives a bounded discrepancy grace period** if no provider fault is known yet. During the grace period,
+   bid filtering may use the provider's pre-discrepancy effective tier so a provider is not immediately dropped to L4
+   for an auditor conflict they may not have caused.
 5. A `DiscrepancyEvent` is emitted on-chain recording both auditor addresses, both tier claims, the provider, and
    a timestamp.
 
 Resolution requires a [governance proposal](./README.md#resolvediscrepancy) that determines:
+
 - Which auditor (if either) was correct
 - Whether to slash either or both auditor bonds
 - Whether to remove either or both from the approved auditor set
 - Unfreezing bonds of the vindicated auditor(s)
+- Fault attribution for fee and deposit settlement
+- Whether any discrepancy grace record should end immediately
 
 The discrepancy rule always triggers regardless of the temporal distance between the two attestations. If an old
 attestation is stale, it should have expired via its TTL.
@@ -883,6 +1626,35 @@ attestation from a different auditor conflicts with one of the frozen auditor's 
 new discrepancy is created normally. The already-frozen auditor gains an additional discrepancy count. Both
 discrepancies must be resolved before the frozen auditor can become Active again.
 
+#### Discrepancy Grace Period
+
+Cross-validation starts from an unknown fault state. The chain knows two auditors disagree, but it does not yet know
+whether the provider, one auditor, both auditors, or neither party caused the conflict. To avoid immediately punishing
+a provider for a conflict they may not have caused, the module creates a `ProviderVerificationGraceRecord` when a
+discrepancy voids the provider's currently effective tier.
+
+```
+ProviderVerificationGraceRecord {
+  provider: AccAddress
+  preserved_tier: VerificationTier
+  source_discrepancy_ids: []uint64
+  started_at: Timestamp
+  expires_at: Timestamp
+  status: Active | Expired | Terminated
+}
+```
+
+During an active grace period:
+
+- `x/market` uses `preserved_tier` for tier bid filtering when `verification_module_active == true` and an order has a
+  `VerificationRequirement`.
+- Snapshot suspension, provider bond insufficiency, or provider bond slashing terminates the grace period immediately.
+- Capability requirements still require valid capability attestations. The grace record preserves tier only.
+- The provider should seek a replacement attestation before `expires_at`.
+
+The grace period is bounded by the `discrepancy_grace_period` governance parameter. Governance resolution can terminate
+the grace period early if the provider is at fault, or let it expire naturally if the discrepancy is auditor-side.
+
 #### Discrepancy Auto-Resolution Timeout
 
 If a discrepancy event remains in `Pending` status for longer than `discrepancy_resolution_timeout` (governance
@@ -890,11 +1662,14 @@ parameter), the [EndBlocker](./README.md#endblocker-design) automatically resolv
 
 1. Discrepancy status becomes `TimedOut`
 2. Both attestations remain voided (they are not reinstated)
-3. Both auditors' bonds are unfrozen (no slash applied)
-4. A `EventDiscrepancyTimedOut` event is emitted
+3. Escrowed fees are returned to the provider
+4. Both auditor deposits for the conflicting attestations are slashed to the community pool
+5. Auditor bonds are unfrozen for this discrepancy if the auditor has no other pending discrepancies
+6. A `EventDiscrepancyTimedOut` event is emitted
 
-This prevents indefinite bond freezing when governance is slow to act. The voided attestations are not reinstated --
-both auditors must re-evaluate the provider and submit new attestations if they wish.
+The timeout is not a finding that either auditor was correct. It is a simple v1 safety default: stale disputes do not
+restore voided attestations, do not pay either auditor, and do not return anti-griefing deposits. Governance can avoid
+that blunt outcome by resolving the discrepancy before timeout.
 
 #### Attestation Deposit (Anti-Griefing)
 
@@ -902,19 +1677,35 @@ To raise the economic cost of triggering frivolous discrepancies, auditors must 
 each attestation submission. The deposit is separate from the audit fee.
 
 - **Deposit amount**: `attestation_deposit` (governance parameter), applied uniformly across all tiers.
-- **Normal flow**: the deposit is returned to the auditor when the attestation reaches any terminal state
-  (Expired, Revoked, Removed, or replaced by a new attestation from the same auditor).
+- **Normal flow**: the deposit is returned to the auditor when the attestation expires, is removed by the provider, is
+  replaced by a new attestation from the same auditor, or is revoked for a provider-side or no-fault reason.
+- **Auditor-fault flow**: the deposit is slashed when a typed auditor-fault revocation or governance action says the
+  auditor's evidence or process was wrong.
 - **Discrepancy flow**: when a discrepancy is triggered, both auditors' deposits for the conflicting attestations
-  are locked. On resolution, the non-vindicated auditor's deposit is slashed (sent to community pool). The
-  vindicated auditor's deposit is returned. On auto-resolution timeout, both deposits are returned.
+  become `PendingDiscrepancy`. On resolution, the non-vindicated auditor's deposit is slashed (sent to community pool).
+  The vindicated auditor's deposit is returned. On auto-resolution timeout, both deposits are slashed to the community
+  pool.
 - The deposit is included in `MsgSubmitAttestation` as an additional `deposit` field. The module validates
   the deposit meets the governance minimum.
+
+Deposit lifecycle is explicit:
+
+| Status               | Meaning                                        |
+| -------------------- | ---------------------------------------------- |
+| `Escrowed`           | Deposit is active for a valid attestation      |
+| `PendingDiscrepancy` | Deposit is held while a discrepancy is pending |
+| `ReturnedToAuditor`  | Deposit has been returned to the auditor       |
+| `Slashed`            | Deposit has been sent to the community pool    |
+
+The escrow invariant counts deposits by `deposit_status`, not attestation validity. A voided attestation can still have
+escrowed or pending-discrepancy funds.
 
 ### Auditor Lifecycle
 
 #### Active Operation
 
 An Active auditor may:
+
 - Submit attestations for any provider (within their max attestation tier)
 - Revoke their own attestations
 - Receive escrowed fees on attestation expiry
@@ -922,6 +1713,7 @@ An Active auditor may:
 #### Frozen
 
 An auditor whose bond is frozen (due to a discrepancy event) may not:
+
 - Submit new attestations
 - Unbond
 
@@ -931,6 +1723,7 @@ voided attestation until governance resolves the discrepancy and unfreezes their
 #### Resignation
 
 An auditor may voluntarily resign via `MsgResignAuditor`:
+
 - Status becomes `Resigned` -- cannot issue new attestations
 - Existing attestations remain valid until their natural TTL expiry
 - Bond enters unbonding after all outstanding attestation escrows have resolved (expired, voided, or superseded)
@@ -942,7 +1735,7 @@ Governance must periodically re-approve every auditor. This is the same process 
 auditor's maximum attestation authority: higher authority requires more frequent re-validation.
 
 | Max Attestation Authority | Renewal Period                                                       |
-|---------------------------|----------------------------------------------------------------------|
+| ------------------------- | -------------------------------------------------------------------- |
 | Level 3 (Identified)      | `renewal_period_l3` (governance parameter, longest, e.g., 24 months) |
 | Level 2 (Verified)        | `renewal_period_l2` (governance parameter, e.g., 18 months)          |
 | Level 1 (Established)     | `renewal_period_l1` (governance parameter, e.g., 12 months)          |
@@ -952,6 +1745,7 @@ On successful renewal (governance proposal passes), the auditor's `renewal_deadl
 the applicable renewal period.
 
 If the renewal deadline passes without a successful governance proposal:
+
 - Auditor status becomes `Lapsed` -- cannot issue new attestations
 - Existing attestations remain valid until their natural TTL expiry (providers are not disrupted)
 - Bond enters unbonding
@@ -963,6 +1757,7 @@ renewal period to prepare the governance proposal.
 #### Lapsed
 
 An auditor whose renewal deadline has passed without re-approval:
+
 - Cannot issue new attestations
 - Existing non-expired attestations remain valid until their TTL expiry
 - Bond enters unbonding
@@ -971,6 +1766,7 @@ An auditor whose renewal deadline has passed without re-approval:
 #### Removal by Governance
 
 Governance may remove an auditor via a [`RemoveAuditor`](./README.md#removeauditor) proposal:
+
 - Status becomes `Removed` -- cannot issue new attestations
 - Existing attestations remain valid until their natural TTL expiry (providers are not immediately disrupted)
 - Bond enters unbonding (governance-configurable duration)
@@ -983,8 +1779,9 @@ the `authority` field set to the governance module address and are submitted via
 
 #### RegisterAuditor
 
-Adds a new auditor to the approved set. Includes auditor address, max attestation tier, organization metadata, and
-required bond amount. On approval, the auditor must post their [bond](./README.md#auditor-bond) to become Active.
+Adds a new auditor to the approved set. Includes auditor address, max attestation tier, and organization metadata. On
+approval, the module derives the required bond from the max attestation tier and current params. The auditor must post
+their [bond](./README.md#auditor-bond) to become Active.
 Sets the initial `renewal_deadline` to the current time plus the applicable
 [renewal period](./README.md#renewal).
 
@@ -1007,14 +1804,18 @@ RevokeProviderAttestation {
   authority: AccAddress
   provider: AccAddress
   auditor: AccAddress
-  reason: string
+  reason: GovernanceAttestationReason
+  fault_attribution: FaultAttribution
+  evidence_hash: bytes
 }
 ```
 
 Effect:
+
 - The specific attestation (provider + auditor pair) is voided (status: `Voided`, reason: `GovernanceAction`)
-- Escrowed fee returned to provider
-- No automatic action against the auditor
+- Escrowed fee and auditor deposit are settled according to
+  [Fee Disposition Summary](./README.md#fee-disposition-summary)
+- No automatic auditor status or bond action
 
 #### RevokeAllProviderAttestations
 
@@ -1025,15 +1826,24 @@ fraudulent or compromised.
 RevokeAllProviderAttestations {
   authority: AccAddress
   provider: AccAddress
-  reason: string
+  reason: GovernanceAttestationReason
+  fault_attribution: FaultAttribution
+  evidence_hash: bytes
 }
 ```
 
 Effect:
+
 - All valid attestations on this provider are voided (status: `Voided`, reason: `GovernanceAction`)
-- All escrowed fees for those attestations returned to provider
+- Escrowed fees and deposits are settled according to `fault_attribution`
 - Provider is effectively Level 4 (Permissionless)
 - No automatic action against any of the auditors involved
+
+When `fault_attribution` is `ProviderFault`, the auditors are paid for completed work and auditor deposits are returned.
+`RevokeAllProviderAttestations` should not be used for a single faulty auditor because it does not name one auditor as
+the target. For auditor-side fault on one provider, use `RevokeProviderAttestation`. For auditor-side fault across many
+providers, use `RevokeAuditorAttestations`. `Inconclusive` is not a fund-settlement outcome for v1. Governance must use
+a concrete fault attribution before this proposal moves fees or deposits.
 
 #### RevokeAuditorAttestations
 
@@ -1044,13 +1854,17 @@ to have been issuing fraudulent or negligent attestations.
 RevokeAuditorAttestations {
   authority: AccAddress
   auditor: AccAddress
-  reason: string
+  reason: GovernanceAttestationReason
+  fault_attribution: FaultAttribution
+  evidence_hash: bytes
 }
 ```
 
 Effect:
+
 - All valid attestations issued by this auditor (across all providers) are voided (status: `Voided`, reason: `GovernanceAction`)
-- All escrowed fees for those attestations returned to the respective providers
+- Escrowed fees are returned to the respective providers when `fault_attribution` is `AuditorFault`
+- Auditor attestation deposits for the voided attestations are slashed when `fault_attribution` is `AuditorFault`
 - **Auditor bond is fully slashed**
 - Auditor status is not automatically changed to `Removed` -- this proposal can be combined with a separate
   [`RemoveAuditor`](./README.md#removeauditor) proposal if governance also wants to formally remove them. However,
@@ -1061,7 +1875,8 @@ necessarily preventing future work (though the full bond slash makes continuatio
 
 #### ResolveDiscrepancy
 
-Resolves a pending [discrepancy event](./README.md#cross-validation) triggered by the cross-validation rule.
+Resolves a pending or timed-out [discrepancy event](./README.md#cross-validation) triggered by the cross-validation
+rule.
 
 ```
 ResolveDiscrepancy {
@@ -1070,15 +1885,22 @@ ResolveDiscrepancy {
   vindicated_auditor: AccAddress (empty if neither vindicated)
   slash_auditor_a: bool
   slash_auditor_b: bool
-  reason: string
+  reason: DiscrepancyResolutionReason
+  fault_attribution: FaultAttribution
+  evidence_hash: bytes
 }
 ```
 
 Effect:
+
 - Discrepancy event status becomes `Resolved`
 - Vindicated auditor's bond is unfrozen (only if all their discrepancies are resolved)
 - Non-vindicated auditor's bond is slashed (fully) if the corresponding slash flag is set
-- Both auditors' statuses are updated accordingly (unfrozen for vindicated, unchanged, or removed for non-vindicated)
+- Auditor bond states are updated accordingly. Auditor removal requires a separate `RemoveAuditor` governance action.
+- Escrowed fees and pending-discrepancy deposits are settled according to `fault_attribution`
+- `resolution_reason`, `fault_attribution`, and `resolution_evidence_hash` are stored on the `DiscrepancyEvent`
+- If the discrepancy already timed out, fees and deposits have already followed the timeout rule. The late governance
+  action can still settle bond slashing, auditor status, and the final reason record.
 
 #### SlashProviderBond
 
@@ -1090,16 +1912,20 @@ SlashProviderBond {
   authority: AccAddress
   provider: AccAddress
   slash_fraction: Dec (0.0 to 1.0)
-  reason: string
+  reason: ProviderBondSlashReason
+  evidence_hash: bytes
 }
 ```
 
 Effect:
+
 - Provider's `bonded_amount` is reduced by `bonded_amount * slash_fraction`
 - Slashed tokens are sent to the community pool
 - Provider's `slashed` flag is set, `last_slash_time` is recorded
 - If remaining bond falls below the minimum required by any active attestation tier, those attestations are voided
   (status: `Voided`, reason: `BondSlashed`)
+- Fees for attestations voided by a provider bond slash are released to auditors by default because the fault is
+  provider-side
 - An `EventProviderBondSlashed` event is emitted
 
 #### UpdateParams
@@ -1116,7 +1942,7 @@ UpdateParams {
 #### Governance Proposal Summary
 
 | Proposal                                                                     | Target             | Attestation Effect               | Bond Effect              | Auditor Status Effect                |
-|------------------------------------------------------------------------------|--------------------|----------------------------------|--------------------------|--------------------------------------|
+| ---------------------------------------------------------------------------- | ------------------ | -------------------------------- | ------------------------ | ------------------------------------ |
 | [`RegisterAuditor`](./README.md#registerauditor)                             | Auditor            | --                               | Requires posting         | Creates `Active` auditor             |
 | [`RenewAuditor`](./README.md#renewauditor)                                   | Auditor            | --                               | Must remain posted       | Resets renewal deadline              |
 | [`RemoveAuditor`](./README.md#removeauditor)                                 | Auditor            | Existing valid until TTL         | Enters unbonding         | `Removed`                            |
@@ -1150,12 +1976,12 @@ required_bond = sum(
 Each `bond_per_*[tier]` is a [governance parameter](./README.md#governance-parameters). Higher tiers require higher
 per-unit bonds:
 
-| Resource | L2 (Verified) | L1 (Established) | L0 (Trusted) |
-|---|---|---|---|
-| Per GPU | `bond_gpu_l2` | `bond_gpu_l1` (>= 2x L2) | `bond_gpu_l0` (>= 4x L2) |
-| Per vCPU | `bond_vcpu_l2` | `bond_vcpu_l1` | `bond_vcpu_l0` |
-| Per GB memory | `bond_mem_gb_l2` | `bond_mem_gb_l1` | `bond_mem_gb_l0` |
-| Per TB storage | `bond_storage_tb_l2` | `bond_storage_tb_l1` | `bond_storage_tb_l0` |
+| Resource       | L2 (Verified)        | L1 (Established)         | L0 (Trusted)             |
+| -------------- | -------------------- | ------------------------ | ------------------------ |
+| Per GPU        | `bond_gpu_l2`        | `bond_gpu_l1` (>= 2x L2) | `bond_gpu_l0` (>= 4x L2) |
+| Per vCPU       | `bond_vcpu_l2`       | `bond_vcpu_l1`           | `bond_vcpu_l0`           |
+| Per GB memory  | `bond_mem_gb_l2`     | `bond_mem_gb_l1`         | `bond_mem_gb_l0`         |
+| Per TB storage | `bond_storage_tb_l2` | `bond_storage_tb_l1`     | `bond_storage_tb_l0`     |
 
 #### Bond Messages
 
@@ -1169,6 +1995,7 @@ MsgPostProviderBond {
 ```
 
 On submission:
+
 1. Validate the provider is registered on-chain
 2. Transfer AKT from provider to the module's bond escrow account
 3. Update the provider's [`ProviderBondRecord`](./README.md#provider-bond-record) (add to `bonded_amount`)
@@ -1185,11 +2012,12 @@ MsgWithdrawProviderBond {
 ```
 
 On submission:
+
 1. Validate the requested amount does not exceed the current bonded amount
 2. Calculate the remaining bond after withdrawal: `remaining = bonded_amount - amount`
 3. If the remaining bond is less than the minimum required by the provider's highest active attestation tier,
    void all attestations at tiers that can no longer be supported (status: `Voided`, reason: `BondWithdrawn`),
-   and return their escrowed fees to the provider
+   and settle their fees as `ProviderFault` by default
 4. Reduce `bonded_amount` by the withdrawal amount
 5. Add an `UnbondingEntry` with `completion_time = block_time + provider_bond_unbonding_period`
 6. Add an entry to the provider bond unbonding queue for [EndBlocker](./README.md#endblocker-design) processing
@@ -1219,6 +2047,7 @@ AuditorRecord {
   max_attestation_tier: VerificationTier (TierTrusted through TierIdentified)
   bond_amount: Coin
   bond_status: Bonded | Frozen | Unbonding
+  bond_unbonding_completion_time: Timestamp (nullable)
   metadata_hash: bytes
   registered_at: Timestamp
   renewal_deadline: Timestamp
@@ -1236,15 +2065,42 @@ AuditorRecord {
 AttestationRecord {
   provider: AccAddress
   auditor: AccAddress
+  audit_escrow_id: uint64
   tier: VerificationTier (TierTrusted through TierIdentified)
   capabilities: []CapabilityFlag
   evidence_hash: bytes
   fee: Coin
   fee_status: Escrowed | ReleasedToAuditor | ReturnedToProvider
+  deposit: Coin
+  deposit_status: Escrowed | PendingDiscrepancy | ReturnedToAuditor | Slashed
   created_at: Timestamp
   expires_at: Timestamp
   status: Valid | Voided | Expired | Revoked | Removed
   voided_reason: null | Discrepancy | Governance | BondWithdrawn | BondSlashed
+  fault_attribution: FaultAttribution
+}
+```
+
+#### Audit Escrow Record
+
+```
+AuditEscrowRecord {
+  id: uint64
+  provider: AccAddress
+  consumed_by_auditor: AccAddress (empty until consumed)
+  requested_tier: VerificationTier
+  requested_capabilities: []CapabilityFlag
+  fee: Coin
+  fee_status: Escrowed | ReleasedToAuditor | ReturnedToProvider
+  provider_deposit: Coin
+  provider_deposit_status: Escrowed | ReturnedToProvider | Slashed
+  status: Open | Consumed | Cancelled | Expired | Settled
+  opened_at: Timestamp
+  consumed_at: Timestamp (nullable)
+  expires_at: Timestamp
+  metadata_hash: bytes
+  settlement_reason: AuditEscrowSettlementReason
+  fault_attribution: FaultAttribution
 }
 ```
 
@@ -1259,8 +2115,26 @@ DiscrepancyEvent {
   auditor_b: AccAddress
   auditor_b_tier: uint
   timestamp: Timestamp
-  resolution_status: Pending | Resolved
+  resolution_status: Pending | Resolved | TimedOut
   resolution_proposal_id: uint64 (nullable)
+  grace_record_id: uint64 (nullable)
+  resolution_reason: DiscrepancyResolutionReason
+  fault_attribution: FaultAttribution
+  resolution_evidence_hash: bytes
+}
+```
+
+#### Provider Verification Grace Record
+
+```
+ProviderVerificationGraceRecord {
+  id: uint64
+  provider: AccAddress
+  preserved_tier: VerificationTier
+  source_discrepancy_ids: []uint64
+  started_at: Timestamp
+  expires_at: Timestamp
+  status: Active | Expired | Terminated
 }
 ```
 
@@ -1305,12 +2179,32 @@ ResourceSummary {
 }
 ```
 
+#### Provider Maintenance Record
+
+Stored in `x/provider`, not `x/verification`.
+
+```
+ProviderMaintenanceRecord {
+  id: uint64
+  provider: AccAddress
+  maintenance_type: Planned | Emergency | Security | Network | Capacity
+  starts_at: Timestamp
+  expected_ends_at: Timestamp
+  opened_at: Timestamp
+  closed_at: Timestamp (nullable)
+  metadata_hash: bytes
+}
+```
+
+`Scheduled`, `Active`, `Elapsed`, and `Closed` are derived from the record fields and block time. See
+[Provider Maintenance Notices](./README.md#provider-maintenance-notices).
+
 ### Governance Parameters
 
 See [Initial Governance Parameter Values](./README.md#initial-governance-parameter-values) for suggested genesis values.
 
 | Parameter                                                          | Description                                                                                                         |
-|--------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
 | `bond_l3`                                                          | Minimum auditor bond for Level 3 attestation authority                                                              |
 | `bond_l2`                                                          | Minimum auditor bond for Level 2 attestation authority                                                              |
 | `bond_l1`                                                          | Minimum auditor bond for Level 1 attestation authority                                                              |
@@ -1349,70 +2243,82 @@ See [Initial Governance Parameter Values](./README.md#initial-governance-paramet
 | `contact_response_critical_l2`                                     | Maximum response time for critical incidents at Level 2                                                             |
 | `contact_response_critical_l1`                                     | Maximum response time for critical incidents at Level 1                                                             |
 | `contact_response_critical_l0`                                     | Maximum response time for critical incidents at Level 0                                                             |
-| `contact_response_standard_l3`                                     | Maximum response time for standard inquiries at Level 3                                                             |
-| `contact_response_standard_l2`                                     | Maximum response time for standard inquiries at Level 2                                                             |
-| `contact_response_standard_l1`                                     | Maximum response time for standard inquiries at Level 1                                                             |
-| `contact_response_standard_l0`                                     | Maximum response time for standard inquiries at Level 0                                                             |
+| `contact_response_standard_l3`                                     | Maximum response time for standard provider-controlled operational inquiries at Level 3                             |
+| `contact_response_standard_l2`                                     | Maximum response time for standard provider-controlled operational inquiries at Level 2                             |
+| `contact_response_standard_l1`                                     | Maximum response time for standard provider-controlled operational inquiries at Level 1                             |
+| `contact_response_standard_l0`                                     | Maximum response time for standard provider-controlled operational inquiries at Level 0                             |
+| `provider_maintenance_max_duration`                                | Maximum length of one provider maintenance window in `x/provider`                                                   |
+| `provider_maintenance_max_lookahead`                               | Maximum time in the future a provider can schedule a maintenance window in `x/provider`                             |
 | `max_endblocker_attestation_expiries`                              | Maximum attestation expiries processed per block by [EndBlocker](./README.md#endblocker-design)                     |
 | `max_endblocker_snapshot_suspensions`                              | Maximum snapshot suspensions processed per block                                                                    |
 | `max_endblocker_unbonding_completions`                             | Maximum bond unbonding completions processed per block                                                              |
 | `max_endblocker_discrepancy_timeouts`                              | Maximum discrepancy auto-resolutions processed per block                                                            |
+| `max_endblocker_audit_escrow_expiries`                             | Maximum audit escrow expiries processed per block                                                                   |
+| `max_endblocker_grace_expiries`                                    | Maximum discrepancy grace expiries processed per block                                                              |
 | `discrepancy_resolution_timeout`                                   | Duration before unresolved [discrepancies](./README.md#discrepancy-auto-resolution-timeout) auto-resolve            |
+| `discrepancy_grace_period`                                         | Bounded period where a provider may retain pre-discrepancy tier eligibility while fault is unresolved               |
 | `attestation_deposit`                                              | Required [deposit](./README.md#attestation-deposit-anti-griefing) per attestation submission (anti-griefing)        |
-| `verification_module_active`                                       | Feature flag for [migration](./README.md#migration-from-aep-9): when `true`, market uses `x/verification` for bids |
+| `provider_audit_deposit`                                           | Minimum provider-side deposit for opening an audit escrow                                                           |
+| `verification_module_active`                                       | Feature flag for [migration](./README.md#migration-from-aep-9): when `true`, market uses `x/verification` for bids  |
 
 ### Initial Governance Parameter Values
 
-| Parameter | Value | Rationale |
-|---|---|---|
-| `bond_l3` | 1,000 AKT | Low barrier for L3 auditors |
-| `bond_l2` | 5,000 AKT | Moderate for L2 |
-| `bond_l1` | 25,000 AKT | Significant for L1 |
-| `bond_l0` | 100,000 AKT | Highest assurance |
-| `ttl_l3` | 365 days | Annual re-audit |
-| `ttl_l2` | 180 days | Semi-annual |
-| `ttl_l1` | 90 days | Quarterly |
-| `ttl_l0` | 90 days | Quarterly |
-| `min_fee_l3` | 10 AKT | Nominal |
-| `min_fee_l2` | 50 AKT | Covers automated audit cost |
-| `min_fee_l1` | 200 AKT | Covers deeper evaluation |
-| `min_fee_l0` | 1,000 AKT | Covers on-site audit |
-| `discrepancy_threshold` | 1 | Trigger on >1 tier difference |
-| `auditor_unbonding_period` | 21 days | Standard Cosmos unbonding |
-| `renewal_period_l3` | 24 months | Longest renewal cycle |
-| `renewal_period_l2` | 18 months | |
-| `renewal_period_l1` | 12 months | |
-| `renewal_period_l0` | 6 months | Most frequent re-approval |
-| `snapshot_hash_interval` | 24 hours | Daily freshness |
-| `max_snapshot_age` | 1 hour | Snapshot must be recent |
-| `bond_gpu_l2` / `l1` / `l0` | 50 / 100 / 200 AKT | Per GPU |
-| `bond_vcpu_l2` / `l1` / `l0` | 0.5 / 1 / 2 AKT | Per vCPU |
-| `bond_mem_gb_l2` / `l1` / `l0` | 0.25 / 0.5 / 1 AKT | Per GB memory |
-| `bond_storage_tb_l2` / `l1` / `l0` | 2 / 4 / 8 AKT | Per TB storage |
-| `provider_bond_unbonding_period` | 21 days | Standard unbonding |
-| `min_age_l2` | 30 days | |
-| `min_age_l1` | 120 days | |
-| `min_age_l0` | 300 days | |
-| `min_lease_completion_bps_l1` / `l0` | 9800 (98%) | High completion threshold |
-| `clean_history_window_l1` | 90 days | |
-| `clean_history_window_l0` | 180 days | |
-| `min_l1_duration_for_l0` | 180 days | 6 months at L1 before L0 |
-| `min_leases_for_completion_rate` | 10 | Avoids 1/1 = 100% gaming |
-| `contact_response_critical_l3` | 72 hours | Lenient; proves channel is monitored |
-| `contact_response_critical_l2` | 24 hours | Business-day response |
-| `contact_response_critical_l1` | 4 hours | Near-real-time for established operators |
-| `contact_response_critical_l0` | 1 hour | Highest-trust providers must be highly responsive |
-| `contact_response_standard_l3` | 7 days | Generous window for non-urgent inquiries |
-| `contact_response_standard_l2` | 72 hours | |
-| `contact_response_standard_l1` | 24 hours | |
-| `contact_response_standard_l0` | 4 hours | |
-| `max_endblocker_attestation_expiries` | 100 | Per-block processing cap |
-| `max_endblocker_snapshot_suspensions` | 50 | Per-block processing cap |
-| `max_endblocker_unbonding_completions` | 50 | Per-block processing cap |
-| `max_endblocker_discrepancy_timeouts` | 10 | Per-block processing cap |
-| `discrepancy_resolution_timeout` | 90 days | Prevents indefinite bond freezing |
-| `attestation_deposit` | 100 AKT | Anti-griefing; returned on normal expiry, slashed on losing discrepancy |
-| `verification_module_active` | `false` | Off during Phase 1; governance sets to `true` for Phase 2 |
+| Parameter                              | Value              | Rationale                                                                      |
+| -------------------------------------- | ------------------ | ------------------------------------------------------------------------------ |
+| `bond_l3`                              | 1,000 AKT          | Low barrier for L3 auditors                                                    |
+| `bond_l2`                              | 5,000 AKT          | Moderate for L2                                                                |
+| `bond_l1`                              | 25,000 AKT         | Significant for L1                                                             |
+| `bond_l0`                              | 100,000 AKT        | Highest assurance                                                              |
+| `ttl_l3`                               | 365 days           | Annual re-audit                                                                |
+| `ttl_l2`                               | 180 days           | Semi-annual                                                                    |
+| `ttl_l1`                               | 90 days            | Quarterly                                                                      |
+| `ttl_l0`                               | 90 days            | Quarterly                                                                      |
+| `min_fee_l3`                           | 10 AKT             | Nominal                                                                        |
+| `min_fee_l2`                           | 50 AKT             | Covers automated audit cost                                                    |
+| `min_fee_l1`                           | 200 AKT            | Covers deeper evaluation                                                       |
+| `min_fee_l0`                           | 1,000 AKT          | Covers on-site audit                                                           |
+| `discrepancy_threshold`                | 1                  | Trigger on >1 tier difference                                                  |
+| `auditor_unbonding_period`             | 21 days            | Standard Cosmos unbonding                                                      |
+| `renewal_period_l3`                    | 24 months          | Longest renewal cycle                                                          |
+| `renewal_period_l2`                    | 18 months          |                                                                                |
+| `renewal_period_l1`                    | 12 months          |                                                                                |
+| `renewal_period_l0`                    | 6 months           | Most frequent re-approval                                                      |
+| `snapshot_hash_interval`               | 24 hours           | Daily freshness                                                                |
+| `max_snapshot_age`                     | 1 hour             | Snapshot must be recent                                                        |
+| `bond_gpu_l2` / `l1` / `l0`            | 50 / 100 / 200 AKT | Per GPU                                                                        |
+| `bond_vcpu_l2` / `l1` / `l0`           | 0.5 / 1 / 2 AKT    | Per vCPU                                                                       |
+| `bond_mem_gb_l2` / `l1` / `l0`         | 0.25 / 0.5 / 1 AKT | Per GB memory                                                                  |
+| `bond_storage_tb_l2` / `l1` / `l0`     | 2 / 4 / 8 AKT      | Per TB storage                                                                 |
+| `provider_bond_unbonding_period`       | 21 days            | Standard unbonding                                                             |
+| `min_age_l2`                           | 30 days            |                                                                                |
+| `min_age_l1`                           | 120 days           |                                                                                |
+| `min_age_l0`                           | 300 days           |                                                                                |
+| `min_lease_completion_bps_l1` / `l0`   | 9800 (98%)         | High completion threshold                                                      |
+| `clean_history_window_l1`              | 90 days            |                                                                                |
+| `clean_history_window_l0`              | 180 days           |                                                                                |
+| `min_l1_duration_for_l0`               | 180 days           | 6 months at L1 before L0                                                       |
+| `min_leases_for_completion_rate`       | 10                 | Avoids 1/1 = 100% gaming                                                       |
+| `contact_response_critical_l3`         | 72 hours           | Lenient; proves channel is monitored                                           |
+| `contact_response_critical_l2`         | 24 hours           | Business-day response                                                          |
+| `contact_response_critical_l1`         | 4 hours            | Near-real-time for established operators                                       |
+| `contact_response_critical_l0`         | 1 hour             | Highest-trust providers must be highly responsive                              |
+| `contact_response_standard_l3`         | 7 days             | Generous window for non-urgent provider-controlled inquiries                   |
+| `contact_response_standard_l2`         | 72 hours           |                                                                                |
+| `contact_response_standard_l1`         | 24 hours           |                                                                                |
+| `contact_response_standard_l0`         | 4 hours            |                                                                                |
+| `provider_maintenance_max_duration`    | 7 days             | Allows long planned windows without making stale notices permanent             |
+| `provider_maintenance_max_lookahead`   | 90 days            | Lets tenants see planned maintenance without turning the store into a calendar |
+| `max_endblocker_attestation_expiries`  | 100                | Per-block processing cap                                                       |
+| `max_endblocker_snapshot_suspensions`  | 50                 | Per-block processing cap                                                       |
+| `max_endblocker_unbonding_completions` | 50                 | Per-block processing cap                                                       |
+| `max_endblocker_discrepancy_timeouts`  | 10                 | Per-block processing cap                                                       |
+| `max_endblocker_audit_escrow_expiries` | 50                 | Per-block processing cap                                                       |
+| `max_endblocker_grace_expiries`        | 50                 | Per-block processing cap                                                       |
+| `discrepancy_resolution_timeout`       | 90 days            | Prevents indefinite bond freezing                                              |
+| `discrepancy_grace_period`             | 14 days            | Gives providers time to replace an attestation while fault is unresolved       |
+| `attestation_deposit`                  | 100 AKT            | Anti-griefing; returned on normal expiry, slashed on losing discrepancy        |
+| `provider_audit_deposit`               | 100 AKT            | Discourages providers from opening audits and then obstructing them            |
+| `verification_module_active`           | `false`            | Off during Phase 1; governance sets to `true` for Phase 2                      |
 
 ### Store Layout and Indexing
 
@@ -1430,12 +2336,39 @@ enable efficient prefix iteration and range scans.
 0x05 | provider_addr (20 bytes)                             -> ProviderSnapshotRecord
 0x06                                                        -> Params
 0x07                                                        -> next_discrepancy_id (uint64)
+0x08 | audit_escrow_id (8 bytes BE)                         -> VerificationStoreRecord(AuditEscrowRecord)
+0x09                                                        -> next_audit_escrow_id (uint64)
+0x0A | grace_record_id (8 bytes BE)                         -> VerificationStoreRecord(ProviderVerificationGraceRecord)
+0x0B                                                        -> next_grace_record_id (uint64)
 ```
+
+#### Dynamic Verification Records
+
+Escrow and verification lifecycle records under prefixes `0x08` and `0x0A` are stored through a dynamic marshalled
+envelope so the store can add new verification record types without overloading one protobuf message.
+
+```
+VerificationStoreRecord {
+  type_url: string
+  value: bytes
+}
+```
+
+`type_url` must match the concrete protobuf message, for example
+`/akash.verification.v1.AuditEscrowRecord`. Handlers must reject unknown `type_url` values unless the chain software
+has registered a decoder for that type.
+
+These prefixes are KV-store prefixes, not separate module accounts. AEP-86 v1 holds audit fees, provider audit deposits,
+auditor attestation deposits, auditor bonds, and provider bonds in the `x/verification` module account, then uses
+verification-store records to say why those coins are held and how they can be released.
 
 #### Secondary Indexes
 
 ```
 0x10 | auditor_addr (20 bytes) | provider_addr (20 bytes)   -> [] (empty value; existence index)
+0x11 | provider_addr (20 bytes) | audit_escrow_id (8B BE)    -> [] (provider audit escrow index)
+0x12 | auditor_addr (20 bytes) | audit_escrow_id (8B BE)    -> [] (consumed audit escrow index)
+0x13 | provider_addr (20 bytes) | grace_record_id (8B BE)     -> [] (provider grace index)
 ```
 
 This index enables efficient iteration of all attestations issued by a specific auditor, which is needed for
@@ -1453,6 +2386,8 @@ efficient range iteration from the start of the queue up to the current block ti
 0x23 | completion (8B BE) | provider_addr | seq (4B)        -> [] (provider bond unbonding queue)
 0x24 | completion (8B BE) | auditor_addr                    -> [] (auditor bond unbonding queue)
 0x25 | timeout (8B BE) | discrepancy_id (8B BE)            -> [] (discrepancy auto-resolution queue)
+0x26 | expires_at (8B BE) | audit_escrow_id (8B BE)         -> [] (audit escrow expiry queue)
+0x27 | expires_at (8B BE) | grace_record_id (8B BE)         -> [] (discrepancy grace expiry queue)
 ```
 
 #### Queue Processing Pattern
@@ -1475,9 +2410,11 @@ for each entry where expires_at <= block_time (up to max_endblocker_attestation_
     2. If status == Valid:
        a. Set status = Expired
        b. Set fee_status = ReleasedToAuditor
-       c. Transfer escrowed fee from module account to auditor
-       d. Emit EventAttestationExpired
-       e. Emit EventFeeReleasedToAuditor
+       c. Set deposit_status = ReturnedToAuditor
+       d. Transfer escrowed fee from module account to auditor
+       e. Transfer auditor deposit from module account to auditor
+       f. Emit EventAttestationExpired
+       g. Emit EventFeeReleasedToAuditor
     3. Remove the secondary index entry (prefix 0x10)
     4. Delete queue entry
 ```
@@ -1490,9 +2427,10 @@ for each entry where deadline <= block_time:
     2. If status == Active:
        a. Set status = Lapsed
        b. Set bond_status = Unbonding
-       c. Add entry to auditor bond unbonding queue (prefix 0x24)
+       c. Set bond_unbonding_completion_time = block_time + auditor_unbonding_period
+       d. Add entry to auditor bond unbonding queue (prefix 0x24)
           with completion_time = block_time + auditor_unbonding_period
-       d. Emit EventAuditorLapsed
+       e. Emit EventAuditorLapsed
     3. Delete queue entry
 ```
 
@@ -1523,10 +2461,10 @@ for each entry where completion_time <= block_time (up to max_endblocker_unbondi
 #### 5. Auditor Bond Unbonding Queue (prefix `0x24`)
 
 ```
-for each entry where completion_time <= block_time:
+for each entry where completion_time <= block_time (up to max_endblocker_unbonding_completions):
     1. Load AuditorRecord from prefix 0x01
     2. Transfer bond from module escrow to auditor
-    3. Set bond_amount = 0, bond_status = Unbonding (completed)
+    3. Set bond_amount = 0, bond_status = Unbonding (completed), bond_unbonding_completion_time = null
     4. Store updated AuditorRecord
     5. Delete queue entry
 ```
@@ -1538,10 +2476,35 @@ for each entry where timeout <= block_time (up to max_endblocker_discrepancy_tim
     1. Load DiscrepancyEvent from prefix 0x03
     2. If resolution_status == Pending:
        a. Set resolution_status = TimedOut
-       b. Unfreeze auditor_a's bond (if no other pending discrepancies remain)
-       c. Unfreeze auditor_b's bond (if no other pending discrepancies remain)
-       d. Return attestation deposits for both voided attestations to respective auditors
+       b. Return escrowed fees to the provider
+       c. Slash both auditor deposits to the community pool
+       d. Unfreeze auditor bonds for this discrepancy if the auditor has no other pending discrepancies
        e. Emit EventDiscrepancyTimedOut
+    3. Delete queue entry
+```
+
+#### 7. Audit Escrow Expiry Queue (prefix `0x26`)
+
+```
+for each entry where expires_at <= block_time (up to max_endblocker_audit_escrow_expiries):
+    1. Load AuditEscrowRecord from prefix 0x08
+    2. If status == Open:
+       a. Set status = Expired
+       b. Set fee_status = ReturnedToProvider
+       c. Set provider_deposit_status = ReturnedToProvider
+       d. Transfer escrowed fee and provider deposit to provider
+       e. Emit EventAuditEscrowSettled with reason `ExpiredUnconsumed`
+    3. Delete queue entry
+```
+
+#### 8. Discrepancy Grace Expiry Queue (prefix `0x27`)
+
+```
+for each entry where expires_at <= block_time (up to max_endblocker_grace_expiries):
+    1. Load ProviderVerificationGraceRecord from prefix 0x0A
+    2. If status == Active:
+       a. Set status = Expired
+       b. Emit EventVerificationGraceExpired
     3. Delete queue entry
 ```
 
@@ -1556,26 +2519,58 @@ msg, service, query, events, genesis) are provided in the
 Tenants specify minimum verification requirements in their deployment SDL. The `x/market` module enforces these
 requirements during bid creation by querying the `x/verification` module.
 
+During the AEP-9 migration, `x/market` must be wired with both legacy audit support and new verification support. The
+bid path should use a small adapter owned by `x/market` that fans out to the legacy `AuditKeeper` and the new
+`VerificationKeeper` based on order contents and `verification_module_active`. The current market bid path already
+depends on `AuditKeeper` for legacy audited attributes, so AEP-86 extends that path rather than replacing it during the
+migration.
+
 #### VerificationKeeper Interface
 
-The `x/market` module replaces its existing `AuditKeeper` dependency with a `VerificationKeeper` interface:
+The `x/market` module consumes `VerificationKeeper` through an interface:
 
 ```
 VerificationKeeper:
+  IsVerificationActive(ctx) -> bool
   GetProviderValidAttestations(ctx, provider) -> ([]AttestationRecord, bool)
   IsProviderSnapshotCompliant(ctx, provider) -> bool
   GetProviderBestTier(ctx, provider) -> VerificationTier
+  GetProviderGraceTier(ctx, provider) -> (VerificationTier, bool)
   ProviderHasCapability(ctx, provider, CapabilityFlag) -> bool
+  CountQualifiedAuditors(ctx, provider, min_tier) -> uint32
 ```
 
+- `IsVerificationActive` returns the `verification_module_active` governance parameter. `x/market` uses this to decide
+  whether `VerificationRequirement` is enforced during the migration.
 - `GetProviderValidAttestations` returns all attestations with status `Valid` that have not expired. This method
   does NOT filter by snapshot compliance -- the caller must check `IsProviderSnapshotCompliant` separately. This
   separation ensures the verification module reports facts while the market module applies bid-time policy.
 - `IsProviderSnapshotCompliant` returns `false` if the provider's `ProviderSnapshotRecord.suspended` is `true`.
 - `GetProviderBestTier` returns the best (lowest numeric enum value = highest trust) tier from valid attestations.
   Returns `TierUnspecified` if no valid attestations exist (effectively Level 4).
+- `GetProviderGraceTier` returns the active discrepancy grace tier, if one exists. `x/market` uses this tier for tier
+  filtering only when verification filtering is active. It must still enforce snapshot compliance, bond requirements,
+  capability requirements, and named auditor requirements.
 - `ProviderHasCapability` returns `true` if any valid attestation for this provider includes the given
   [capability flag](./README.md#capability-flags).
+- `CountQualifiedAuditors` counts independent auditors with valid attestations at `min_tier` or better. Named auditor
+  requirements are checked separately with `auditor_mode`.
+
+#### Dual-Keeper Adapter
+
+`x/market` uses the following migration behavior:
+
+- If an order has only legacy `AttributesFilters`, evaluate it through `AuditKeeper`.
+- If an order has only `VerificationRequirement`, evaluate it through `VerificationKeeper` when
+  `verification_module_active == true`. When the flag is `false`, accept the field but do not enforce it.
+- If an order has both legacy attributes and verification requirements, both filters must pass when
+  `verification_module_active == true`.
+- Orders created before activation keep legacy audit matching for their legacy attributes.
+
+The keeper dependency cycle is resolved with narrow interfaces and late binding. `x/verification` receives a read-only
+`MarketStatsKeeper` interface for lease completion stats. `x/market` receives a read-only `VerificationKeeper`
+interface for bid filtering. Neither keeper imports the other's concrete keeper type, and the app wiring sets the
+interfaces after both keepers are constructed.
 
 #### Bid Filtering
 
@@ -1583,16 +2578,22 @@ The `CreateBid` handler in `x/market` is updated to check verification requireme
 
 ```
 1. If the order has a VerificationRequirement with min_tier set:
-   a. Check snapshot compliance: if provider is snapshot-suspended and min_tier <= L2,
-      reject with ErrProviderSnapshotSuspended
-   b. Check tier: if provider's best tier > min_tier (numerically higher = lower trust),
+   a. Check snapshot compliance: if `min_tier` is L2 or better and the provider is snapshot-suspended,
+      reject with `ErrProviderSnapshotSuspended`. This check uses the requested tier, not the provider's current best tier
+      or grace tier.
+   b. Check tier: use the provider's best valid tier. If an active grace record exists, use its `preserved_tier` directly
+      for tier filtering. If the resulting tier is lower trust than `min_tier`,
       reject with ErrInsufficientVerificationTier
    c. Check capabilities: for each required capability, if provider does not have it,
       reject with ErrMissingCapability
-   d. Check specific auditors: if required_auditors is non-empty, at least one valid
-      attestation must be from a listed auditor, otherwise reject with
-      ErrRequiredAuditorNotFound
+   d. Check auditor count: if min_auditor_count > 0, require at least that many
+      independent valid auditors at min_tier or better
+   e. Check specific auditors: if required_auditors is non-empty, apply auditor_mode:
+      any requires at least one listed auditor, all requires every listed auditor
 ```
+
+If `min_tier` is omitted or `TierUnspecified`, `x/market` does not apply verification filtering. Capability, auditor
+count, and required-auditor fields are only enforced inside a verification requirement that sets `min_tier`.
 
 #### SDL Syntax
 
@@ -1606,19 +2607,28 @@ profiles:
         region: us-west
       verification:
         min_tier: 2
+        min_auditor_count: 2
+        auditor_mode: all
         capabilities:
           - tee_hardware_attestation
           - confidential_computing
         auditors:
           - akash1auditor1...
+          - akash1auditor2...
       pricing:
         web:
           denom: uakt
           amount: 1000
 ```
 
+`auditor_mode: any` treats `auditors` as an allow-list where one listed auditor is enough. `auditor_mode: all` requires
+a valid attestation from every listed auditor. If omitted, `auditor_mode` defaults to `any`. `min_auditor_count` is
+independent of the named list and counts total qualified auditors at the requested tier or better. If both are present,
+both checks must pass.
+
 **On-chain representation**: The `PlacementRequirements` message (in the deployment module) gains a new
-`VerificationRequirement` field containing `min_tier`, `required_capabilities`, and `required_auditors`.
+`VerificationRequirement` field containing `min_tier`, `required_capabilities`, `required_auditors`,
+`auditor_mode`, and `min_auditor_count`.
 If omitted or `min_tier` is unspecified, no verification filtering is applied (backward compatible with
 existing deployments). See [Implementation Guide](./IMPLEMENTATION.md#35-verificationrequirement-xdeployment-proto-addition)
 for the full protobuf definition.
@@ -1642,6 +2652,8 @@ phased migration.
 - `x/audit` continues to operate normally for existing deployments
 - New deployments can use `verification` requirements in SDL (opt-in via the new `VerificationRequirement` field)
 - Market module accepts both `AttributesFilters` (legacy) and `VerificationRequirement` (new)
+- Market module wires both keepers through a market-owned adapter. Legacy audit checks remain live, while verification
+  checks are accepted but gated by `verification_module_active`.
 - A governance parameter `verification_module_active` (default: `false`) gates whether `x/verification` is
   checked during bid creation. When `false`, verification requirements in SDL are accepted but not enforced,
   allowing testing.
@@ -1656,6 +2668,8 @@ phased migration.
 - Existing deployments and open orders created with `x/audit` attribute requirements continue to use `x/audit`
   matching for bid filtering. The market module checks both `AttributesFilters` (legacy, for orders created before
   activation) and `VerificationRequirement` (new). An order may contain either or both.
+- Integration tests must cover legacy-only, verification-only, and mixed orders before and after activation. For mixed
+  orders, the matched-bid set must be the intersection of the legacy audit result and the verification result.
 
 #### Phase 3: Audit Deprecation (chain upgrade N+2, approximately 6-12 months after Phase 1)
 


### PR DESCRIPTION
Over the last few days Artur and the Core team helwent through my feedback doc and provided more info on what the spec should include and is currently missing. This commit adds the auditor software and provides implementation actions for spec items that were left open ended on purpose
