### PR TITLE
docs: fix AEP MultiZone link

### DIFF
--- a/spec/aep-12/README.md
+++ b/spec/aep-12/README.md
@@ -39,7 +39,7 @@ TEE is platform-dependent, all major providers have a form for TEE implementatio
 * Intel
   * [SGX Software Guard Extensions](https://01.org/intel-softwareguard-extensions)
 * RISC-V
-  * [MultiZone™ Security Trusted Execution Environment](https://hex-five.com/multizone-security-sdk/)
+  * [MultiZone™ Security Trusted Execution Environment](https://github.com/hex-five/multizone-iot-sdk)
 * IBM
   * [IBM Secure Service Container](https://www.ibm.com/us-en/marketplace/secure-service-container)
 


### PR DESCRIPTION
## Summary
- replace the dead Hex Five MultiZone SDK landing-page link with the active GitHub repository

## Verification
- `curl -L -s -o /dev/null -w "%{http_code}" https://hex-five.com/multizone-security-sdk/` returned `404`
- `curl -L -s -o /dev/null -w "%{http_code}" https://github.com/hex-five/multizone-iot-sdk` returned `200`