### PR TITLE
docs: fix AEP bold formatting

### DIFF
--- a/spec/aep-31/README.md
+++ b/spec/aep-31/README.md
@@ -266,7 +266,7 @@ $137,291.78</p>
   </tr>
 </table>
 
-**AKT volatility buffer* 
+**AKT volatility buffer**
 *This buffer accounts for the historical daily volatility of AKT measured over the last 30 days leading up to September 30, 2024. By providing a more substantial buffer against potential downswings in AKT, we mitigate the need to request any budget shortfalls through subsequent proposals. In the event of excess funds above the US dollar amount of labor, taxes, and overage, all remaining AKT will be returned to the community promptly after completing the proposal.*
 
 ## Limited Market Impact & Transparent Reporting

--- a/spec/aep-83/README.md
+++ b/spec/aep-83/README.md
@@ -26,7 +26,7 @@ This AEP defines how tenants request confidential computing workloads on Akash N
 4. How GPU confidential computing (NVIDIA CC-on mode) integrates with the Kata VM model.
 5. How composite attestation works when both CPU and GPU TEEs are involved.
 
-This AEP addresses all five, with the vision of **minimal SDL and UX changes.
+This AEP addresses all five, with the vision of **minimal SDL and UX changes**.
 
 ## Design Principles
 

--- a/spec/aep-86/README.md
+++ b/spec/aep-86/README.md
@@ -740,9 +740,8 @@ consequences apply:
 1. The provider's `ProviderSnapshotRecord.suspended` is set to `true` by the
    [EndBlocker](./README.md#endblocker-design)
 2. An `EventSnapshotSuspended` event is emitted
-3. **Effect on attestations**: Suspended providers' attestations at Level 2 and above are treated as **inactive for
-   bid matching purposes**. The attestations themselves are NOT voided -- they remain valid in state and their TTLs
-   continue running. However, the `x/market` module checks snapshot compliance as an additional filter and rejects
+3. **Effect on attestations**: Suspended providers' attestations at Level 2 and above are treated as **inactive for bid matching purposes**.
+   The attestations themselves are NOT voided -- they remain valid in state and their TTLs continue running. However, the `x/market` module checks snapshot compliance as an additional filter and rejects
    bids from suspended providers for orders that require Level 2+ verification (see
    [Market Module Integration](./README.md#market-module-integration)).
 4. **Effect on new attestations**: `MsgSubmitAttestation` at Level 2 or above is rejected for snapshot-suspended


### PR DESCRIPTION
## Summary
- close malformed bold spans in AEP-31 and AEP-83
- keep the AEP-86 list item formatting from swallowing the line break into the bold span

## Verification
- verified the malformed Markdown exists on current `akash-network/AEP` `main`
- `git diff --check origin/main..HEAD` passes locally