### PR TITLE
docs: use supported proto fences in AEPs

### DIFF
--- a/spec/aep-37/README.md
+++ b/spec/aep-37/README.md
@@ -47,7 +47,7 @@ By migrating to gRPC, we expect to achieve better performance, efficiency, and m
 Implement `akash.provider.lease.v1.LeaseRPC` with following types and RPC calls
 
 
-```protobuf
+```proto
 syntax = "proto3";
 package akash.provider.lease.v1;
 

--- a/spec/aep-76/README.md
+++ b/spec/aep-76/README.md
@@ -279,7 +279,7 @@ Mint non-transferable ACT credits by removing AKT from circulation.
 
 ##### Message
 
-```protobuf
+```proto
 MsgMintACT {
   // who provides AKT (tenant or console wallet)
   payer:   Address       
@@ -346,7 +346,7 @@ Tenant burns unused ACT and receives AKT back at **current price**.
 
 ##### Message
 
-```protobuf
+```proto
 MsgBurnACT {
   owner:      Address    // whose ACT to burn
   to:         Address    // who receives AKT (default = owner)

--- a/spec/aep-80/README.md
+++ b/spec/aep-80/README.md
@@ -44,7 +44,7 @@ No existing Cosmos SDK module provides this combination. The `x/oracle` module f
 
 Uniquely identifies a price pair.
 
-```protobuf
+```proto
 message DataID {
   string denom = 1;       // Asset denomination (e.g., "uakt")
   string base_denom = 2;  // Base denomination (e.g., "usd")
@@ -55,7 +55,7 @@ message DataID {
 
 Identifies a price from a specific source.
 
-```protobuf
+```proto
 message PriceDataID {
   uint32 source = 1;      // Oracle provider index (assigned sequentially)
   string denom = 2;
@@ -67,7 +67,7 @@ message PriceDataID {
 
 Complete price record identifier including block height, enabling range queries.
 
-```protobuf
+```proto
 message PriceDataRecordID {
   uint32 source = 1;
   string denom = 2;
@@ -80,7 +80,7 @@ message PriceDataRecordID {
 
 The price value and its publish timestamp.
 
-```protobuf
+```proto
 message PriceDataState {
   string                    price = 1;     // cosmos.Dec (must be positive)
   google.protobuf.Timestamp timestamp = 2; // Publisher timestamp
@@ -91,7 +91,7 @@ message PriceDataState {
 
 The computed aggregate output stored per `DataID` at the end of each block.
 
-```protobuf
+```proto
 message AggregatedPrice {
   string                    denom = 1;
   string                    twap = 2;           // Time-weighted average price
@@ -108,7 +108,7 @@ message AggregatedPrice {
 
 Health status computed alongside aggregation.
 
-```protobuf
+```proto
 message PriceHealth {
   string          denom = 1;
   bool            is_healthy = 2;           // has_min_sources AND deviation_ok
@@ -138,7 +138,7 @@ Custom codecs encode composite keys with length-prefixed strings and big-endian 
 
 ### Parameters
 
-```protobuf
+```proto
 message Params {
   repeated string              sources = 1;                    // Authorized source addresses
   uint32                       min_price_sources = 2;          // Min sources for valid price
@@ -163,7 +163,7 @@ message Params {
 
 The `feed_contracts_params` field uses `google.protobuf.Any` to store typed configuration for different oracle integrations:
 
-```protobuf
+```proto
 message PythContractParams {
   string akt_price_feed_id = 1;  // Pyth price feed ID for AKT/USD
 }
@@ -181,7 +181,7 @@ These are read by the custom CosmWasm querier (see [CosmWasm Integration](#cosmw
 
 Submits a new price from an authorized source.
 
-```protobuf
+```proto
 service Msg {
   rpc AddPriceEntry(MsgAddPriceEntry) returns (MsgAddPriceEntryResponse);
   rpc UpdateParams(MsgUpdateParams) returns (MsgUpdateParamsResponse);
@@ -208,7 +208,7 @@ On success, the price is stored with a `PriceDataRecordID` keyed to the current 
 
 Governance-only message to update module parameters.
 
-```protobuf
+```proto
 message MsgUpdateParams {
   string authority = 1;  // x/gov module account
   Params params = 2;
@@ -258,7 +258,7 @@ At the end of every block, the module runs aggregation:
 
 ### Queries
 
-```protobuf
+```proto
 service Query {
   // Historical price data with pagination
   rpc Prices(QueryPricesRequest) returns (QueryPricesResponse);
@@ -291,7 +291,7 @@ service Query {
 
 ### Events
 
-```protobuf
+```proto
 // Emitted on successful price submission
 message EventPriceData {
   string         source = 1;  // Source address
@@ -400,7 +400,7 @@ Returns guardian addresses as base64
 
 ### Genesis State
 
-```protobuf
+```proto
 message GenesisState {
   Params                params = 1;
   repeated PriceData    prices = 2;

--- a/spec/aep-82/IMPLEMENTATION.md
+++ b/spec/aep-82/IMPLEMENTATION.md
@@ -127,7 +127,7 @@ if lease.State != mv1.LeaseActive && lease.State != mv1.LeaseReclaiming {
 
 ### 2.1 New File: `proto/node/akash/market/v1/reclamation.proto`
 
-```protobuf
+```proto
 syntax = "proto3";
 package akash.market.v1;
 
@@ -185,7 +185,7 @@ message Reclamation {
 
 Add to `Lease.State` enum:
 
-```protobuf
+```proto
 // LeaseReclaiming denotes a lease in reclamation (grace period before closure).
 reclaiming = 4 [
     (gogoproto.enumvalue_customname) = "LeaseReclaiming"
@@ -194,7 +194,7 @@ reclaiming = 4 [
 
 Add field to `Lease` message:
 
-```protobuf
+```proto
 // Reclamation holds reclamation configuration and state, if applicable.
 // Nil if reclamation is not configured for this lease.
 Reclamation reclamation = 7 [
@@ -208,7 +208,7 @@ Reclamation reclamation = 7 [
 
 Add:
 
-```protobuf
+```proto
 // EventLeaseReclaimStarted is triggered when a provider initiates reclamation.
 message EventLeaseReclaimStarted {
   option (gogoproto.equal) = true;
@@ -237,7 +237,7 @@ message EventLeaseReclaimStarted {
 
 Add:
 
-```protobuf
+```proto
 // MsgLeaseStartReclaim is sent by the provider to initiate reclamation on an active lease.
 message MsgLeaseStartReclaim {
   option (gogoproto.equal) = false;
@@ -263,7 +263,7 @@ message MsgLeaseStartReclaimResponse {}
 
 Add RPC to `service Msg`:
 
-```protobuf
+```proto
 // LeaseStartReclaim initiates the reclamation window on an active lease.
 rpc LeaseStartReclaim(MsgLeaseStartReclaim) returns (MsgLeaseStartReclaimResponse);
 ```
@@ -272,7 +272,7 @@ rpc LeaseStartReclaim(MsgLeaseStartReclaim) returns (MsgLeaseStartReclaimRespons
 
 Add to `MsgCreateBid`:
 
-```protobuf
+```proto
 // reclamation_window is the reclamation window duration the provider offers.
 // If the order requires reclamation, this must be >= the order's min_window.
 // Nil means the provider does not offer reclamation on this bid.
@@ -288,7 +288,7 @@ google.protobuf.Duration reclamation_window = 5 [
 
 Add to `Bid`:
 
-```protobuf
+```proto
 // reclamation_window is the reclamation window offered by this provider.
 google.protobuf.Duration reclamation_window = 6 [
   (gogoproto.nullable)    = true,
@@ -302,7 +302,7 @@ google.protobuf.Duration reclamation_window = 6 [
 
 Add to `Order`:
 
-```protobuf
+```proto
 // reclamation is the deployment-level reclamation requirement, propagated to the order.
 // Nil means the deployment does not require reclamation.
 akash.market.v1.DeploymentReclamation reclamation = 5 [
@@ -316,7 +316,7 @@ akash.market.v1.DeploymentReclamation reclamation = 5 [
 
 Add:
 
-```protobuf
+```proto
 // min_reclamation_window is the minimum reclamation window duration allowed.
 google.protobuf.Duration min_reclamation_window = 4 [
   (gogoproto.nullable)    = false,
@@ -338,7 +338,7 @@ google.protobuf.Duration max_reclamation_window = 5 [
 
 Add to `MsgCreateDeployment`:
 
-```protobuf
+```proto
 // reclamation specifies the deployment-level reclamation requirements.
 // Nil means the tenant does not require reclamation.
 akash.market.v1.DeploymentReclamation reclamation = 5 [
@@ -352,7 +352,7 @@ akash.market.v1.DeploymentReclamation reclamation = 5 [
 
 Add to `Deployment`:
 
-```protobuf
+```proto
 // reclamation stores the deployment's reclamation requirements for persistence.
 // Needed so that StartGroup can propagate reclamation to newly created orders.
 akash.market.v1.DeploymentReclamation reclamation = 5 [

--- a/spec/aep-86/IMPLEMENTATION.md
+++ b/spec/aep-86/IMPLEMENTATION.md
@@ -176,7 +176,7 @@ Required `x/provider` additions:
 
 Suggested protobuf shape:
 
-```protobuf
+```proto
 enum ProviderMaintenanceType {
     provider_maintenance_type_unspecified = 0;
     provider_maintenance_type_planned = 1;
@@ -243,7 +243,7 @@ message MsgCloseProviderMaintenanceResponse {}
 
 Suggested query shape:
 
-```protobuf
+```proto
 service Query {
     rpc ProviderMaintenance(QueryProviderMaintenanceRequest) returns (QueryProviderMaintenanceResponse) {
         option (google.api.http).get = "/akash/provider/v1beta4/providers/{provider}/maintenance/{maintenance_id}";
@@ -275,7 +275,7 @@ message QueryProviderMaintenancesResponse {
 
 Suggested events:
 
-```protobuf
+```proto
 message EventProviderMaintenanceOpened {
     uint64 maintenance_id = 1;
     string provider = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
@@ -548,7 +548,7 @@ legacy attributes and verification requirements, the adapter requires both check
 
 The `PlacementRequirements` in the deployment module gains a new field:
 
-```protobuf
+```proto
 // In deployment proto -- PlacementRequirements
 message PlacementRequirements {
     // ... existing attribute fields ...
@@ -576,7 +576,7 @@ Complete proto file specifications for `akash.verification.v1`. All files are pl
 
 ### 4.1 types.proto
 
-```protobuf
+```proto
 syntax = "proto3";
 package akash.verification.v1;
 
@@ -895,7 +895,7 @@ enum AuditorSelectionMode {
 
 ### 4.2 state.proto
 
-```protobuf
+```proto
 syntax = "proto3";
 package akash.verification.v1;
 
@@ -1041,7 +1041,7 @@ message ProviderSnapshotRecord {
 
 ### 4.3 params.proto
 
-```protobuf
+```proto
 syntax = "proto3";
 package akash.verification.v1;
 
@@ -1160,7 +1160,7 @@ message Params {
 
 ### 4.4 msg.proto
 
-```protobuf
+```proto
 syntax = "proto3";
 package akash.verification.v1;
 
@@ -1386,7 +1386,7 @@ message MsgUpdateParamsResponse {}
 
 ### 4.5 service.proto
 
-```protobuf
+```proto
 syntax = "proto3";
 package akash.verification.v1;
 
@@ -1423,7 +1423,7 @@ service Msg {
 
 ### 4.6 query.proto
 
-```protobuf
+```proto
 syntax = "proto3";
 package akash.verification.v1;
 
@@ -1587,7 +1587,7 @@ message QueryParamsResponse {
 
 ### 4.7 events.proto
 
-```protobuf
+```proto
 syntax = "proto3";
 package akash.verification.v1;
 
@@ -1785,7 +1785,7 @@ message EventVerificationGraceEnded {
 
 ### 4.8 genesis.proto
 
-```protobuf
+```proto
 syntax = "proto3";
 package akash.verification.v1;
 
@@ -1911,7 +1911,7 @@ separate signing-key AEP or phase 2 work.
 
 The Inventory Service is exposed as a gRPC service on the existing provider daemon endpoint:
 
-```protobuf
+```proto
 service InventoryService {
     rpc GetInventorySnapshot(GetInventorySnapshotRequest) returns (GetInventorySnapshotResponse);
 }


### PR DESCRIPTION
## Summary
- Normalize Protocol Buffer code fences from ` ```protobuf ` to ` ```proto ` across the AEP spec, matching the `proto` language id already used elsewhere in the repository.

## Scope / honesty note
This is a **cosmetic consistency** change — not a rendering fix. The Akash website renders AEP code fences through `astro-expressive-code` (bundled shiki ≥ 4.x), which registers `protobuf` as an alias of `proto`, so both tags already highlight identically on the live site. The only goal here is to standardize on a single fence id (`proto`) throughout the spec. Happy to close this if maintainers would rather not churn the files for a purely stylistic change.

## Verification
- 41 fences normalized across 5 files; only the fence language tag changes — no code or prose is touched
- `rg "^```protobuf$" spec` returns no matches after this change
- `git diff --check origin/main..HEAD` passes
