### PR TITLE
docs: fix AEP founding member links

### DIFF
--- a/spec/aep-4/README.md
+++ b/spec/aep-4/README.md
@@ -12,7 +12,7 @@ roadmap: major
 
 ## Summary
 
-Launch Testnet with a fully functioning spot computing marketplace for containers and serverless deployment platform as proposed in the [AEP-2](/spec/aep-2). Incentivize user adoption of by applying game mechanics.
+Launch Testnet with a fully functioning spot computing marketplace for containers and serverless deployment platform as proposed in [AEP-2](../aep-2). Incentivize user adoption of by applying game mechanics.
 
 ## Motivation
 
@@ -28,12 +28,12 @@ Decentralized Computing is a novel concept that mandates user behavior change to
 
 - Codename: Alpha
 - Includes DCSs:
-  - [AEP-2: Decentralized Cloud Exchange](/spec/aep-2)
-  - [AEP-3: Stack Definition Language](/spec/aep-3)
+  - [AEP-2: Decentralized Cloud Exchange](../aep-2)
+  - [AEP-3: Stack Definition Language](../aep-3)
 - Token Allocation: 2,000,000 AKT
 - Limit: 100 Members
 - Program(s): Akash Founder Member Rewards
-- Support: [Akash Techinical Chat](https://akash.network/chat)
+- Support: [Akash Technical Chat](https://discord.akash.network)
 
 ### Akash Founder Member Challenge
 
@@ -50,10 +50,10 @@ Decentralized Computing is a novel concept that mandates user behavior change to
 - Developers: 68. [Proof](https://github.com/ovrclk/ecosystem/graphs/contributors).
 - Providers: 144. [Proof](https://akash.vitwit.com).
 
-## Annoucements
+## Announcements
 
 - [Become an Akash Founding Member and Earn Token Rewards](https://akash.network/blog/become-and-akash-founding-member-and-earn-token-rewards/)
 - [Earn 1,000 Tokens and the Akash Founder Level 2 Badge!](https://akash.network/blog/earn-1000-tokens-and-the-akash-founder-level-2-badge/)
-- [Announcing Our Third Founding Member Challenge!](https://akash.network/blog/announcing-our-third-founding-member-challenge-earn-2000-akash-tokens/)
+- [Announcing Our Third Founding Member Challenge!](https://akash.network/blog/announcing-our-third-founding-member-challenge/)
 - [Congratulations to Founding Member Challenge Contributors! Still Time to Join for 5500 Akash Tokens!](https://akash.network/blog/congratulations-to-founding-member-challenge-contributors-still-time-to-join-for-5500-akash-tokens)
 - [Announcing Our Founding Member Challenge Winners & Leaderboard!](https://akash.network/blog/announcing-our-founding-member-challenge-winners-leaderboard)


### PR DESCRIPTION
## Summary
- fix stale internal AEP references in AEP-4
- replace dead chat and blog links with active targets
- fix the misspelled announcements heading

## Verification
- `curl -L -s -o /dev/null -w "%{http_code}" https://akash.network/chat` returned `404`
- `curl -L -s -o /dev/null -w "%{http_code}" https://discord.akash.network` returned `200`
- `curl -L -s -o /dev/null -w "%{http_code}" https://akash.network/blog/announcing-our-third-founding-member-challenge-earn-2000-akash-tokens/` returned `404`
- `curl -L -s -o /dev/null -w "%{http_code}" https://akash.network/blog/announcing-our-third-founding-member-challenge/` returned `200`
- verified `spec/aep-2/README.md` and `spec/aep-3/README.md` exist in this repository
- `git diff --check origin/main..HEAD` passes locally