### PR TITLE
docs: fix AEP BME reference links

### DIFF
--- a/spec/aep-76/README.md
+++ b/spec/aep-76/README.md
@@ -153,7 +153,7 @@ When an invoice for A ACT is due, the protocol:
 #### `x/market` Leases & settlement
 * Quotes remain **USD‑first** in the UI; on chain, settlement pays providers **in AKT** by consuming ACT.  
 * Providers optionally auto‑stake a % of payouts (off by default).
-* AEP‑23 brought [stable payments](https://akash.network/docs/deployments/stable-payment-deployments) and take‑rates; with BME we keep the stable UX but remove take‑rates and settle AKT‑only.*
+* AEP‑23 brought [stable payments](../aep-23) and take‑rates; with BME we keep the stable UX but remove take‑rates and settle AKT‑only.*
 
 ##### Settlement loop (system flow)
 
@@ -438,7 +438,7 @@ MsgBurnACT {
 
 * `RemintCredits >= 0` except during a price‑crash path when circuit breaker logic governs shortfall; if `RemintCredits < 0`, only inflationary mint covers the difference (visible metric).
 
-*(Cosmos SDK’s [bank/mint](https://docs.cosmos.network/v0.46/modules/bank/) facilities support this pattern cleanly)*
+*(Cosmos SDK’s [bank/mint](https://docs.cosmos.network/sdk/latest/modules/bank/README) facilities support this pattern cleanly)*
 
 ### Provider & Tenant UX
 
@@ -469,7 +469,7 @@ MsgBurnACT {
 
 * **Oracle manipulation:** use multi‑feed medianization with [TWAP](https://docs.osmosis.zone/overview/features/concentrated-liquidity); cap per‑block price move; pausable by governance multisig in emergencies. 
 * **Liquidity stress:** perform console buys via RFQ/aggregator (Osmosis primary) with max slippage. (Osmosis as Cosmos liquidity hub. 
-* **Module integrity:** [bank](https://docs.cosmos.network/v0.46/modules/bank) burn/mint auditing with supply invariants in end blockers. 
+* **Module integrity:** [bank](https://docs.cosmos.network/sdk/latest/modules/bank/README) burn/mint auditing with supply invariants in end blockers.
 
 ### Rollout plan
 

--- a/spec/aep-80/README.md
+++ b/spec/aep-80/README.md
@@ -502,7 +502,7 @@ This is a new module with no existing state to migrate. It does not modify any e
 ## References
 
 - [AEP-76: Burn Mint Equilibrium](../aep-76)
-- [Cosmos SDK Bank Module](https://docs.cosmos.network/v0.46/modules/bank/)
+- [Cosmos SDK Bank Module](https://docs.cosmos.network/sdk/latest/modules/bank/README)
 - [CosmWasm Documentation](https://docs.cosmwasm.com/)
 
 ## Copyright


### PR DESCRIPTION
## Summary
- replace stale Cosmos SDK bank module links in AEP-76 and AEP-80
- replace the dead stable payments docs link with the local AEP-23 reference

## Verification
- `curl -L -s -o /dev/null -w "%{http_code}" https://docs.cosmos.network/v0.46/modules/bank/` returned `404`
- `curl -L -s -o /dev/null -w "%{http_code}" https://docs.cosmos.network/sdk/latest/modules/bank/README` returned `200`
- `curl -L -s -o /dev/null -w "%{http_code}" https://akash.network/docs/deployments/stable-payment-deployments` returned `404`
- verified `spec/aep-23/README.md` exists in this repository
- `git diff --check origin/main..HEAD` passes locally