### PR TITLE
docs: fix AEP announcement headings

### DIFF
--- a/spec/aep-7/README.md
+++ b/spec/aep-7/README.md
@@ -56,7 +56,7 @@ A total of **3 million AKT (3% of AKT)** is allocated for rewards that include:
 *   **Phase 1:** April 30, 2020
 
 
-## Annoucements
+## Announcements
 
 * [Announcing The Akashian Challenge: Incentivized Testnet](https://akash.network/blog/announcing-the-akashian-challenge-incentivized-testnet/)
 * [The Akashian Challenge: Token Rewards, Prizes, and Schedule](https://akash.network/blog/the-akashian-challenge-token-rewards-prizes-schedule/)

--- a/spec/aep-8/README.md
+++ b/spec/aep-8/README.md
@@ -41,7 +41,7 @@ Token distribution is critical to the success of Akash, propose the [genesis.jso
 
 Liquidity is critical to Proof-of-Stake (PoS) chains, as the security of the blockchain relies on the economic value staked to secure the chain. We propose using an exchange to bootstrap liquidity.
 
-## Annoucements
+## Announcements
 
 - [Announcing Akash Mainnet Live and Bitmax IEO](https://akash.network/blog/announcing-akash-mainnet-live-and-bitmax-ieo/)
 - [Akash DeCloud Mainnet Overview](https://akash.network/blog/akash-decloud-mainnet-overview/)


### PR DESCRIPTION
## Summary
- fix misspelled announcement headings in AEP-7 and AEP-8

## Verification
- verified the heading typo exists on current `akash-network/AEP` `main`
- `git diff --check origin/main..HEAD` passes locally