### PR TITLE
docs: fix AEP SDL links

### DIFF
--- a/spec/aep-3/README.md
+++ b/spec/aep-3/README.md
@@ -17,7 +17,7 @@ Stack Definition Language
 
 ## Specification
 
-Deployment services, datacenters, pricing, etc.. are described by a [YAML](http://www.yaml.org/start.html) configuration file. Configuration files may end in `.yml` or `.yaml`.
+Deployment services, datacenters, pricing, etc.. are described by a [YAML](https://yaml.org/spec/) configuration file. Configuration files may end in `.yml` or `.yaml`.
 
 A complete deployment has the following sections:
 
@@ -26,7 +26,7 @@ A complete deployment has the following sections:
 - [profiles](#profiles)
 - [deployment](#deployment)
 
-A full example deployment configuration can be found [here](deployment.yml).
+Current deployment examples can be found in the [SDL examples library](https://akash.network/docs/developers/deployment/akash-sdl/examples-library/).
 
 ### version
 


### PR DESCRIPTION
## Summary
- replace the dead YAML landing-page link with the current YAML spec page
- replace the missing local `deployment.yml` reference with the current SDL examples library

## Verification
- `curl -L -s -o /dev/null -w "%{http_code}" http://www.yaml.org/start.html` returned `404`
- `curl -L -s -o /dev/null -w "%{http_code}" https://yaml.org/spec/` returned `200`
- verified `spec/aep-3/deployment.yml` does not exist on current `akash-network/AEP` `main`
- `curl -L -s -o /dev/null -w "%{http_code}" https://akash.network/docs/developers/deployment/akash-sdl/examples-library/` returned `200`
- `git diff --check origin/main..HEAD` passes locally