### PR TITLE
docs: fix AEP connection typos

### DIFF
--- a/spec/aep-2/README.md
+++ b/spec/aep-2/README.md
@@ -384,15 +384,15 @@ A _deployment_ represents the _current state_ of a stack as fulfilled by the Aka
 | container   | Docker container                                     |
 | compute     | [resources](#computeunit) needed for each instance   |
 | count       | number of instances to run                           |
-| connections | List of allowed incomming [connections](#connection) |
+| connections | List of allowed incoming [connections](#connection) |
 
 #### Connection
 
 | Field      | Description                                                                |
 | ---------- | -------------------------------------------------------------------------- |
 | port       | TCP port                                                                   |
-| workload   | [Workload](#workload) name to allow incomming connection from              |
-| datacenter | [Datacenter](#deploymentinfrastructure) to allow incomming connection from |
+| workload   | [Workload](#workload) name to allow incoming connection from               |
+| datacenter | [Datacenter](#deploymentinfrastructure) to allow incoming connection from  |
 | global     | If `true`, allow all connections, regardless of source                     |
 
 #### LeasedWorkload


### PR DESCRIPTION
## Summary
- fix repeated `incomming` typos in AEP-2 connection tables

## Verification
- verified the typo exists on the current `akash-network/AEP` `main` branch
- `git diff --check origin/main..HEAD` passes locally