### PR TITLE
docs: fix AEP-42 internal reference

### DIFF
--- a/spec/aep-42/README.md
+++ b/spec/aep-42/README.md
@@ -17,4 +17,4 @@ Being able to store logs on Akash (or other decentralized storage) reduces cost 
 
 ## Summary
 
-While [AEP-34](https://github.com/ovrclk/aeps/tree/main/spec/aep-34) will address the pressing need for tenant/ workload logs it will do so by utilizing centralized logging setvices provided as SaaS. The scope of this AEP is to find a way to store logs relatively inexpensively on Akash or dedicated decentralized storage networks (like StorJ or Filecoin) while ensuring that the Akash user experience does not suffer significantly in doing so.
+While [AEP-34](../aep-34) will address the pressing need for tenant/ workload logs it will do so by utilizing centralized logging services provided as SaaS. The scope of this AEP is to find a way to store logs relatively inexpensively on Akash or dedicated decentralized storage networks (like StorJ or Filecoin) while ensuring that the Akash user experience does not suffer significantly in doing so.


### PR DESCRIPTION
## Summary
- Replace AEP-42's dead `ovrclk/aeps` link to AEP-34 with an internal AEP reference

## Verification
- Confirmed `https://github.com/ovrclk/aeps/tree/main/spec/aep-34` returns HTTP 404
- Confirmed `https://github.com/akash-network/AEP/tree/main/spec/aep-34` returns HTTP 200
- Confirmed the local AEP-34 target directory exists
- Ran `git diff --check`