### PR TITLE
docs: fix AEP economics paper link

### DIFF
--- a/spec/aep-5/README.md
+++ b/spec/aep-5/README.md
@@ -20,7 +20,7 @@ Akash is a marketplace for cloud compute resources which is designed to reduce w
 
 ## Detailed Proposal
 
-Detailed proposal is publised in the [paper](https://github.com/akash-network/AEP/blob/main/spec/aep-2/economics.pdf)
+Detailed proposal is published in the [paper](./economics.pdf)
 
 ## References
 


### PR DESCRIPTION
## Summary
- Replace AEP-5's dead external economics paper URL with the local `economics.pdf` included beside the AEP
- Fix the `publised` typo in the same sentence

## Verification
- Confirmed `https://github.com/akash-network/AEP/blob/main/spec/aep-2/economics.pdf` returns HTTP 404
- Confirmed `spec/aep-5/economics.pdf` exists in this repository and is a PDF
- Ran `git diff --check`