### PR TITLE
docs: fix AEP DTP link

### DIFF
--- a/spec/aep-11/README.md
+++ b/spec/aep-11/README.md
@@ -31,7 +31,7 @@ Standard services such as databases, when managed by specialized service provide
 - Primitives for frictionless integration with - backend services
 - Provide a pragmatic set of services at early phases to drive adoption
 - Provide a federated experience by extending identity, operational, and user interface support to a diverse set of managed services that include services from decentralized and managed infrastructure ecosystems
-- Provide a standard mechanism to decouple services from data to enable maximum possible portability such as [DTP](https://datatransferproject.dev)
+- Provide a standard mechanism to decouple services from data to enable maximum possible portability such as [DTP](https://github.com/dtinit/data-transfer-project)
 - Provide necessary technical and operational support 
 
 ## Copyright


### PR DESCRIPTION
## Summary
- replace the dead Data Transfer Project website link with the active repository

## Verification
- `curl -L -s -o /dev/null -w "%{http_code}" https://datatransferproject.dev` returned `404`
- `curl -L -s -o /dev/null -w "%{http_code}" https://github.com/dtinit/data-transfer-project` returned `200`