### PR TITLE
docs(aep-79): add chain migration doc set, link README to it

### DIFF
--- a/spec/aep-79/README.md
+++ b/spec/aep-79/README.md
@@ -6,10 +6,12 @@ status: Final
 type: Standard
 category: Core
 created: 2025-12-15
-updated: 2025-12-15
+updated: 2026-08-11
 estimated-completion: 2026-12-31
 roadmap: major
 ---
+
+> **Migration documentation:** For details about the migration and the current process, see [doc/README.md](./doc/README.md) — the Akash Chain Migration Program document set, which specifies the migration to execution depth and supersedes this RFP where the two conflict.
 
 ## Abstract
 

--- a/spec/aep-79/doc/00-executive-summary.md
+++ b/spec/aep-79/doc/00-executive-summary.md
@@ -1,0 +1,185 @@
+# 00. Executive Summary
+
+| | |
+|---|---|
+| **Document** | 00. Executive summary |
+| **Doc ID** | AKASH-MIG-00 |
+| **Version** | 0.9 (draft for review) |
+| **Date** | 2026-08-10 |
+| **Owner** | Overclock Labs |
+| **Audience** | Everyone: start here |
+| **Status** | Informative summary of the normative set |
+
+## Purpose
+
+A ten-minute orientation to the entire migration program: why Akash is leaving its sovereign Cosmos
+SDK chain, where it is going, how the move works, what it costs, and what could go wrong. Every claim
+here is elaborated in a numbered document ([README](./README.md) has the map).
+
+## In scope
+
+- Drivers, candidate targets, migration shape, program plan, effort, top risks, all summarized.
+
+## Out of scope
+
+- Normative requirements (live in docs 02–11); rationale detail (02, 13).
+
+---
+
+## 1. What this program is
+
+Akash Network operates a decentralized compute marketplace: tenants deploy containerized workloads
+(defined in SDL manifests) and independent providers bid to host them, with payments streaming
+through on-chain escrow. Today the protocol runs as its own Cosmos SDK Layer-1 (`akashnet-2`),
+secured by ~100 validators bonding AKT, and has evolved a sophisticated on-chain economy: a
+dual-token system (AKT plus ACT, an oracle-priced compute-credit token minted against AKT through a
+collateralized burn-mint engine), streaming escrow with multi-depositor support, provider
+attestation, and an on-chain Pyth price feed hosted in CosmWasm.
+
+This program migrates the protocol (its marketplace logic, tokens, balances, and community) onto
+one of two candidate execution layers, **Solana** or **Ethereum (an existing EVM L2)**, retiring the sovereign
+chain. This document set carries both paths at identical, execution-ready depth. The full analysis is
+[02. Target selection](./02-target-selection.md); the target is selected at **Gate 0** on the
+evidence of a kickoff verification sprint.
+
+## 2. Why
+
+1. **Capital efficiency:** AKT bonded for consensus security does nothing for the marketplace.
+   Inherited security frees it for provider incentives and liquidity.
+2. **Operational overhead:** Akash maintains forks of cosmos-sdk, CometBFT and gogoproto, a
+   16-upgrade release history, validator coordination, and an entire CosmWasm subsystem whose only
+   production job is importing Pyth prices. On the targets, most of this apparatus ceases to exist
+   rather than being re-hosted.
+3. **Scale with cost predictability:** marketplace operations (orders, bids, settlements, BME
+   swaps) are chatty; both targets price this at ≤$0.01/op with 10–100× headroom.
+4. **Distribution:** users, wallets, stablecoins, DeFi, and, on Solana, the entire DePIN category
+   (Helium, Render, io.net, Hivemapper) are already there. Meanwhile the Cosmos ecosystem is
+   consolidating (Noble's exit to its own EVM L1 in Mar 2026 being the sharpest recent signal).
+
+Akash pays sovereign costs without using sovereign powers: the codebase survey
+([01](./01-current-architecture.md)) found no consensus-level customization the marketplace actually
+depends on. That asymmetry is the case for leaving.
+
+## 3. Where: two candidate targets
+
+The protocol will run on one of two targets. Both are specified to the same execution-ready depth,
+and the choice between them is made at **Gate 0**, on the evidence collected during the kickoff
+verification sprint (decision D-01; the evidence items are listed in
+[02 §4.2](./02-target-selection.md)). All work before Gate 0 is target-neutral.
+
+**Path A: Solana mainnet** ([03](./03-solana-architecture.md)). What it offers:
+
+- The DePIN category is concentrated there, along with the two closest precedent migrations:
+  Helium's full L1 sunset (2023, healthy three years on) and Render's token move.
+- Fees (~$0.001 per transaction, median) and 100M-CU blocks comfortably absorb a chatty
+  marketplace.
+- Pyth is native, so the current CosmWasm-hosted oracle apparatus disappears instead of being
+  rebuilt.
+- Token-2022 expresses ACT's non-transferability directly at the mint level.
+
+**Path B: Ethereum, as contracts on an existing EVM L2** ([04](./04-ethereum-architecture.md)). The
+specific host chain is selected per Q-42; candidates include Base, Arbitrum One, and Robinhood
+Chain. What it offers:
+
+- The deepest engineering, audit, and tooling market of any ecosystem.
+- Enterprise credibility and exchange-affiliated distribution funnels.
+- Commodity infrastructure for claims, vesting, and governance, giving this path the lowest
+  execution novelty.
+
+A dedicated rollup (Arbitrum Orbit) is specified as a variant of Path B but is not a default path:
+operating one would re-create the burden this migration exists to eliminate (D-02).
+
+## 4. How: the migration shape
+
+Five structural decisions define the mechanics (full log:
+[13](./13-open-questions-and-assumptions.md)):
+
+1. **Rebuild, don't port bytes.** The marketplace programs/contracts re-implement current semantics
+   exactly (order→bid→lease flow, streaming escrow, ACT pricing, reclamation windows, SDL
+   untouched), verified by a differential-testing harness that replays recorded mainnet histories
+   through the new implementation ([09](./09-testing-and-verification.md)).
+2. **Dual snapshot, no bridge (D-05).** At cutover **S1**, all liquid AKT/ACT balances, vesting
+   schedules, and (as liquid) staked positions become claimable on the target chain via Merkle
+   proofs signed with existing Cosmos keys. Exchanges swap custodial balances in bulk at S1, while
+   self-custody claims open after a ~7-day public verification of the snapshot root (D-05.b).
+   Funds locked in protocol accounts (escrow, BME vault, community pool, IBC escrows) back a
+   **Wind-down Reserve** on the target chain.
+3. **90-day wind-down, workloads never stop (D-08).** The old chain stops accepting new deployments
+   at S1 but keeps settling existing leases for 90 days. Providers' old-chain earnings and tenants'
+   refunds during this window are paid out in new-chain AKT via **weekly residual distributions**
+   from the reserve. At halt **S2**, a final distribution closes the books; supply conservation is
+   machine-verifiable end-to-end.
+4. **The token economy ports whole (D-19/D-20/D-12).** ACT remains a non-transferable compute
+   credit; the BME engine (queued AKT↔ACT swaps, collateral-ratio circuit breaker, Pyth-priced)
+   becomes a program/contract with permissionless crank execution. Sovereign inflation ends at S1;
+   a reduced, DAO-governed emissions schedule redirects to provider incentives and the treasury
+   (curve to be modeled; Q-01).
+5. **Identity and trust re-anchor (D-10/D-11).** Providers re-register on the new chain (with
+   collateral) before S1; auditors re-attest; the on-chain x509 registry is replaced by JWT auth
+   against on-chain registered keys. Governance moves to Realms+Squads (Solana) or
+   Governor+Safe+timelock (EVM), with program upgradeability behind multisig+timelock and a
+   published path to immutability.
+
+What each constituency experiences:
+
+- **Tenants:** existing leases run untouched through wind-down; new deployments go to the new chain
+  from day one; Console abstracts most of the difference; SDL files unchanged.
+- **Providers:** one daemon upgrade + one re-registration before S1; old-chain earnings arrive
+  weekly in new-chain AKT during wind-down.
+- **AKT holders:** exchange balances swap automatically; self-custody holders claim with their
+  existing keys (2-year window); stakers are credited liquid at S1; vesting continues on schedule.
+- **Validators:** the role ends at S2; a wind-down incentive (reserved at S1) pays for keeping the
+  chain healthy through the transition (Q-13).
+
+## 5. Program plan & effort
+
+Phases P0–P7 across gates G0–G5 ([10](./10-rollout-and-cutover.md)): mobilization & verification →
+design freeze → build → testnet + audits → rehearsals + binding governance approval → **S1 cutover**
+→ 90-day wind-down → **S2** + sunset + hypercare. This set sequences work by gates and protocol
+events (C, H) only; calendar planning is maintained separately and is not part of this technical
+package.
+
+Vendor scope ([11](./11-scope-of-work.md)) is structured as target-neutral **Stage A** (verification
+sprint, tokenomics modeling, migration-engine design, prototypes) and single-path **Stage B** after
+Gate 0, across nine workstreams (protocol, migration engine, off-chain/clients, security, QA,
+launch ops, docs). Planning estimate: **142–200 person-months**, team of ~8–12 FTE plus audit
+firms, with Overclock counterpart staffing of ≥2 FTE engineering plus product/comms/governance.
+Four migration rehearsals (R1–R4, ending with a final dress at S1−14d) on forked mainnet state and two
+independent snapshot implementations
+are non-negotiable quality gates; client-side budget lines (audits, bounty pool, RPC/infra opex,
+exchange coordination) are itemized separately.
+
+## 6. Top risks (register: [12](./12-risk-register.md))
+
+1. **Claims contract as honeypot:** it briefly custodies rights to essentially the entire supply;
+   mitigated by dual audits, dual-implementation root verification, staged authority, pause-without-
+   blocking-withdrawals design.
+2. **Escrow/BME parity defects:** money-losing behavioral drift vs the current chain; mitigated by
+   the differential-replay harness and invariant fuzzing.
+3. **Exchange coordination slippage:** precedent (Render) shows multi-month tails; mitigated by
+   early venue engagement and S1 gating on venue commitments covering ≥70% of volume.
+4. **Provider/validator attrition during wind-down:** mitigated by incentives reserved at S1 and
+   weekly payout cadence.
+5. **Host-chain events in our window:** Solana's Alpenglow consensus upgrade lands ~Q3–Q4 2026;
+   buffer in schedule + a Gate 0 evidence item.
+
+## 7. What this document set asks of you
+
+- **Akash community:** review 02 (the choice), 05 (your tokens), 10 (the timeline), 13 (what's still
+  open); the signal proposal follows this review cycle.
+- **Prospective Vendor:** respond against [11](./11-scope-of-work.md) with per-workstream approach,
+  team, and per-milestone pricing; every normative obligation carries a stable `REQ-*` ID for
+  traceability from proposal through acceptance.
+- **Overclock/core team:** validate assumptions A-01..A-13, staff the counterpart roles, and own the
+  governance and exchange tracks.
+
+## Cross-references
+
+- [README](./README.md): document map and conventions.
+- [02](./02-target-selection.md): full option analysis behind §3.
+- [05](./05-token-migration.md) / [06](./06-state-and-data-migration.md): the mechanics behind §4.
+- [11](./11-scope-of-work.md): the commercial ask behind §5.
+
+## Feeds into
+
+The community signal proposal (Gate 0) and Vendor RFP distribution.

--- a/spec/aep-79/doc/01-current-architecture.md
+++ b/spec/aep-79/doc/01-current-architecture.md
@@ -1,0 +1,1002 @@
+# 01. Current Architecture: Akash on Cosmos SDK
+
+| | |
+|---|---|
+| **Document** | 01. Current architecture (Akash on Cosmos SDK) |
+| **Doc ID** | AKASH-MIG-01 |
+| **Version** | 0.9 (draft for review) |
+| **Date** | 2026-08-10 |
+| **Owner** | Overclock Labs |
+| **Audience** | Vendor engineering |
+| **Status** | INFORMATIVE: no `REQ-*` requirements; the factual baseline the normative documents build on |
+
+## Purpose
+
+- Describe, at engineering depth, what the Akash protocol **is today** on its sovereign Cosmos SDK chain: every
+  module, its state layout, messages, parameters, events, block-lifecycle behavior, and inter-module wiring.
+- Give Vendor engineers with **zero Cosmos background** enough context to read the rest of the set: every
+  Cosmos-specific concept is defined on first use (§1.2).
+- Isolate behaviors the target chain must reproduce faithfully (escrow settlement, the BME engine, the close
+  cascade; §4) from incidental Cosmos plumbing that will not carry over.
+- Enumerate off-chain systems coupled to the chain (§6), known defects that must **not** be ported (§7), and data
+  that exists only as mainnet state and must be pulled at kickoff (§8).
+
+## In scope
+
+- The v2 protocol line as at commit `096bff57` (2026-08-10) of
+  [`akash-network/node`](https://github.com/akash-network/node), Go module `pkg.akt.dev/node/v2`.
+- Custom Akash modules, the in-repo CosmWasm contracts, chain-level configuration, genesis shape, upgrade history,
+  and off-chain integration seams.
+- Behavior descriptions grounded in code, cited as `path/file.go:line`.
+
+## Out of scope
+
+- Anything about the target chains; see [03](./03-solana-architecture.md) and [04](./04-ethereum-architecture.md).
+- Migration mechanics; see [05](./05-token-migration.md) and [06](./06-state-and-data-migration.md).
+- Message/state/event mapping to target designs; see [14](./14-appendix-protocol-mapping.md).
+- Rationale for what is kept vs dropped; recorded as `D-xx` in [13](./13-open-questions-and-assumptions.md).
+
+## 1. Orientation
+
+### 1.1 What Akash is
+
+Akash Network is a decentralized marketplace for compute. **Tenants** (customers) describe workloads in **SDL**
+(Stack Definition Language, a YAML manifest: containers, resources, placement constraints, pricing). **Providers**
+(datacenter/GPU operators running the separate `provider-services` daemon on Kubernetes) bid for that business.
+The chain's job is narrow: run the **order book** (deployments → orders → bids → leases), hold **escrow** so
+tenants can pay for leases as they run, meter payment out to providers block by block, and anchor the
+identity/attribute/audit records that make bids trustworthy. Workloads never touch the chain: the SDL manifest
+travels tenant→provider over an authenticated HTTPS channel, and only its hash lives on-chain.
+
+Today this runs as a **sovereign Cosmos SDK Layer-1** ("Akash mainnet", chain-id `akashnet-2`) with its own
+validator set, staking token (AKT), inflation, and governance. This document is the "as-is" baseline the
+migration program starts from.
+
+### 1.2 Cosmos SDK primer: concepts used throughout
+
+The Cosmos SDK is a Go framework for building application-specific blockchains on the CometBFT (formerly
+Tendermint) BFT consensus engine. Definitions the rest of this document assumes:
+
+| Concept | Definition |
+|---|---|
+| **Module (`x/name`)** | A vertical slice of on-chain functionality: state + message handlers + queries + genesis logic. Stock SDK modules (`x/bank`, `x/staking`, `x/gov`, …) ship with the framework; Akash adds ten custom ones. |
+| **Keeper** | A module's state-access object; holds its KV store and references to other modules' keepers (the dependency graph). "Keeper X calls keeper Y" = synchronous in-process call inside one state transition. |
+| **KV store / IAVL / collections** | Each module owns a namespaced key-value store inside one Merkleized tree (IAVL); keys are hand-rolled byte prefixes. `collections` are newer typed wrappers; an `IndexedMap` maintains secondary indexes (e.g. "orders by state") automatically. A **transient store** is per-block scratch, wiped after each block. |
+| **Msg / Query** | A `Msg` is a typed, signed state-transition request (protobuf), e.g. `MsgCreateDeployment`; a transaction carries one or more, executed atomically (any error rolls back the tx). A `Query` is a read-only gRPC service per module, also exposed as REST via **grpc-gateway**. |
+| **Params** | A module's governance-adjustable configuration, changed via `MsgUpdateParams` that only the governance module account may sign ("gov-gated"). |
+| **denom / Coin / DecCoin** | A `denom` is a token denomination string (`uakt` = micro-AKT, 10⁻⁶ AKT). `Coin` = integer amount + denom; `DecCoin` = high-precision decimal amount + denom (prices/rates). |
+| **Module account** | A chain-owned account (no private key) holding funds a module controls, e.g. the escrow pool. Permissions (`Minter`, `Burner`, `Staking`) gate supply operations. |
+| **bech32 address** | Cosmos address encoding: human-readable prefix + base32 payload. Akash prefixes: `akash` (accounts), `akashvaloper` (validators), `akashvalcons` (consensus keys) (`pkg.akt.dev/go/sdkutil/init.go:26-33`, `app/types/app.go:94`). |
+| **ante handler** | An ordered decorator chain pre-validating every transaction before execution: signature checks, fee deduction, sequence increment. |
+| **BeginBlocker / EndBlocker / hooks** | Per-module callbacks run automatically at the start/end of every block ("cron inside consensus"); cross-module ordering is significant (§5.5). Hooks are callback interfaces one module registers on another, e.g. escrow notifies market when an account closes (§4.3). |
+| **Events** | Key-value attributes (legacy) or typed protobuf events emitted during execution; indexed by nodes, consumed by off-chain indexers; not consensus state. |
+| **x/gov** | On-chain proposal/voting. Governance actions execute as Msgs whose `authority` is the gov module account. |
+| **x/authz / x/feegrant** | `authz`: generic grants, where account A grants B the right to execute a specific Msg type within limits (used for delegated escrow deposits, §4.1.3). `feegrant`: A pays transaction fees for B (fees only, on Akash). |
+| **IBC** | Inter-Blockchain Communication, Cosmos's trust-minimized cross-chain protocol. ICS-20 = the fungible-token-transfer standard over IBC. |
+| **CosmWasm / wasmd / `Any`** | A smart-contract VM module (Rust→Wasm) embeddable in an SDK chain; on Akash it exists solely to host the Pyth oracle plumbing (§3.10–3.11). Protobuf `Any` = type-erased container (`type_url` + bytes), how contracts emit native Msgs. |
+| **Genesis / zero-height export** | The JSON document a chain starts from; each module defines an export/import shape. A zero-height export re-creates genesis from live state (basis for migration snapshots). |
+| **ConsensusVersion** | Per-module state-schema version, incremented with an in-place store migration at chain upgrades. |
+| **Upgrade / Cosmovisor** | Coordinated halt-and-restart chain upgrades scheduled by governance at a named height; Cosmovisor swaps binaries. |
+
+### 1.3 Marketplace lifecycle, end to end
+
+Identifiers: a deployment is `(owner, dseq)`; groups add `gseq` (1..N), orders `oseq`, bids the provider address
+and `bseq`. `dseq` is **client-chosen**, by convention the current block height at creation (CLI default), a UX
+detail preserved per D-09 (Q-12 tracks whether tooling depends on the height correlation).
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor T as Tenant wallet
+    participant BME as x/bme (burn-mint engine)
+    participant DEP as x/deployment
+    participant MKT as x/market
+    participant ESC as x/escrow
+    actor P as Provider daemon (off-chain)
+
+    Note over T,BME: Lease pricing is ACT-denominated. Tenant first swaps AKT for ACT.
+    T->>BME: MsgMintACT (burn uakt, mint uact)
+    BME-->>T: uact credited at next mint epoch (queued, oracle-priced)
+
+    T->>DEP: MsgCreateDeployment (groups, SDL hash, uact deposit)
+    DEP->>ESC: AccountCreate(deployment escrow account, deposit)
+    DEP->>MKT: CreateOrder (one per group)
+
+    P->>MKT: MsgCreateBid (price <= order price, collateral deposit)
+    MKT->>ESC: AccountCreate(bid escrow account = collateral)
+    Note over MKT: attribute + audit matching against provider registry
+
+    T->>MKT: MsgCreateLease (chosen BidID)
+    MKT->>ESC: PaymentCreate(rate = bid price per block, payee = provider)
+    MKT->>ESC: AccountClose(losing bid accounts) - collateral refunded
+
+    T-->>P: SDL manifest via provider gateway (OFF-CHAIN, mTLS+JWT).<br/>Provider checks SHA-256(manifest) == on-chain Hash
+    P->>P: schedules workload on Kubernetes
+
+    loop while lease active (streaming payment)
+        Note over ESC: no per-block work - lazy accrual:<br/>owed = rate x (height - SettledAt)
+        P->>MKT: MsgWithdrawLease
+        MKT->>ESC: PaymentWithdraw -> settle, pay provider 100% (no protocol fee)
+        T->>ESC: MsgAccountDeposit (optional top-up, uakt or uact)
+    end
+
+    alt tenant closes
+        T->>DEP: MsgCloseDeployment
+        DEP->>ESC: AccountClose -> settle, refund depositors FIFO
+        ESC-->>MKT: hooks close leases/orders/bids (cascade, §4.3)
+    else escrow exhausted
+        ESC-->>MKT: account/payment overdrawn -> hooks close lease<br/>(reason: insufficient funds)
+    else provider exits gracefully
+        P->>MKT: MsgLeaseStartReclaim, then MsgCloseBid after window elapses
+    end
+```
+
+Withdraw/close paths in words: providers pull earned funds any time (`MsgWithdrawLease`); tenants close whole
+deployments or individual groups; either close triggers final settlement and FIFO refund of unspent deposits; if
+funds run out first, the escrow marks itself **overdrawn** and the hook cascade closes the lease with reason
+`insufficient funds` (§4.3). Providers can also *reclaim*: a graceful provider-initiated wind-down with an
+on-chain notice window (min 1 h, max 720 h) before the bid may close (D-24).
+
+## 2. Protocol baseline: READ THIS FIRST
+
+> **IMPORTANT: the protocol being migrated is the v2 line, not the classic Akash app.**
+> The baseline is commit `096bff57` (2026-08-10, module `pkg.akt.dev/node/v2`). It differs materially from
+> pre-2025 descriptions of Akash found elsewhere:
+>
+> 1. **Dual token.** AKT (`uakt`) remains the staking/governance/gas token. **ACT** (`uact`, "Akash Compute
+>    Token") is a second denom in which **all lease pricing is denominated**; it is **bank-transfer-disabled**
+>    (`SendEnabled: uact=false`, `cmd/akash/cmd/genesis.go:121-130`) and moves only through module logic.
+> 2. **BME (burn-mint engine, `x/bme`).** ACT is created/redeemed against AKT through a queued, epoch-batched
+>    burn-mint engine with an oracle-priced collateral-ratio circuit breaker (§3.4, §4.2).
+> 3. **On-chain oracle.** AKT/USD enters consensus via `x/oracle`, fed exclusively by a CosmWasm-hosted Pyth
+>    contract pipeline (§3.10–3.11), the only reason CosmWasm exists on the chain (D-22).
+> 4. **Epochs scheduler** (`x/epochs`) drives periodic maintenance (oracle pruning).
+> 5. **`x/take` is DELETED.** The historic protocol-fee module is out of the app since v2.0.0 (store removed).
+>    **Providers currently keep 100% of lease payments; there is no protocol take** (§3.12, §4.1.5).
+>
+> Any protocol change shipped on mainnet before Gate 1 must be folded back into this document (A-12).
+
+## 3. Module-by-module reference
+
+Store-key bytes below are prefixes inside each module's namespaced KV store. All protobuf/state definitions live
+**outside this repo** in the shared API module `pkg.akt.dev/go` (pinned `v0.2.14`, `go.mod:51`), import pattern
+`pkg.akt.dev/go/node/<module>/<version>`; there are no `.proto` files in `akash-network/node` itself.
+
+App wiring at a glance: Akash keepers are Audit, Bme, Cert, Deployment, Epochs, Escrow, Market, Oracle, Provider,
+Wasm (`app/types/app.go:120-131`); **Take is not wired**. Keeper construction order encodes the dependency graph
+(`app/types/app.go:421-491`): Oracle → Bme(account, bank, oracle) → Escrow(bank, authz, oracle, bme) →
+Market(escrow) → Deployment(escrow, oracle, market, authz, bank) → Provider, Audit, Cert, Epochs, Wasm(awasm),
+wasmd.
+
+### 3.1 `x/deployment`: store `deployment`, ConsensusVersion 8
+
+**Purpose.** Marketplace entry point. One SDL deployment = a `Deployment` record plus N `Group`s (a group is a
+co-placed resource bundle with a price). Creating a deployment opens a deployment-scoped escrow account and one
+market `Order` per group. Groups pause/start/close independently; closing the deployment closes the escrow
+account, and everything else follows from the hook cascade (§4.3).
+
+**State** (collections; `x/deployment/keeper/keeper.go:63-66`; protos `pkg.akt.dev/go/node/deployment/v1` (IDs,
+Deployment, events) and `.../v1beta4` (Group, GroupSpec, Params, Msgs)):
+
+| Object | Key layout | Fields |
+|---|---|---|
+| `Deployment` | IndexedMap @ `0x11 0x00`; state index @ `0x11 0x02` | `ID{Owner string, DSeq uint64}`, `State` (active \| closed), `Hash []byte` (SDL manifest hash), `CreatedAt int64`, `Reclamation *{MinWindow time.Duration}` |
+| `Group` | IndexedMap @ `0x12 0x00`; indexes `groups_by_state`, `groups_by_deployment` @ `0x12 0x03` | `ID{Owner, DSeq, GSeq uint32}`, `State` (open \| paused \| insufficient_funds \| closed), `GroupSpec{Name, Requirements, Resources}`, `CreatedAt`. `ResourceUnit{Resources (cpu/mem/storage/gpu/endpoints), Count uint32, Price DecCoin}` |
+| `pendingDenomMigrations` | Map @ `0x13 0x01` | `DeploymentID → math.Int`: AKT→ACT migration scratch, drained by v2.1.0 |
+| `Params` | Item | below |
+
+**Messages** (`x/deployment/handler/server.go`):
+
+| Msg | Key fields | Handler behavior (funds movements in bold) |
+|---|---|---|
+| `MsgCreateDeployment` | `ID`, `Groups []GroupSpec`, `Hash`, `Deposit{Amount, Sources}`, `Reclamation` | `:41-130`: rejects existing ID; validates deposit vs `MinDeposits`; **rejects `uakt` deposits outright** (`:60-62`: AKT enters escrow only via later `MsgAccountDeposit`); reclamation window bounds vs market params; **group `Price` denom MUST be `uact`** (`:93`); `escrow.AuthorizeDeposits` (§4.1.3); stores Deployment + Groups (gseq 1..N); `market.CreateOrder` per group; **`escrow.AccountCreate` pulls the deposit into the escrow module account** |
+| `MsgUpdateDeployment` | `ID`, `Hash` | `:132-157`: active-only; hash must differ; updates the SDL manifest hash pointer |
+| `MsgCloseDeployment` | `ID` | `:159-177`: active-only; `escrow.AccountClose`; **all further state changes (refunds, lease/order/bid closure) flow through the escrow→market hook cascade** |
+| `MsgCloseGroup` | `GroupID` | `:179-201`: group→`GroupClosed`; `market.OnGroupClosed` closes the group's order/bids |
+| `MsgPauseGroup` | `GroupID` | `:203-214`: group→`GroupPaused`; `market.OnGroupClosed` |
+| `MsgStartGroup` | `GroupID` | `:226-253`: reopens a paused group; `market.CreateOrder` with the deployment's reclamation settings |
+| `MsgUpdateParams` | `Authority`, `Params` | `:255-268`: gov-gated |
+
+**Params:** `MinDeposits sdk.Coins`, default `500000uakt, 500000uact`
+(`pkg.akt.dev/go/node/deployment/v1beta4/params.go:32-38`); per-denom validation: a deposit in a denom missing
+from `MinDeposits` errors. (The `uakt` entry gates top-ups; creation itself is uact-only, above.)
+**Queries:** `Deployments`, `Deployment`, `Group`, `Params` (gRPC `akash.deployment.v1beta4.Query`).
+**Events:** `EventDeploymentCreated/Updated/Closed`, `EventGroupClosed/Paused/Started`
+(`x/deployment/keeper/keeper.go:228-379`).
+**Block hooks:** module `EndBlock` delegates to `keeper.EndBlocker`, a **no-op** (`x/deployment/keeper/abci.go:7-9`);
+the comment at `x/deployment/module.go:157` still references a deferred AKT→ACT denom migration, which actually
+ran as store-migration v7 (`x/deployment/migrate/v7/act.go`: migrates group prices, escrow accounts/payments,
+and authz grants between denoms at an oracle rate).
+**Deps:** Escrow, Market, Oracle, Authz, Bank, BME (`x/deployment/imports/keepers.go`); inbound hook
+`OnBidClosed(gid)` → `OnPauseGroup` (`keeper.go:421-427`).
+**Genesis:** `{Params, Deployments: [{Deployment, Groups[]}]}`.
+
+### 3.2 `x/market`: store `market`, ConsensusVersion 9
+
+**Purpose.** The order book. Every open group has an `Order`; providers respond with `Bid`s, each collateralized
+by its own escrow account; the tenant matches one bid into a `Lease`, which creates a streaming escrow `Payment`
+at the bid price. Market also owns the provider-initiated **reclamation** flow.
+
+**State** (collections; key layout `x/market/keeper/keys/key.go:29-56`; protos `pkg.akt.dev/go/node/market/v1`
+(IDs, Lease, events) and `.../v1beta5` (Order, Bid, Params, Msgs)):
+
+| Object | Key layout | Fields |
+|---|---|---|
+| `Order` | IndexedMap @ `0x11 0x01`; indexes by state `0x11 0x02`, by group+state `0x11 0x03` | `ID{Owner, DSeq, GSeq, OSeq uint32}`, `State` (open \| active \| closed), `Spec GroupSpec` (copied from group), `CreatedAt`, `Reclamation *DeploymentReclamation` |
+| `Bid` | IndexedMap @ `0x12 0x02`; indexes by state `0x12 0x03`, by provider `0x12 0x04`, by order+state `0x12 0x05` | `ID{Owner, DSeq, GSeq, OSeq, Provider, BSeq uint32}`, `State` (open \| active \| lost \| closed), `Price DecCoin`, `CreatedAt`, `ResourcesOffer`, `ReclamationWindow *time.Duration` |
+| `Lease` | IndexedMap @ `0x13 0x02`; indexes by state `0x13 0x03`, by provider `0x13 0x04` | `ID LeaseID`, `State` (active \| insufficient_funds \| closed \| reclaiming), `Price DecCoin`, `CreatedAt`, `ClosedOn int64`, `Reason LeaseClosedReason`, `Reclamation *{Window, StartedAt int64, Deadline int64, Reason}` |
+| `Params` | Item @ `0x14 0x00` | below |
+
+**Messages** (`x/market/handler/server.go`):
+
+| Msg | Key fields | Handler behavior |
+|---|---|---|
+| `MsgCreateBid` | `ID BidID`, `Price DecCoin`, `Deposit`, `ResourcesOffer`, `ReclamationWindow` | `:29-136`: per-denom `BidMinDeposits`; rejects if order already has > `OrderMaxBids` bids; `BSeq` must be 0; order must accept bids; `order.Price() >= msg.Price`; offer must match group spec; provider must exist; **attribute matching against provider attrs + `audit.GetProviderAttributes`** (self-declared attrs prepended); `escrow.AuthorizeDeposits`; reclamation bounds; stores Bid; **`escrow.AccountCreate(bid escrow)` pulls the collateral**; telemetry `akash.bids` |
+| `MsgCloseBid` | `ID`, `Reason` | `:138-192`. Open bid: just close. Active bid: reclamation gate. Lease active with `Reclamation != nil` ⇒ `ErrReclamationNotStarted`; lease reclaiming and `now < Deadline` ⇒ `ErrReclamationWindowNotElapsed`. Then `deployment.OnBidClosed` (pauses group), closes lease/bid/order, **`escrow.PaymentClose` (final settle + payout)** |
+| `MsgCreateLease` | `BidID` | `:209-283`: bid, order, group all open; **`escrow.PaymentCreate(lease payment, payee = provider, rate = bid.Price)`**; stores Lease (copies `bid.ReclamationWindow` into `lease.Reclamation.Window`); marks order/bid matched; **closes all other open bids (`lost`) and `escrow.AccountClose` refunds their collateral** |
+| `MsgCloseLease` | `ID`, `Reason` | `:285-336`: tenant-initiated; closes lease/bid/order; **`escrow.PaymentClose`**; `deployment.OnLeaseClosed`; **if the group is still open, re-creates a fresh Order (automatic relist)** |
+| `MsgWithdrawLease` | `ID` | `:194-207`. **`escrow.PaymentWithdraw`: settle then pay accrued balance to provider** |
+| `MsgLeaseStartReclaim` | `ID`, `Reason` | `:338-379`: lease active, `Reclamation != nil`, not already started; sets `StartedAt = height`, `Deadline = blockTime + Window`, state → `reclaiming`; emits `EventLeaseReclaimStarted` |
+| `MsgUpdateParams` | | `:381-392`: gov-gated |
+
+**Params** (`pkg.akt.dev/go/node/market/v1beta5/params.go:16-58`): `BidMinDeposit` (legacy single-denom)
+`500000uakt`; `BidMinDeposits` `500000uakt, 500000uact`; `OrderMaxBids` 20 (validation cap 500);
+`MinReclamationWindow` 1 h; `MaxReclamationWindow` 720 h.
+**Queries:** `Orders/Order/Bids/Bid/Leases/Lease/Params`.
+**Events:** `EventOrderCreated/Closed`, `EventBidCreated/Closed`, `EventLeaseCreated/Closed`,
+`EventLeaseReclaimStarted`. `LeaseClosedReason` enum: `Invalid=0`, `Owner=1`, `Unstable=10000`,
+`Decommissioned=10001`, `Unspecified=10002`, `ManifestTimeout=10003`, `InsufficientFunds=20000`.
+**Block hooks:** none. **Hooks provided (inbound from escrow):** `OnEscrowAccountClosed`,
+`OnEscrowPaymentClosed` (`x/market/hooks/hooks.go`, wired `app/types/app.go:568-574`); see §4.3.
+**Deps:** Escrow, Deployment, Provider, Audit, Account, Authz, Bank (`x/market/handler/keepers.go`).
+**Genesis:** `{Params, Orders, Bids, Leases}`.
+
+### 3.3 `x/escrow`: store `escrow`, ConsensusVersion 3
+
+**Purpose.** Generic streaming-payment escrow used by deployments (funding accounts) and bids (collateral
+accounts). An `Account` holds multi-denom funds plus an ordered depositor list; `Payment`s attached to an account
+drain it at a per-block `Rate`. Settlement is **fully lazy**: no per-block sweep (EndBlocker returns nil,
+`x/escrow/keeper/abci.go:8-10`). Deep-dive in §4.1.
+
+**State** (raw KVStore, NOT collections; `x/escrow/keeper/key.go:19-26`); note the unusual **state-in-key**
+encoding (§4.1.4):
+
+| Object | Key layout |
+|---|---|
+| `Account` | `0x11 0x00` ‖ state byte (`open=0x01`, `closed=0x02`, `overdrawn=0x03`) ‖ `'/'` ‖ `id.Key()` |
+| `Payment` | `0x12 0x00` ‖ same shape |
+| `BmeAccountsPrefix` | `0x14 0x01`: declared, unused (dead) |
+
+Legacy `v1beta3` prefixes are retained alongside. Types (protos `pkg.akt.dev/go/node/escrow/{id/v1, types/v1,
+v1}` + `types/deposit/v1`):
+
+```
+escrowid.Account{Scope (invalid|deployment|bid), XID string}   // deployment/bid ID rendered to string
+escrowid.Payment{AID Account, XID string}                      // lease ID rendered to string
+AccountState{Owner, State (open|closed|overdrawn), Transferred DecCoins, SettledAt int64 /*height*/,
+             Funds []Balance{Denom, Amount LegacyDec}, Deposits []Depositor}
+Depositor{Owner, Height int64, Source (balance|grant), Balance DecCoin}
+PaymentState{Owner, State, Rate DecCoin /*per block*/, Balance DecCoin /*accrued, unwithdrawn*/,
+             Unsettled DecCoin /*debt when overdrawn*/, Withdrawn Coin}
+```
+
+**Messages:** exactly one, `MsgAccountDeposit{Signer, ID, Deposit{Amount, Sources}}`
+(`x/escrow/handler/server.go:31-44`), the top-up path and **the only way AKT (`uakt`) ever enters a deployment
+escrow** (creation rejects it, §3.1). Everything else is keeper-to-keeper API called by deployment/market.
+**Queries:** `Accounts`, `Payments` (`x/escrow/keeper/grpc_query.go`; prefix search over scope/state/xid).
+**Params:** none. **Events:** none of its own; state changes surface via deployment/market events triggered by
+hooks. **Block hooks:** EndBlocker nil (the settlement sweep was removed). **Deps:** Bank, Authz, Oracle, BME.
+**Genesis:** `{Accounts, Payments}`. Recent fix the Vendor should know: `d7d0205d`. Closed payments are
+persisted **before** account hooks fire (ordering matters for the cascade).
+
+### 3.4 `x/bme`: stores `bme` + transient `bme`, ConsensusVersion 1
+
+**Purpose.** The burn-mint engine between `uakt` and `uact`. Swap requests are queued as ledger records and
+executed in batches on epoch boundaries inside the EndBlocker; a collateral-ratio (CR) circuit breaker halts ACT
+minting when the vault's AKT value degrades. The `bme` module account is the vault and the only Akash module
+account with `Burner+Minter`. Deep-dive in §4.2. Protos: `pkg.akt.dev/go/node/bme/v1`.
+
+**State** (collections; `x/bme/keeper/key.go:12-26`):
+
+| Object | Key | Content |
+|---|---|---|
+| `Params` | Item @ `0x09 0x00` | below |
+| `status` | Item @ `0x04 0x00` | `{Status MintStatus, PreviousStatus, EpochHeightDiff int64}` |
+| `epochs` | Map @ `0x04 0x01` | `"mint"` / `"burn"` → next execution height |
+| `remintCredits` | Map @ `0x01 0x00` | denom → Int (§4.2.3) |
+| `totalBurned` / `totalMinted` | `0x02 0x01` / `0x02 0x02` | lifetime counters |
+| `ledgerPending` | Map @ `0x03 0x01` | queued swaps: `LedgerRecordID{Denom, ToDenom, Source, Height, Sequence}` → `{Owner, To, CoinsToBurn Coin, DenomToMint, Attempts uint32}` |
+| `ledger` | Map @ `0x03 0x02` | executed: `{BurnedFrom, MintedTo, Burner, Minter, Burned/Minted *CoinPrice{Coin, Price LegacyDec}, Spread Coin, RemintCreditIssued/Accrued *CoinPrice}` |
+| `ledgerPendingBalances` | Map @ `0x03 0x03` | denom → in-flight amount (excluded from CR) |
+| `ledgerCanceled` | Map @ `0x03 0x04` | `{Owner, CancelReason, To, CoinsToBurn, DenomToMint}` |
+| `ledgerSequence` | transient Item @ `0x03 0x05` | per-block sequence, reset each BeginBlocker |
+
+`MintStatus` enum: `unspecified=0, healthy=1, warning=2, halt_cr=3, halt_oracle=4`.
+
+**Messages** (`x/bme/handler/server.go`):
+
+| Msg | Behavior |
+|---|---|
+| `MsgBurnMint{Owner, To, CoinsToBurn, DenomToMint}` | `:52-75`: general form → `RequestBurnMint` |
+| `MsgMintACT` | `:77-98`. Sugar: burn `uakt` → mint `uact` |
+| `MsgBurnACT` | `:100-121`. Sugar: burn `uact` → mint `uakt` (redemption) |
+| `MsgFundVault{Authority, Amount, Source}` | `:123-167`: **gov-only**; source must be a non-module account; **bank-sends source → bme vault**; emits `EventVaultFunded` |
+| `MsgUpdateParams` | `:34-50`: gov-gated |
+
+`RequestBurnMint` (`x/bme/keeper/keeper.go:786-865`): only `uakt`↔`uact`; requires a healthy oracle price for
+both denoms; rejects when status ≥ `halt_cr` **except ACT→AKT redemptions remain allowed under a CR-driven halt**
+(blocked under `halt_oracle`); allocates `(height, sequence)`; adds to `ledgerPendingBalances`; **escrows the
+burn-side coin into the module account immediately**; writes the pending record. Execution is in the EndBlocker
+(§4.2.1).
+
+**Params** (`pkg.akt.dev/go/node/bme/v1/params.go:13-44`): `CircuitBreakerWarnThreshold` 9500 bps;
+`HaltThreshold` 9000 bps; `MintSpreadBps` 25; `SettleSpreadBps` 0; `MinEpochBlocks` 10;
+`EpochBlocksBackoffPercent` 10; `MaxEndblockerRecords` 50; `MinMint` 10,000,000 uact; `MaxPendingAttempts` 3.
+Validation: warn > halt, both ≤ 10000, spreads ≤ 1000. The same file also defines the settlement epoch identifier
+`"bme"` and a 1 h oracle TWAP window.
+**Queries:** `Params`, `VaultState`, `Status`, `LedgerRecords`.
+**Events:** `EventMintStatusChange{Previous, New, CollateralRatio}`, `EventVaultFunded`,
+`EventLedgerRecordExecuted`, `EventLedgerRecordCanceled`.
+**Block hooks:** BeginBlocker resets the transient sequence; EndBlocker executes epochs
+(`x/bme/keeper/abci.go:35-213`, §4.2.1).
+**Deps:** Account, Bank (mint/burn/send/`GetSupply`/`GetBalance`), `Oracle.GetAggregatedPrice`.
+**Genesis:** `{Params, State{TotalBurned, TotalMinted, RemintCredits}, Ledger{Records, PendingRecords}}`.
+
+### 3.5 `x/oracle`: stores `oracle` + transient `oracle`, ConsensusVersion 2
+
+**Purpose.** The AKT/USD price oracle. Authorized sources (in practice: exactly one CosmWasm Pyth contract
+address) push timestamped price entries; the EndBlocker computes a TWAP+median aggregate and a health status.
+Consumers: `bme.calculateCR`, `escrow.settleFromAktFallback`, the deployment keeper. Recently moved to time-based
+prices (`319be8e8`). Protos `oracle/v2` (`v1` retained for migration).
+
+**State** (collections; `x/oracle/keeper/key.go:12-24`): `Params` Item @ `0x09`; `latestPriceID`
+Map[`PriceDataID{Source uint32, Denom, BaseDenom}`] @ `0x11 0x01`; `aggregatedPrices`
+Map[`DataID{Denom, BaseDenom}` → `AggregatedPrice`] @ `0x11 0x02`; `pricesHealth` @ `0x11 0x03`; `prices`
+Map[`PriceDataRecordID{Source, Denom, BaseDenom, Timestamp, Sequence}` (custom key codec)] @ `0x11 0x05`; source
+registry `sourceSequence` @ `0x12 0x00` / `sourceID` Map[string→uint32] @ `0x12 0x02`; transient `pricesSequence`
+@ `0x12 0x01`.
+
+**Messages:** `MsgAddPriceEntry{Signer, ID DataID, Price LegacyDec, Timestamp}`; signer must be listed in
+`params.Sources`; **only `Denom=="akt"`, `BaseDenom=="usd"` accepted**; price positive; timestamp monotonically
+non-decreasing per source. `MsgUpdateParams` gov-gated.
+**Params** (`x/oracle` `params.go:31-46`): `MinPriceSources` 1; `MaxPriceStalenessPeriod` 30 s;
+`MaxPriceDeviationBps` 150; `TwapWindow` 5 s; `PriceRetention` 24 h; `PruneEpoch` `"hour"`; `MaxPrunePerEpoch`
+1000; `MaxFutureTimeDrift` 10 s; `Sources` (mainnet: the Pyth contract address, set by v2.1.0; see §5.8);
+`FeedContractsParams []*Any`.
+**Queries:** `Prices`, `Params`, `AggregatedPrice`.
+**Events:** `EventPriceData`, `EventPriceStaleWarning`, `EventPriceStaled`, `EventPriceRecovered`,
+`EventAggregatedPrice`.
+**Block hooks:** EndBlocker (`x/oracle/keeper/abci.go:28-176`): builds the active-source set from params (entries
+from removed sources ignored); drops entries older than `now − staleness`; computes TWAP over `[now − window,
+now]` with boundary clamping; aggregates + writes health; emits `EventAggregatedPrice` only when healthy. Pruning
+of records older than `PriceRetention` runs via the epochs hook (`x/oracle/keeper/prune.go`), ≤
+`MaxPrunePerEpoch` per `"hour"` epoch.
+
+### 3.6 `x/epochs`: store `epochs`
+
+**Purpose.** Osmosis-style named-epoch scheduler exposing `BeforeEpochStart`/`AfterEpochEnd` hooks. Its only
+consumer today is oracle price pruning; BME keeps its own height-based epoch counters (§3.4), though the named
+epoch `"bme"` (`DefaultSettlementEpochName`) is defined. Protos `epochs/v1beta1`.
+
+**State:** `EpochInfo{ID, StartTime, Duration, CurrentEpoch, CurrentEpochStartTime, CurrentEpochStartHeight,
+EpochCountingStarted}` per named epoch (`"hour"`, `"bme"`). **Messages/Params:** none. **Queries:** `EpochInfos`,
+`CurrentEpoch`. **Block hooks:** BeginBlocker (`x/epochs/keeper/abci.go:12-91`); on rollover it emits
+`EventEpochEnd`, runs `AfterEpochEnd` hooks in a cache context (**hook errors are swallowed, non-halting**),
+increments, emits `EventEpochStart`, runs `BeforeEpochStart` the same way. **Genesis:** `{Epochs}`.
+
+### 3.7 `x/provider`: store `provider`, ConsensusVersion 3
+
+**Purpose.** The provider registry: owner address, public host URI (the gateway tenants talk to), self-declared
+attributes (region, tier, GPU models, …), contact info. Bids are validated against these attributes plus audits
+(§3.8). Protos `pkg.akt.dev/go/node/provider/v1beta4`.
+
+**State:** raw KV, single map; `ProviderKey = ProviderPrefix ‖ LengthPrefix(ownerAddr)`;
+`Provider{Owner, HostURI, Attributes, Info{EMail, Website}}`.
+**Messages** (`x/provider/handler/server.go`): `MsgCreateProvider` `:33-51`; `MsgUpdateProvider` `:53-72` (the
+historical "no active leases" guard was removed in v0.32.0 for gas cost and never reintroduced);
+`MsgDeleteProvider` `:74-88`, which **returns `ErrInternal "NOTIMPLEMENTED"`** (in-code TODO: cancel leases first; §7).
+**Queries:** `Providers`, `Provider`. **Params:** none. **Events:** `EventProviderCreated/Updated`
+(`EventProviderDeleted` exists in proto, never emitted). **Genesis:** `{Providers}`.
+
+### 3.8 `x/audit`: store `audit`, ConsensusVersion 3
+
+**Purpose.** Third-party attestation over provider attributes. An auditor signs a subset of a provider's
+attributes; bid matching treats audited attributes first-class via `audit.GetProviderAttributes` (§3.2). Protos
+`pkg.akt.dev/go/node/audit/v1`.
+
+**State:** raw KV; `ProviderKey = PrefixProviderID ‖ LengthPrefix(owner) ‖ LengthPrefix(auditor)`; value
+`AuditedAttributesStore{Attributes}`; read model `AuditedProvider{Owner, Auditor, Attributes}`. Recent fix
+`151b989a` (serialize audited attributes in queries).
+**Messages:** `MsgSignProviderAttributes{Owner, Auditor, Attributes}`;
+`MsgDeleteProviderAttributes{Owner, Auditor, Keys []string}`.
+**Queries:** `AllProvidersAttributes`, `ProviderAttributes`, `ProviderAuditorAttributes`, `AuditorAttributes`.
+**Params:** none. **Events:** `EventTrustedAuditorCreated/Deleted`. **Genesis:** `{Providers}`.
+
+### 3.9 `x/cert`: store `cert`, ConsensusVersion 4
+
+**Purpose.** On-chain x509 certificate registry backing mutual-TLS between tenant clients and provider gateways;
+the chain is the CA-less trust root (a certificate is trusted because its owner published it on-chain). Per D-10
+this module is **not ported** (replaced by JWT auth over on-chain registered signing keys), but its semantics
+matter for the transition window ([07](./07-offchain-and-clients.md)). Protos `pkg.akt.dev/go/node/cert/v1`.
+
+**State:** raw KV; key `0x11` ‖ state (`valid=0x01`, `revoked=0x02`) ‖ `len(owner)` ‖ owner ‖ `len(serial)` ‖
+serial (max serial length 40). `Certificate{State, Cert []byte PEM, Pubkey []byte}`; `CertID{Owner, Serial
+big.Int}`.
+**Messages:** `MsgCreateCertificate{Owner, Cert, Pubkey}`, which parses/validates the x509, stores keyed by serial
+(duplicates rejected); `MsgRevokeCertificate{ID}`, which moves the record to the revoked prefix.
+**Queries:** `Certificates` (filter Owner/Serial/State). **Params/Events:** none.
+**Genesis:** export re-parses every stored x509 and **panics** if the parsed serial mismatches the store key;
+relevant to export tooling in [06](./06-state-and-data-migration.md).
+
+Off-chain companions in-repo: `x/cert/utils/key_pair_manager.go` (local cert generation/load) and
+`x/cert/utils/utils.go` (`LoadAndQueryCertificateForAccount`: local validity + on-chain presence check). **JWT
+auth is off-chain only today:** `akash auth jwt` (`cmd/akash/cmd/auth.go`) signs keyring-backed JWTs via
+`pkg.akt.dev/go/util/jwt` (`--exp/--nbf/--access/--scope`); no on-chain JWT state; verification is provider-side.
+
+### 3.10 `x/wasm` ("awasm") + wasmd: stores `awasm` and `wasm`
+
+**Purpose.** `wasmd` is the standard CosmWasm smart-contract module. Akash wires it **only** to host the Pyth
+oracle contract pipeline (§3.11) and wraps it with a thin guardrail module `awasm` (store `awasm`,
+ConsensusVersion 1, protos `wasm/v1`) that filters what contracts may do.
+
+**awasm state:** `Params{BlockedAddresses []string}`. **Messages:** `MsgUpdateParams` only. **Queries:** `Params`.
+**Events:** `EventMsgBlocked{ContractAddress, MsgType, Reason}`.
+
+**The message filter** (`x/wasm/keeper/msg_filter.go:64-180`, installed via `WithMessageHandlerDecorator`,
+`app/types/app.go:495-497`) constrains every native message a contract emits: Bank `Send` ALLOW unless the
+recipient is blocked; Bank `Burn` DENY; Staking/Distribution/Gov/IBC/IBC2/Custom DENY; Wasm (contract→contract)
+ALLOW; protobuf `Any`: **ALLOW exactly one type-url, `/akash.oracle.v2.MsgAddPriceEntry`** (`:171`), the single
+pinhole through which Pyth prices reach `x/oracle`; everything else DENY.
+
+**Query side:** the stargate query whitelist is **empty** (`x/wasm/bindings/query_whitelist.go`: all stargate
+queries from contracts rejected) and the custom-querier handlers are commented out
+(`x/wasm/bindings/custom_querier.go` returns UnsupportedRequest), though the plugin wiring exposes
+`AkashQuery::OracleParams` (`app/types/app.go:499-503`). See §7.
+
+**wasmd configuration is hard-coded** (`app/app.go:158-163`): `MemoryCacheSize=100MB`,
+`SmartQueryGasLimit=3,000,000`, `ContractDebugMode=true` (in-code comment: "MUST be false in production";
+outstanding defect, §7). Capabilities: builtin + `"akash"`.
+
+### 3.11 `contracts/`: in-repo CosmWasm (Rust) crates
+
+**Purpose.** The oracle feed path: an off-chain pusher submits signed Pyth price updates to a CosmWasm contract,
+which verifies them and emits the one whitelisted native message (`MsgAddPriceEntry`) into `x/oracle`. Per D-22
+this layer collapses into direct Pyth pull-oracle reads on the targets; it is documented because its
+**verification semantics** define what "a valid price" means today.
+
+Cargo workspace (Rust 1.86, edition 2021, `panic=abort`, overflow checks; `cosmwasm-std 3.0.2`, `cw-storage-plus
+3.0.1`). Contract bytecode is embedded in Go upgrade handlers (`upgrades/software/v2.1.0/contracts.go`,
+`.../v2.0.0/contracts.go`; `script/wasm2go.sh`) and uploaded via `MsgStoreAndMigrateContract` during upgrades.
+
+| Crate | Version | Role |
+|---|---|---|
+| `contracts/pyth_pro` | 1.0.1 | Newest consumer (`0dbfd230`): delegates VAA signature verification to `pyth_vaa` instead of embedding a Wormhole guardian set |
+| `contracts/pyth` | 1.0.1 | Original consumer; verifies against the wormhole contract |
+| `contracts/pyth_vaa` | 1.0.1 | "Pyth router-signed VAA verifier"; near-stateless verifier queried by `pyth_pro` |
+| `contracts/wormhole` | 1.0.0 | Full Wormhole core: guardian sets, VAA archive, governance packets |
+
+`pyth_pro`: `Config{admin, pyth_vaa_contract, update_fee Uint256, price_feed_id, default_data_id{denom:"akt",
+base_denom:"usd"}}`; stores `PriceFeed{symbol "AKT/USD", price, conf, expo=-8, publish_time, prev_publish_time}`.
+`execute_update_price_feed` (`contracts/pyth_pro/src/contract.rs:90-231`): requires attached `uakt` funds ≥
+`update_fee`; parses the Pyth accumulator update (PNAU, from the Hermes service); smart-queries `pyth_vaa`
+`VerifyVAA{vaa, block_time}`; verifies the Merkle proof; parses the price-feed message; asserts feed id, non-zero
+price, `expo == -8`, `publish_time >=` stored; saves the feed; emits
+`CosmosMsg::Any{"/akash.oracle.v2.MsgAddPriceEntry"}` with manual protobuf encoding
+(`contracts/pyth_pro/src/oracle.rs:89`). `pyth_vaa` holds a router-verifier config (router set index, router
+keys, expected emitter chain/address). `wormhole` maintains guardian sets, sequences, a VAA archive, and
+governance packets (ContractUpgrade/GuardianSetUpgrade/SetFee/TransferFee).
+
+### 3.12 `x/take`: dead code, not wired
+
+Historic protocol-fee module: skimmed a percentage of every escrow payout to the community pool. Its store was
+deleted at the v2.0.0 upgrade; it is absent from keepers, stores, module lists, and module-account permissions
+(`app/types/app.go:120-131`, `app/mac.go:15-27`). Residual code: `SubtractFees(amt)` at
+`findRate(denom) = DenomTakeRates[denom] ?? DefaultTakeRate` (%); legacy params `DefaultTakeRate=20`, `uakt=2`
+(`pkg.akt.dev/go/node/take/v1/params.go:29-38`). **Net effect today: providers keep 100% of lease payments; the
+current chain has no protocol take.** Whether the target chain re-introduces a take is a target-design question
+([03](./03-solana-architecture.md)/[04](./04-ethereum-architecture.md)); it is *not* current behavior, and parity
+tests ([09](./09-testing-and-verification.md)) must model zero take.
+
+## 4. Deep-dives: behavior the target chain must reproduce faithfully
+
+These three subsections are the heart of the protocol. [14](./14-appendix-protocol-mapping.md) maps each element
+to target-chain constructs; D-19/D-20/D-21 fix the porting decisions.
+
+### 4.1 Escrow mechanics (`x/escrow/keeper/keeper.go`)
+
+#### 4.1.1 Lazy settlement math
+
+There is **no per-block escrow work**. Each account records `SettledAt` (the height of its last settlement).
+Whenever anything touches the account, `accountSettle` (`:535-604`) runs:
+
+```
+heightDelta = currentHeight − account.SettledAt
+for each open payment:      owed = payment.Rate × heightDelta     (per-denom, LegacyDec)
+for each overdrawn payment: owed = payment.Unsettled              (carried debt, cleared on success)
+```
+
+`accountSettleFullBlocks` (`:1282-1333`) transfers `owed` from account funds into each `Payment.Balance`
+(accrued-but-unwithdrawn earnings), truncating to integer micro-units at withdrawal. Rates are `DecCoin` per
+block; with the 6.5 s target block time (`util/network/network.go:8`) a price of X uact/block ≈ X/6.5 uact/s,
+the basis for the per-second conversion fixed in D-21. If funds cannot cover a payment in full, the shortfall
+becomes that payment's `Unsettled` debt and the payment goes overdrawn. `SettledAt` advances to the current
+height, except when the account is already overdrawn, in which case it is frozen (no further accrual against a
+dead account).
+
+#### 4.1.2 Settlement trigger points
+
+Settlement runs **only** at these interaction points (no timer, no sweep):
+
+| Trigger | Notes |
+|---|---|
+| `AccountClose` | deployment close, losing-bid refund |
+| `AccountDeposit` | **only when the account is overdrawn** (top-up rescue path) |
+| `PaymentCreate` | lease creation |
+| `PaymentWithdraw` | provider withdrawal (`MsgWithdrawLease`) |
+| `PaymentClose` | lease/bid close |
+| `AccountSettle` (public keeper API) | **no in-repo caller**; exists for external use |
+
+Consequence the Vendor must internalize: **overdrawn detection is event-driven.** A lease whose escrow ran dry at
+height h is not observed as overdrawn until someone interacts (typically the provider's periodic withdraw).
+Nothing in consensus forces timely detection; D-21 adds a permissionless settle entrypoint on the target chain
+precisely because of this.
+
+#### 4.1.3 Deposits: multi-depositor FIFO + authz grants
+
+Deposits carry `Deposit{Amount, Sources}`, `Sources ∈ {SourceBalance, SourceGrant}`. `AuthorizeDeposits`
+(`:176-345`) walks sources in order for the single signer:
+
+- `SourceBalance`: spend from the signer's own spendable bank balance, capped at the remainder ⇒
+  `Depositor{signer, source=balance}`.
+- `SourceGrant`: resolve `x/authz` grants of type `/akash.escrow.v1.DepositAuthorization` where the tx signer is
+  grantee (`authzKeeper.GetGranteeGrantsByMsgType`); rebuild a synthetic msg for just the requested amount
+  (`:252-282`); `TryAccept(partial=true)` decrements the grant's `SpendLimits` and persists it ⇒
+  `Depositor{granter, source=grant}`. `DepositAuthorization{SpendLimit Coin (legacy), Scopes []Scope, SpendLimits
+  Coins}`. Grants are **authz**, not feegrant (feegrant covers tx fees only). Supported grantee msg types:
+  `MsgAccountDeposit`, `MsgCreateDeployment`, `MsgCreateBid`. Since v0.34.0, only **one** authz depositor per
+  deployment is supported.
+
+Any unfunded remainder ⇒ `ErrInvalidDeposit` (whole tx reverts). `fetchDepositsToAccount` (`:471-533`) then
+bank-sends each depositor's coins into the `escrow` module account, resets negative funds to zero first,
+increments `Funds`, and **appends** to the ordered `Deposits` list; deposit order is preserved.
+
+**Spend is FIFO; refunds restore grants.** `deductFromBalance` (`:1211-1280`) consumes depositors oldest-first
+per denom, pruning exhausted entries and accumulating per-denom `Transferred` totals. On account close/overdraw,
+`saveAccount` (`:1022-1104`) refunds each surviving depositor's remaining balance from the module account, and
+**if the depositor was a grant, the refund is credited back to the granter's
+`DepositAuthorization.SpendLimits`** (`:1050-1075`). Console's fee-sponsorship product depends on this
+restore-on-refund behavior (D-21 preserves it as an explicit delegated-deposit allowance).
+
+#### 4.1.4 Overdrawn encoding
+
+"Overdrawn" is encoded twice, and both encodings are load-bearing:
+
+1. **Negative `Funds`.** When FIFO deduction cannot cover the owed amount, the remainder is subtracted anyway,
+   driving `Funds[denom]` negative; the negative balance *is* the overdraft marker (`deductFromBalance`,
+   `:1211-1280`). Later deposits reset negatives to zero before crediting (`:471-533`).
+2. **State-in-key.** The record is deleted from its `open`-prefixed key and rewritten under the `overdrawn` state
+   byte (§3.3). Every read probes all three state keys (`:1335-1375`).
+
+On overdraw: account → `StateOverdrawn`; every attached payment → `StateOverdrawn` with residual debt in
+`Unsettled`; accrued balances are paid out (`paymentWithdraw`); remaining depositor balances refunded; hooks fire
+(§4.3). Raw writers `SaveAccountRaw/SavePaymentRaw` (`:947-962`) bypass hooks/refunds, used only by the denom
+migration.
+
+#### 4.1.5 AKT-fallback settlement, and the no-fee payout
+
+`settleFromAktFallback` (`:609-687`): if an account is overdrawn on `uact` but still holds `uakt`, **and**
+`bme.GetMintStatus() >= halt_cr` (the engine is halted, so AKT cannot become ACT), **and** the oracle has a
+positive AKT price, then the keeper converts the unsettled ACT debt at the oracle price
+(`unsettled_uact / akt_price ⇒ uakt`), deducts from the account's AKT funds, bank-sends escrow → provider
+directly in `uakt`, clears the `uact` `Unsettled`, and reopens the payment. Debt is not carried past exhausted
+funds. This is the safety valve keeping providers whole in AKT when ACT liquidity is frozen; D-21 ports it.
+
+Payout itself, `paymentWithdraw` (`:1187-1209`): truncate `Payment.Balance` to integer micro-units, bank-send
+escrow module account → payment owner (the provider), `Withdrawn += earnings`, `Balance −= earnings`. **No
+take/fee deduction anywhere in the path: the provider receives 100%** (§3.12).
+
+### 4.2 The BME engine (`x/bme/keeper/`)
+
+#### 4.2.1 Swap queue and epoch execution
+
+A swap is two-phase. Phase 1 (msg handling, §3.4): validate, escrow the burn-side coins into the vault, record a
+pending ledger entry keyed `(denom, toDenom, source, height, sequence)`. In-flight amounts sit in
+`ledgerPendingBalances` and are **excluded from the collateral ratio** so queued swaps do not distort the
+breaker. Phase 2 is the EndBlocker (`x/bme/keeper/abci.go:35-213`), per block in order:
+
+1. **Burn epoch** (`uact → uakt` redemptions): if `epochs["burn"] ≤ height`, iterate pending burn records,
+   executing at most `MaxEndblockerRecords`; next epoch at `height + MinEpochBlocks`.
+2. **Status update** (`mintStatusUpdate`, `keeper.go:882-946`): recompute CR, transition `MintStatus`, emit
+   `EventMintStatusChange` on change.
+3. **Mint epoch** (`uakt → uact`): if the breaker just reset (previous ≥ `halt_cr`, now ≤ `warning`), recompute
+   the next epoch first; else if due **and** status healthy/warning, iterate pending mint records; a
+   post-condition check aborts the walk if CR trips mid-loop.
+
+Each record executes in a `CacheContext` (isolated child state merged only on success): success ⇒ write-through +
+move to the executed `ledger`; fatal error ⇒ cancel with reason (refund path); retriable error ⇒ `Attempts++`,
+canceled at `MaxPendingAttempts` (`BMCancelReasonMaxAttempts`). Execution mints the target denom at the oracle
+price, applies `MintSpreadBps` (25 bps withheld on mint; `SettleSpreadBps` 0), and records
+`{Burned, Minted, Spread, RemintCredit*}` as `CoinPrice` pairs (amount + execution price).
+
+#### 4.2.2 Collateral ratio and circuit breaker
+
+`calculateCR` (`keeper.go:742-784`):
+
+```
+CR = (vault_uakt − pending_uakt) × (price_AKT / price_ACT) / TotalSupply(uact)
+```
+
+A zero/absent oracle price ⇒ `halt_oracle` (everything blocked). Otherwise (bps of fully collateralized):
+CR < 9000 ⇒ `halt_cr`; CR < 9500 ⇒ `warning`; else `healthy`. Under `halt_cr`, **ACT→AKT redemptions still
+execute** (they raise CR); new mints do not. Under `warning`, epochs stretch:
+`EpochHeightDiff = MinEpochBlocks × (1 + backoff%)^steps`, `steps = (warn − cr_bps)/10`, capped at 14,400 blocks
+(~26 h at 6.5 s), throttling mint throughput as collateral degrades.
+
+#### 4.2.3 Remint credits and vault funding
+
+Remint credits are supply-accounting bookkeeping (the implementation does true burn+mint; comment at
+`x/bme/keeper/keeper.go:64-65`): when AKT is burned on the mint side, the burned amount accrues to
+`remintCredits["uakt"]` (`keeper.go:601-617`; accrual tracked for non-ACT denoms only). When an ACT→AKT
+redemption later mints AKT, it draws that credit down first; the payout splits into a "remint-issued"
+(credit-backed) portion and a freshly-minted portion (`keeper.go:516-541`), so net new AKT supply from the
+engine trends to zero. The vault is funded only by governance: `MsgFundVault` (§3.4) and, historically, the
+v2.1.0 community-pool transfer (§5.9). Vault seeding on the target chain: D-20 / [05](./05-token-migration.md).
+
+### 4.3 The escrow → market → deployment close cascade
+
+Closing anything in Akash converges on escrow state transitions, which fan back out through hooks
+(`x/market/hooks/hooks.go`, wired `app/types/app.go:568-574`). This is the most intricate control flow in the
+protocol; target designs must reproduce it exactly (cascade tests in [09](./09-testing-and-verification.md)).
+
+```mermaid
+flowchart TD
+    subgraph ESC["x/escrow state transitions"]
+        SA["saveAccount: account -> closed / overdrawn<br/>(refund depositors FIFO, restore grants)<br/>keeper.go:1022-1104"]
+        SP["savePayment: payment -> closed / overdrawn<br/>(pay accrued balance to provider)<br/>keeper.go:1106-1129"]
+    end
+
+    SA -->|"OnEscrowAccountClosed(acc)"| MA{"acc.ID parses as<br/>DeploymentID?"}
+    SP -->|"OnEscrowPaymentClosed(pmt)"| MP{"pmt.ID parses as<br/>LeaseID and bid active?"}
+
+    MA -->|"no: bid collateral account"| STOP1["no cascade<br/>(bid accounts are closed BY market)"]
+    MA -->|"yes, deployment active"| DC["deployment.CloseDeployment"]
+    DC --> GS{"acc.State == overdrawn?"}
+    GS -->|yes| GIF["groups -> GroupInsufficientFunds"]
+    GS -->|no| GC["groups -> GroupClosed"]
+    GIF --> PG["per closable group:<br/>deployment.OnCloseGroup +<br/>market.OnGroupClosed"]
+    GC --> PG
+    PG --> OC["market closes the group's<br/>open order + open bids"]
+
+    MP -->|yes| LC1["market.OnOrderClosed +<br/>market.OnBidClosed"]
+    LC1 --> LR{"payment overdrawn?"}
+    LR -->|yes| LIF["OnLeaseClosed(state=insufficient_funds,<br/>reason=InsufficientFunds)"]
+    LR -->|no| LCL["OnLeaseClosed(state=closed,<br/>reason=Unspecified)"]
+    LIF --> DEP2["deployment.OnBidClosed(gid)<br/>-> OnPauseGroup"]
+    LCL --> DEP2
+```
+
+Directional summary:
+
+- **Deployment-initiated close** (`MsgCloseDeployment`): deployment calls `escrow.AccountClose` and *nothing
+  else*; settlement, provider payout, depositor refunds, group closure, order/bid/lease closure all happen
+  inside the escrow save + hook chain.
+- **Funds exhaustion**: any settlement trigger (§4.1.2) can flip the account/payment to overdrawn; hooks close
+  the lease with `InsufficientFunds` (20000) and mark groups `insufficient_funds` (distinct from `closed`; a
+  top-up + restart path exists).
+- **Market-initiated closes** (`MsgCloseBid`/`MsgCloseLease`) call `escrow.PaymentClose`/`AccountClose`
+  themselves, then do their own order/bid bookkeeping; the hook still fires but finds the bid already inactive
+  (idempotence matters). `MsgCloseLease` on a still-open group **relists** a fresh order (§3.2).
+- Ordering subtlety: closed payments are persisted before account hooks run (`d7d0205d`); hook handlers observe
+  consistent payment state.
+
+## 5. Chain-level configuration
+
+### 5.1 Tokens and denominations
+
+Denom constants: `pkg.akt.dev/go/sdkutil/init.go:8-34`.
+
+| Family | base | mid | display | exponent | Notes |
+|---|---|---|---|---|---|
+| AKT | `uakt` | `makt` | `akt` | 6 | staking bond denom (`sdkutil/init.go:21`), gas fees, gov deposits |
+| ACT | `uact` | `mact` | `act` | 6 | lease pricing denom; **`SendEnabled=false`** (`cmd/akash/cmd/genesis.go:121-130`); moves only via module logic (escrow, BME) |
+| USD | `uusd` | `musd` | `usd` | 6 | oracle quote unit only, not a bankable asset |
+
+Genesis bank metadata (`cmd/akash/cmd/genesis.go:224-265`) defines AKT correctly; ACT's `Display` is `uact`
+instead of `act` (defect, §7). D-19 ports ACT with equivalent non-transferability; D-03/D-04 fix 6 decimals for
+AKT on the targets to match `uakt` micro-units 1:1.
+
+### 5.2 Consensus, block time, tx processing
+
+- CometBFT consensus, ~**6.5 s average block time**, the constant used in lease/deployment time math
+  (`util/network/network.go:8` `AverageBlockTime = 6500ms`); first-init node default `TimeoutCommit = 5s`
+  (`util/cli/configs.go:324`). Per-block escrow rates convert to per-second at this basis under D-21.
+- **Ante chain is entirely stock SDK** (`app/ante.go:46-58`): SetUpContext, ValidateBasic, TxTimeoutHeight,
+  ValidateMemo, ConsumeGasForTxSize, DeductFee (+feegrant), SetPubKey, ValidateSigCount, SigGasConsume,
+  SigVerification, IncrementSequence. No custom fee or deposit decorators; the constructor's
+  GovKeeper/FeegrantKeeper non-nil checks (`app/ante.go:38-44`) are vestigial.
+- **Unordered transactions are ENABLED** (`authkeeper.WithUnorderedTransactions(true)`, `app/types/app.go:279`):
+  txs may commit without strict per-account sequence ordering; client and indexer tooling must not assume
+  monotonic sequences.
+- `PrepareProposal`/`ProcessProposal` are deliberate no-ops (`app/app.go:265-270`); no custom mempool, no vote
+  extensions.
+- **Fees:** flat min-gas-price, no fee market (no EIP-1559 analogue); set via `baseapp.SetMinGasPrices`
+  (`cmd/akash/cmd/app_creator.go:98`). Defaults disagree in-tree: `0.0025uakt` (`cmd/akash/cmd/config.go:26`) vs
+  `0.025uakt` (`util/cli/configs.go:361`); the community-accepted mainnet floor is `0.025uakt` (§7).
+
+### 5.3 Staking / slashing / gov / distribution parameters
+
+From `MainnetGenesisParams()` (`cmd/akash/cmd/genesis.go:219-299`), the only in-repo statement of intended
+values; live values must be read from mainnet state (§8):
+
+| Module | Params |
+|---|---|
+| staking | UnbondingTime 14 days; MaxValidators 100; BondDenom `uakt`; MinCommissionRate 0.05 |
+| distribution | CommunityTax 0; WithdrawAddrEnabled true |
+| gov | MinDeposit 2,500,000,000 uakt (2,500 AKT); MaxDepositPeriod 14 days; VotingPeriod 3 days; Quorum 0.2; Threshold/Veto = SDK defaults |
+| crisis | ConstantFee 500,000,000,000 uakt |
+| slashing | SignedBlocksWindow 30,000 blocks; MinSignedPerWindow 0.05; DowntimeJailDuration 1 min; SlashFractionDoubleSign 0.05; SlashFractionDowntime 0 (no liveness slashing) |
+
+Extras: `ExpeditedMinDeposit` only in the testnetify path (`150000000uakt`, `app/testnet.go:290`); testnet
+overrides at `cmd/akash/cmd/genesis.go:301-316`. **gov `MaxMetadataLen` is raised to 10,200** (vs SDK default
+256; `app/types/app.go:377-379`); off-chain proposal tooling depends on embedding large metadata. The legacy gov
+router with the paramproposal route is still registered (`app/types/app.go:366-375`).
+**Mint/inflation:** stock `x/mint` (`app/types/app.go:355-363`; module `app/modules.go:85-91`, inflation-fn
+override explicitly nil at `:89`). **Inflation parameters are NOT in this repo**: `GenesisParams.MintParams` is
+declared but never assigned (`cmd/akash/cmd/genesis.go:210`); live values are mainnet state only (§8, Q-19).
+**Vesting:** stock `x/auth/vesting` (Base/Delayed/Continuous) via `akash genesis add-account`
+(`cmd/akash/cmd/genaccounts.go:24-110`); no custom types; the live inventory is mainnet state (§8).
+
+### 5.4 Module accounts, permissions, blocked receivers, stores
+
+`app/mac.go:15-27`:
+
+| Module account | Permissions |
+|---|---|
+| `fee_collector`, **`escrow`** (the escrow pool), `distribution` | none |
+| **`bme`** (the BME vault) | **Burner, Minter** |
+| `mint` | Minter |
+| `bonded_tokens_pool` / `not_bonded_tokens_pool` | Burner, Staking |
+| `gov` | Burner |
+| `transfer` (IBC) | Minter, Burner |
+
+`allowedReceivingModAcc` is **empty** ⇒ every module account is blocked from receiving external bank sends
+(`app/app.go:85,496-504`); funds enter module accounts only through module logic. The balances these accounts
+hold at snapshot are exactly the funds routed to the Wind-down Reserve under D-05
+([05](./05-token-migration.md)).
+
+**KV stores** (`app/types/app.go:605-637`); cosmos: consensus, auth, feegrant, authz, bank, staking, mint,
+distribution, slashing, gov, params, ibc, upgrade, evidence, ibctransfer, wasm; akash: epochs, escrow,
+deployment, market, provider, audit, cert, awasm, oracle, bme. Transient: params, bme, oracle. Legacy `x/params`
+subspaces are retained for the stock modules plus deployment/market key tables (`app/types/app.go:582-603`);
+other Akash modules store params under key `0x01` in their own stores.
+
+**Cross-module hooks** (`app/types/app.go:554-579`): staking → distribution + slashing (stock); gov → empty
+multihook; **escrow → market** (§4.3); **epochs → oracle** (price pruning, §3.5). Hazard: gov routes are
+registered before `SetupHooks()` runs (§7 item 6).
+
+### 5.5 Module ordering constraints, and why
+
+Block-lifecycle ordering is computed from declared constraints via `util/partialord` (`app/app.go:325-395`), not
+hand-listed. The declared partial order:
+
+- **BeginBlockers:** `epochs` FIRST (epoch rollovers precede everything consuming epoch hooks);
+  `distribution → slashing → evidence → staking` (stock reward/penalty pipeline); `staking → ibc`; **`oracle`
+  before `bme` before `escrow`**; `awasm` before `wasm`; `transfer` before `wasm`.
+- **EndBlockers:** `gov`, `staking` first (stock); the same oracle→bme→escrow chain governs the modules'
+  end-of-block work.
+- **InitGenesis** is an explicit list ending `… epochs, bme, escrow, awasm, wasm` (`app/app_configure.go`).
+
+The `oracle → bme → escrow` chain is the protocol's economic dataflow, and it is why ordering is semantics, not
+style: the oracle EndBlocker publishes the aggregated AKT/USD price; BME's EndBlocker consumes that price to
+execute queued swaps and recompute the circuit breaker; escrow's AKT-fallback settlement (§4.1.5) consumes both
+the price and BME's halt status. Reordering changes which price a given block's mints and settlements see. On
+target chains with no block-lifecycle hooks, the same constraint re-materializes as "read the freshest oracle
+price inside the swap/settle instruction/function"; see
+[03](./03-solana-architecture.md)/[04](./04-ethereum-architecture.md).
+
+### 5.6 Discovery service: the client/server version contract
+
+The node exposes an Akash-specific discovery endpoint: gRPC `akash.discovery.v1.Discovery/GetInfo`, REST
+`GET /akash/discovery/v1/info`, and CometBFT JSON-RPC method `"akash"` (`app/app.go:538-541,570-578`). Payload:
+`chain_id`, `node_version`, **`min_client_version`**, and per-API module version maps (deployment `v1beta4`,
+market `v1beta5`, oracle `v2`, …). This is a hard client/server contract: `chain-sdk` and the `akt` CLI negotiate
+API versions from it (`pkg.akt.dev/go/node/client/README.md`; `testutil/network/rpc.go:12,26` exists solely to
+satisfy `aclient.DiscoverClient` in tests). Any target-chain RPC/indexer stack must provide an equivalent
+capability/version negotiation surface ([07](./07-offchain-and-clients.md)).
+
+### 5.7 IBC surface
+
+Wired at `app/types/app.go:336-551`:
+
+- IBC core with the 07-tendermint light client only.
+- **Token transfer (ICS-20) only.** v1 router with `transfer` and `wasm` ports, **plus the v2 router (IBC
+  "Eureka")**: `transferv2.NewIBCModule` + a wasm prefix route (`app/types/app.go:546-551`).
+- **Absent:** ICA host/controller (added v0.18.0, removed v0.20.0), packet-forward-middleware, ICS-29 fee
+  middleware, callbacks, async-icq, capability module.
+- `ibctransfer` module account holds Minter+Burner (voucher mint/burn; `app/mac.go:25`).
+
+Implication: cross-chain AKT exists as ICS-20 vouchers on other Cosmos chains (Osmosis, Cosmos Hub, …), backed by
+`uakt` locked in per-channel IBC escrow addresses on Akash. Those balances are snapshot inputs (D-07, §8,
+Q-03/Q-19). Naming trap: "Hermes" in `_run/node` scripts is the **Pyth Hermes price service**, not the IBC
+relayer of the same name (`_docs/pyth-integration.md:304-305`).
+
+### 5.8 Hard-coded addresses and trust roots
+
+- `akash1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrqyagled`: the Pyth price contract; baked into the
+  v2.1.0 upgrade (`upgrades/software/v2.1.0/upgrade.go:66`) and set as the **sole** authorized oracle source
+  (`oracle.Params.Sources`, `MinPriceSources=1`). **Mainnet price truth is a single-source trust root today.**
+- `akash10d07y265gmmuvt4z0w9aw880jnsr700jhe7z0f`: the gov module account; admin of the Pyth/Wormhole contracts
+  and the `authority` on every `MsgUpdateParams`/`MsgFundVault`.
+- Wormhole guardian-set updates bypass Akash governance: any account may submit a valid guardian VAA
+  (`guardian_set_expirity = 86400`; `_docs/governance-updates.md:44-57`).
+
+### 5.9 Upgrade history
+
+Upgrades self-register via a plugin registry (`upgrades/types/types.go`; installed `app/upgrades.go:34-56`;
+height patches run in BeginBlocker `app/app.go:446-454`, currently none). Convention:
+`_docs/adr/adr-001-network-upgrades.md`. Only v2.1.0 remains in-tree; history per CHANGELOG + git:
+
+| Upgrade | One-line summary |
+|---|---|
+| akash_v0.15.0 | Baseline of the named-upgrade era (Cosmos SDK v0.44.x) |
+| v0.18.0 | Added Interchain Accounts (ICA) |
+| v0.20.0 | Removed ICA |
+| v0.24.0 | v1beta3 stores; GPU resource units; multi-denom `MinDeposits`; "Take Pay" introduced (added `take`, `agov`, `astaking`, feegrant) |
+| v0.26.0 | Incremental release (see `upgrades/CHANGELOG.md`) |
+| v0.28.0 | Added `ResourcesOffer` to bids |
+| v0.30.0 | Incremental release (see `upgrades/CHANGELOG.md`) |
+| v0.32.0 | Dropped provider active-lease check on update (gas cost) |
+| v0.34.0 | Authz deposit-grant reuse (refund restores spend limit) |
+| v0.36.0 | Feegrant ante fix |
+| v0.38.0 | AEP-61 key-layout performance work |
+| v1.0.0 | Cosmos SDK 0.47; deleted custom `astaking`/`agov` |
+| v1.1.0 | Repaired overdrawn escrow accounts |
+| v1.2.0 | deployment+market state → collections IndexedMap |
+| v2.0.0 | Added epochs/oracle/awasm/wasm/bme stores (dual-token protocol); **deleted `x/take` store**; release later retracted in go.mod (superseded by v2.1.0) |
+| v2.1.0 | Current (`upgrades/software/v2.1.0/upgrade.go:54-138`): store migrations (oracle v1→v2 **wipes the oracle store**; deployment v7 drains `pendingDenomMigrations`; market v8 no-op); stores+migrates the Pyth contract (admin `AllowNobody`); sets oracle `Sources`; akashnet-2-gated move of 427,414,453 uakt distribution→escrow module account (manual `FeePool.CommunityPool` decrement); backfills `bme.MaxPendingAttempts=3` and market reclamation windows |
+
+The testnetify/upgrade-test tooling (`akash in-place-testnet`, `tests/upgrade`, Cosmovisor v1.7.1) is the current
+chain's operational muscle for coordinated upgrades, context for the sunset upgrade in
+[10](./10-rollout-and-cutover.md) (D-18).
+
+### 5.10 Genesis export shape (per custom module)
+
+Zero-height export (`app/export.go`; folds validator dust into the community pool at `:151-157`) is the basis
+for migration snapshots ([06](./06-state-and-data-migration.md)):
+
+| Module | Export shape |
+|---|---|
+| deployment | `{Params{MinDeposits}, Deployments: [{Deployment, Groups[]}]}` |
+| market | `{Params, Orders, Bids, Leases}` |
+| escrow | `{Accounts, Payments}` (no params) |
+| provider | `{Providers}` |
+| audit | `{Providers: []AuditedProvider}` |
+| cert | `{Certificates: [{Owner, Certificate}]}`; export re-parses x509s, panics on serial mismatch |
+| oracle | `{Params, GenesisSourceID, GenesisLatestPricesIDs}` |
+| bme | `{Params, State{TotalBurned, TotalMinted, RemintCredits}, Ledger{Records, PendingRecords}}` |
+| epochs | `{Epochs}` |
+| awasm | `{Params{BlockedAddresses}}` |
+| take | `{Params}`; not wired, not exported |
+
+### 5.11 Forked core dependencies: a standing maintenance burden
+
+All three foundational dependencies are **Akash forks** (go.mod replaces):
+
+| Upstream | Fork |
+|---|---|
+| cosmos-sdk v0.53.6 | `github.com/akash-network/cosmos-sdk v0.53.7-akash.2` |
+| cometbft v0.38.21 | `github.com/akash-network/cometbft v0.38.21-akash.1` |
+| gogoproto v1.7.2 | `github.com/akash-network/gogoproto v1.7.0-akash.2` |
+
+Plus: ibc-go/v10 v10.5.0 (IBC v2/Eureka-capable), wasmd v0.61.7 + wasmvm/v3 v3.0.2, store v1.1.2, iavl v1.2.6,
+rosetta v0.50.12 (wired `cmd/akash/cmd/root.go:79`), Go 1.26.2. Maintaining a sovereign chain currently means
+rebasing three forks against upstream security releases indefinitely, one of the operational-burden drivers
+quantified in [00](./00-executive-summary.md) and [02](./02-target-selection.md).
+
+## 6. Off-chain seams
+
+Everything here keeps working only if the target chain (or its indexer/API layer) preserves the corresponding
+contract. Adaptation is specified in [07](./07-offchain-and-clients.md).
+
+| Consumer | Seam into the chain |
+|---|---|
+| **`pkg.akt.dev/go`** (successor to `akash-api`; pinned v0.2.14, `go.mod:51`) | The shared contract: ALL proto/state types, denom constants, params, `sdkutil` encoding, event helpers, discovery registry. Every Go client of Akash imports it. Replacing the chain starts with replacing/forking this module. |
+| **`pkg.akt.dev/go/cli`** (v0.2.4, `go.mod:52`) | The entire `query`/`tx`/`keys`/`events`/`genesis` CLI tree and flag definitions: the node repo has **no** `x/*/client/cli` packages; the `akash` binary (`cmd/akash/cmd/root.go:69-87`) mounts this external module. |
+| **`pkg.akt.dev/go/sdl`** (v0.2.2, `go.mod:53`) | SDL parsing/validation used by node tests and provider tooling. |
+| **provider-services** (`akash-network/provider`) | The provider daemon: consumes market events (bid engine), x/cert certificates, JWTs, and the discovery endpoint; dev seams at `_run/common-commands.mk:49-84` (auth-server, send-manifest, `--auth-type` JWT) and `_docs/development-environment.md:28-57`. |
+| **chain-sdk** (`@akashnetwork/chain-sdk`, TypeScript) | Requires an RPC client exposing the `Akash(ctx)` discovery method (§5.6; `testutil/network/rpc.go`). |
+| **Indexers / Console** | grpc-gateway REST + typed events + the `cosmossdk.io/schema` state-streaming seam: newer modules implement `ModuleCodec()` (`x/bme/module.go:190-193`, `x/oracle/module.go:201`, `x/epochs/module.go:166`). **Partial coverage**: only collections-based modules; escrow/provider/audit/cert (raw KV) do not stream, so indexers combine event-tailing with query polling. |
+| **`akash-network/net`** repo | Chain metadata contract: `https://raw.githubusercontent.com/akash-network/net/master/mainnet/meta.json` (and `sandbox-2/meta.json`); RPC endpoints, binary URLs, upgrade matrix consumed by installers and tooling. |
+| **snapshots.akash.network** | Node bootstrap: `https://snapshots.akash.network/<network>/latest`. |
+| **Pyth Hermes price-feeder** | Off-chain pusher (`_run/node/price-feeder.sh`, `_docs/pyth-integration.md`): polls Pyth's Hermes service for signed AKT/USD updates and submits `execute_update_price_feed` txs to the CosmWasm contract (§3.11), the component that keeps the oracle alive. Its liveness is a protocol dependency (no price ⇒ `halt_oracle` ⇒ BME and ACT-mint paths freeze). |
+
+### 6.1 SDL and manifest hashing (ADR-002): byte-identical requirement
+
+The SDL YAML never touches the chain. The tenant's client compiles it into a **manifest**; the chain stores only
+`Deployment.Hash`; the manifest goes tenant → provider over the provider's gateway, and the provider recomputes
+the hash and rejects mismatches. Per ADR-002 (`_docs/adr/adr-002-manifest-v2beta2.md`): **manifest version =
+SHA-256 of the sorted JSON serialization** (reference implementation in `akash-api`
+`go/manifest/v2beta2/manifest.go`), with strict validation rules (sorted services, name regexes, …).
+Consequence: any client producing manifests must serialize **byte-identically** to the Go reference, or providers
+reject valid deployments. This constraint survives the migration untouched (A-10, D-09); only the location of
+the on-chain hash changes.
+
+### 6.2 Events and the in-process bus
+
+Off-chain consumers key on two event styles: legacy `akash.v1` message events (`sdkutil.EventTypeMessage` with
+`BaseModuleEvent{Module, Action}`; `pkg.akt.dev/go/sdkutil/event.go`) and typed protobuf events (e.g.
+`bme.EventVaultFunded`). In-process, `pubsub/bus.go` is the async fan-out bus that historically backs the
+provider bid engine; on the target chain this maps to websocket/log subscriptions
+([07](./07-offchain-and-clients.md)).
+
+## 7. Known defects: do NOT port
+
+Faithful reproduction (§4) does not extend to bugs. Treat the following as explicitly outside the parity
+envelope; each is tracked to a fix or design change in the target docs:
+
+1. **`GenesisParams.MintParams` / `.ConsensusParams` declared but never populated**
+   (`cmd/akash/cmd/genesis.go:210`): `prepare-genesis` emits zero-valued mint params and nil consensus params.
+   (Moot on targets: no sovereign genesis; live values pulled per §8.)
+2. **`wasmConfig.ContractDebugMode = true` hard-coded** (`app/app.go:158-163`) despite the in-code "MUST be false
+   in production" comment.
+3. **Min-gas-price default disagreement**: `0.0025uakt` (`cmd/akash/cmd/config.go:26`) vs `0.025uakt`
+   (`util/cli/configs.go:361`).
+4. **ACT bank metadata `Display: uact`** (should be `act`; `cmd/akash/cmd/genesis.go:224-265`); fix in target
+   token metadata (D-19).
+5. **`upgrades/CHANGELOG.md` consensus-version table is stale** (wrong versions for deployment and oracle; still
+   lists the removed take module): not authoritative; this document and the code are.
+6. **Gov-route/hook ordering hazard**: gov routes are registered before `SetupHooks()` (`app/app.go:188-193`),
+   so a gov proposal that triggers a hook can nil-deref.
+7. **`MsgDeleteProvider` returns `NOTIMPLEMENTED`** (`x/provider/handler/server.go:74-88`): the target provider
+   registry needs a real deregistration path (with lease safety), not a stub.
+8. **No invariants registered**: the crisis module's keeper/store are wired (ConstantFee 500,000 AKT) but its
+   AppModule is not in `appModules()`, so invariant checks never run; supply/escrow conservation is unverified
+   on-chain today. Target designs add explicit conservation checks ([09](./09-testing-and-verification.md)).
+9. **CosmWasm query surface dead.** Empty stargate whitelist and commented-out custom querier
+   (`x/wasm/bindings/query_whitelist.go`, `custom_querier.go`): contracts cannot query chain state at all.
+   Harmless today (the Pyth contracts don't need it); has no successor (D-22).
+
+## 8. Data that exists only on mainnet: pull at Vendor kickoff
+
+The repo does not contain these; they are live `akashnet-2` state, captured in the kickoff data pull
+(owner/timing per Q-19; feeds [05](./05-token-migration.md) supply accounting and Q-01 emissions modeling):
+
+1. **Inflation/mint parameters and current annual provisions**: stock `x/mint` state; not in source (§5.3).
+2. **Vesting account inventory**: stock Base/Delayed/Continuous vesting accounts
+   (`cmd/akash/cmd/genaccounts.go:24-110`); enumerate owners, schedules, remaining locked amounts from a state
+   export (D-06 re-creates them on the target chain).
+3. **Supply split by category**: liquid / bonded / unbonding / community pool / module-account balances (escrow,
+   bme vault, gov deposits, fee collector) / IBC-out; the S1 conservation check in
+   [05](./05-token-migration.md) reconciles against this.
+4. **State sizes per module**: record counts and byte sizes for every store in §5.4 (sizes the export/transform
+   pipeline and archive plan in [06](./06-state-and-data-migration.md)).
+5. **Transaction-rate and operation-mix statistics**: msgs/day by type (deployments, bids, leases, withdrawals,
+   BME swaps), peak rates; drives target-chain fee/compute budgeting in
+   [03](./03-solana-architecture.md)/[04](./04-ethereum-architecture.md) and load targets in
+   [09](./09-testing-and-verification.md).
+6. **Community pool balance** (post the v2.1.0 427,414,453 uakt withdrawal, §5.9): Wind-down Reserve input
+   (D-05).
+7. **IBC escrow balances per channel**: `uakt` locked behind each ICS-20 channel, with counterparty chain
+   identification (Osmosis, Cosmos Hub, …); input to the voucher-return campaign (D-07, Q-03, Q-19).
+8. **Current on-chain param values for every module in §3/§5.3**: governance has changed params since genesis;
+   the tables above are code defaults and intended values, not necessarily live values. The kickoff pull
+   re-baselines [14](./14-appendix-protocol-mapping.md).
+
+## Cross-references
+
+- [00. Executive summary](./00-executive-summary.md): migration drivers this baseline motivates.
+- [02. Target selection](./02-target-selection.md): option analysis built on §2 and §5.11.
+- [03. Solana architecture](./03-solana-architecture.md) / [04. Ethereum architecture](./04-ethereum-architecture.md): target re-designs of §3–§4.
+- [05. Token migration](./05-token-migration.md): consumes §5.1, §5.4, §8.
+- [06. State & data migration](./06-state-and-data-migration.md): consumes §5.10, §8.
+- [07. Off-chain services & clients](./07-offchain-and-clients.md): consumes §6.
+- [09. Testing & verification](./09-testing-and-verification.md): parity envelope = §4 minus §7.
+- [13. Open questions & assumptions](./13-open-questions-and-assumptions.md): D/A/Q items cited throughout.
+- [14. Appendix: protocol mapping](./14-appendix-protocol-mapping.md), element-by-element mapping of §3.
+
+## Feeds into
+
+Every design document treats this file as the factual baseline: 03/04 (target architectures re-implement §3–§4
+under D-19..D-24), 05/06 (migration of §5.1/§5.4/§5.10 state), 07 (adaptation of §6), 08 (threat-model delta
+from §5.8), 09 (behavior-parity test envelope from §4, excluding §7), and 14 (mapping tables enumerate §3
+exhaustively). Update this document first (per A-12) whenever mainnet ships a protocol change before Gate 1.

--- a/spec/aep-79/doc/02-target-selection.md
+++ b/spec/aep-79/doc/02-target-selection.md
@@ -1,0 +1,327 @@
+# 02. Target Selection: Option Space & Analysis
+
+| | |
+|---|---|
+| **Document** | 02. Target selection |
+| **Doc ID** | AKASH-MIG-02 |
+| **Version** | 0.9 (draft for review) |
+| **Date** | 2026-08-10 |
+| **Owner** | Overclock Labs |
+| **Audience** | Akash leadership & community, Vendor engagement lead |
+| **Status** | Analysis; target selected only at Gate 0 |
+
+## Purpose
+
+Establish the option space for Akash's execution environment after leaving its sovereign Cosmos SDK
+chain, evaluate the options against weighted criteria derived from the migration drivers, and define
+the evidence framework by which the target is selected at Gate 0 (D-01). This document exists so that
+Gate 0 is a decision over evidence, not a debate over vibes.
+
+## In scope
+
+- Migration drivers and the requirements they impose on a target (REQ-GEN-001..020).
+- Option space: Solana mainnet; an existing EVM L2; dedicated Arbitrum Orbit rollup; Ethereum L1; SVM L2;
+  stay-Cosmos with shared security; status quo.
+- Gate 0 evidence items and the Gate 0 process.
+
+## Out of scope
+
+- The target designs themselves: [03](./03-solana-architecture.md) and
+  [04](./04-ethereum-architecture.md).
+- Token migration mechanics: [05](./05-token-migration.md).
+- Ecosystem facts are used as of 2026-08 and re-verified at kickoff
+  ([13 §4](./13-open-questions-and-assumptions.md)).
+
+---
+
+## 1. Why migrate at all
+
+The drivers, updated from the earlier shared-security exploration
+([`RFP_SHARED_SECURITY.md`](../README.md)) with what the codebase survey
+([01](./01-current-architecture.md)) established:
+
+1. **Capital efficiency.** Sovereign PoS ties a large share of AKT into validator bonding purely to
+   secure consensus. That capital does nothing for the marketplace. On a shared chain, security is
+   inherited and AKT becomes available for provider incentives, liquidity, and growth programs.
+2. **Operational and engineering overhead.** Running a sovereign chain means owning the full
+   consensus stack. Concretely, today Akash maintains **forks of cosmos-sdk, CometBFT, and gogoproto**
+   (RESEARCH: `go.mod` replaces all three), a bespoke upgrade-plugin system with a 16-upgrade history,
+   validator coordination for every release, snapshot/state-sync infrastructure, and an in-house
+   oracle path (CosmWasm-hosted Pyth contracts) that shared chains provide natively. This is a
+   permanent tax paid in the scarcest resource: core-team engineering time.
+3. **Scale headroom with cost predictability.** Marketplace activity (orders, bids, per-lease
+   settlement, BME swaps) is chatty. The target must absorb 10–100× current activity at fees that
+   round to zero against lease value.
+4. **Distribution, liquidity, and ecosystem gravity.** This is the driver a shared-security
+   arrangement inside Cosmos could never solve. AKT's users (tenants buying compute, providers
+   earning, holders) should live where wallets, stablecoins, DeFi, and retail attention already are.
+   The Cosmos ecosystem is consolidating: the 2025–26 period saw Kujira, Comdex, Picasso, Quasar and
+   Evmos wind down, Neutron exit ICS, and **Noble, the Cosmos-native stablecoin chain, leave for its
+   own EVM L1 (mainnet 2026-03-18)**. Leaving is now a well-trodden path; staying has network-effect
+   costs that compound.
+5. **Developer surface area.** Rust/Anchor and Solidity talent pools dwarf Cosmos SDK talent. The
+   protocol's contribution funnel widens on either target.
+
+**The counter-example is real:** dYdX continues to operate successfully as a sovereign Cosmos
+appchain (v8.2, Jul 2026). Sovereignty works when an orderbook needs custom block processing.
+Akash's marketplace does not require consensus-level customization. Nothing in
+[01](./01-current-architecture.md) needs its own chain: no custom ante handling, no vote extensions,
+no per-block sweeps (escrow settlement is lazy), and the one consensus-adjacent component (the
+oracle) is a workaround for not having Pyth natively. Akash pays sovereign costs without using
+sovereign powers. That asymmetry is the case for migration.
+
+## 2. What the target must provide
+
+Normative requirements a candidate target must satisfy. These bind the evaluation, and re-verifying
+them at kickoff is the first Vendor task ([11](./11-scope-of-work.md), WS0).
+
+**REQ-GEN-001** The target SHALL sustain ≥50 marketplace transactions/second sustained and ≥500 tx/s
+burst headroom without protocol-level congestion pricing exceeding $0.05/tx median (methodology in
+[09](./09-testing-and-verification.md)).
+
+**REQ-GEN-002** Median all-in transaction cost for simple marketplace operations SHALL be ≤$0.01 at
+evaluation-date conditions.
+
+**REQ-GEN-003** The target SHALL have production Pyth price feeds (pull model) or an equivalent
+first-party oracle with sub-minute freshness for AKT/USD (D-13 dependency; BME cannot run without it).
+
+**REQ-GEN-004** At least one natively-issued stablecoin with deep liquidity SHALL be available on
+the target; the settlement-stablecoin asset is selected per Q-43 (USDC is a candidate) and is a
+configurable protocol parameter (D-14).
+
+**REQ-GEN-005** The target's canonical token standard SHALL be supported by the top-10 AKT trading
+venues and at least two qualified custodians (validated via Q-04/Q-05).
+
+**REQ-GEN-006** Mature DAO governance and multisig/timelock tooling SHALL exist in production use by
+≥3 comparable protocols (D-11).
+
+**REQ-GEN-007** At least two independent production-grade indexing paths SHALL exist (D-16).
+
+**REQ-GEN-008** The target SHALL have ≥99.5% trailing-24-month liveness, with any full-halt incidents
+publicly post-mortemed.
+
+**REQ-GEN-009** Deterministic finality or effective confirmation ≤5s for marketplace UX flows.
+
+**REQ-GEN-010** Fee currency abstraction (users transacting without pre-holding the gas asset) SHALL
+be achievable: fee-payer/relayer (Solana) or ERC-4337/EIP-7702 paymaster (EVM).
+
+**REQ-GEN-011** A precedent SHALL exist of a comparable protocol migrating onto the target at
+comparable scale (de-risks mechanics: claims, exchange swaps, community outcomes).
+
+**REQ-GEN-012** The target's runtime SHALL support the protocol's isolation needs: per-entity state
+(D-23), program-enforced token restrictions for ACT (D-19), and secp256k1 signature verification for
+Cosmos-key claims ([05](./05-token-migration.md)).
+
+**REQ-GEN-013** Vendor talent availability: ≥3 credible audit firms and a hiring market for the
+target's core language.
+
+**REQ-GEN-014** No structural dependency on a single commercial entity for chain operation
+(sequencer/validator diversity), or, where one exists (L2 sequencers), a published decentralization
+roadmap and forced-inclusion escape hatch.
+
+**REQ-GEN-015** The all-in protocol cost of the chain (rent/storage, revenue shares, license fees)
+SHALL be modelled at current, 3× and 10× load before Gate 0 sign-off.
+
+## 3. Option space
+
+| # | Option | One-line description | Status |
+|---|---|---|---|
+| A | **Solana mainnet** | Programs on Solana L1 | **Candidate path A (D-01; selected at Gate 0)** |
+| B1 | **Existing EVM L2** | EVM contracts on an established general-purpose L2; host chain selected per Q-42 (candidates: Base, Arbitrum One, Robinhood Chain) | **Candidate path B (D-01; selected at Gate 0)**; fully specified in [04](./04-ethereum-architecture.md) |
+| B2 | Dedicated Arbitrum Orbit chain | Own EVM rollup, AKT as gas | Specified as variant in [04](./04-ethereum-architecture.md); non-default (D-02) |
+| B3 | Ethereum L1 | Contracts directly on mainnet | Rejected |
+| C | SVM L2 (Eclipse/Termina-class) | Own SVM chain or shared SVM L2 | Not a candidate; noted as future option |
+| D | Stay Cosmos: ICS/shared security | Consumer chain of the Hub (prior RFP) | Superseded |
+| E | Status quo | Remain sovereign | Baseline for comparison |
+
+### 3.1 Option A: Solana mainnet
+
+**For.** (i) *Category gravity:* Solana is the de-facto DePIN settlement layer (50+ projects,
+~$3.5B combined market cap, with Helium, Render, io.net, Nosana, Hivemapper resident). The "DePIN
+belongs on Solana" narrative is empirically strong and directly aids BD, listings, and integrations.
+(ii) *Precedent:* Helium executed the only fully successful sovereign-L1-sunset-into-L1 at scale
+(2023) and is thriving three years later; Render executed the token/coordination migration. Their
+playbooks (snapshot+claims, lazy claim distribution, crank automation via Tuk Tuk) de-risk exactly the
+mechanics in [05](./05-token-migration.md)/[06](./06-state-and-data-migration.md). (iii) *Fee/latency
+fit:* median tx ≈$0.0008; blocks now 100M CU (SIMD-0286, 2026-07); the entire marketplace write-load
+is a rounding error at current scale. (iv) *Runtime fit:* Pyth is native (the current chain already
+built a whole CosmWasm subsystem just to import Pyth; that subsystem simply disappears, D-22);
+Token-2022 gives ACT's non-transferability as a mint-level property (D-19); fee-payer services give
+gasless UX (REQ-GEN-010). (v) *Distribution:* the largest retail wallet population and stablecoin
+velocity outside Ethereum, native stablecoin issuance (e.g. USDC, PYUSD), deep AKT-relevant DeFi
+for liquidity programs.
+
+**Against / risks.** (i) *Alpenglow:* the largest consensus rewrite in Solana's history is expected
+to activate inside our program window (Q3–Q4 2026), a real, bounded schedule/stability risk (A-13,
+R-linked in [12](./12-risk-register.md)). (ii) *Token-2022 exchange support* is good but not
+universal; D-03 carries a legacy-SPL fallback. (iii) *State rent:* ~6,960 lamports/byte makes naive
+state porting expensive (≈$1.2/KB at SOL $150); D-23's close-and-refund lifecycle and (optionally)
+ZK compression neutralize this, but it constrains design. (iv) *Competitive adjacency:* io.net (100k+
+GPUs) is resident and will contest the narrative (also an argument that the demand is there).
+(v) *Validator concentration trend* (~840 validators, consolidating) is a fair criticism opponents
+will raise; client diversity (Firedancer ~40% of stake incl. Frankendancer) is the counterpoint.
+
+### 3.2 Option B1: an existing EVM L2
+
+Path B deploys the contract suite on an established general-purpose EVM L2. The specific **host
+chain** is deliberately not fixed here: [04 §1](./04-ethereum-architecture.md) defines chain-neutral
+selection criteria (native stablecoin issuance, production Pyth pull feeds, ERC-4337 paymaster and keeper-automation
+coverage, fee targets, Stage 1+ rollup maturity with forced inclusion, commercial-policy stability,
+RPC/indexer depth), and the host is chosen per Q-42 with the Gate 0 evidence pack. Current
+candidates: Base, Arbitrum One, and Robinhood Chain (an Arbitrum Orbit-based chain launched Jul 2026
+with brokerage-scale distribution). Base and Arbitrum One clear the criteria as of 2026-08;
+Robinhood Chain requires criteria verification at kickoff (young chain; stablecoin, oracle, and
+account-abstraction coverage to confirm per Q-42).
+
+**For.** (i) *EVM everything:* the deepest talent pool, audit market, and tooling maturity
+(Foundry/OZ); enterprise perception. (ii) *Performance is now adequate across mature L2s:* complex
+interactions cost $0.01–0.05; post-Fusaka blob capacity (14/21) keeps L2 costs trending down; some
+candidates add fast preconfirmations (e.g. Flashblocks on Base, ~200ms). (iii) *Distribution and
+integration:* natively-issued stablecoins are first-class on the major L2s, and some candidates carry
+exchange-affiliated funnels (e.g. Base's Coinbase on-ramp and custody path). (iv) All EVM claims
+tooling (Merkle distributors, vesting, governance) is commodity.
+
+**Against / risks.** (i) *Someone else's chain, visibly:* today's general-purpose L2s are
+single-sequencer systems operated by commercial entities. For an infrastructure protocol whose brand
+is decentralized cloud, the optics and the structural dependency both matter (REQ-GEN-014 partially
+satisfied: Stage 1 with forced inclusion across the candidates; decentralization roadmaps slower
+than promised). (ii) *Policy flux:* L2 commercial postures move (example: Base announced its
+Superchain exit in Feb 2026, with consequences still settling); host-chain selection weighs policy
+stability, and the suite stays portable EVM so the host can change before G1 at bounded cost.
+(iii) *No DePIN cluster:* the category's liquidity, integrations, and precedent migrations are
+elsewhere. (iv) L1-anchored finality for withdrawals is irrelevant to our no-bridge design but
+shapes exchange integration lead times.
+
+### 3.3 Option B2: Dedicated Arbitrum Orbit chain
+
+AKT as the gas token, full sovereignty over blockspace, AEP terms (10% of net protocol revenue).
+Excluded as a candidate by D-02: it re-creates the operational burden (sequencer ops, DA choices,
+upgrade trains, RaaS vendor management) that driver #2 exists to eliminate, adds bridge/liquidity
+fragmentation UX, and its ecosystem gravity is only what Akash brings. It is retained fully-specified
+as the escape hatch if an existing-chain path fails on costs or policy (revisit trigger Q-06).
+OP Stack was rejected for this variant: custom gas tokens are deprecated in the spec (ETH-only fees)
+and Superchain commercial terms are in flux post-Base-exit.
+
+### 3.4 Option B3: Ethereum L1
+
+At Aug 2026 gas (0.08–0.23 gwei) L1 is cheap; but the 2026 record still shows 5–40 gwei spikes under
+load, and a marketplace that must submit bids and settlements continuously cannot price its UX off
+the calm days. Blob economics don't help non-rollup apps. Rejected on REQ-GEN-001/002 robustness;
+revisit only if the marketplace's write pattern changes fundamentally.
+
+### 3.5 Option C: SVM L2 / network extension
+
+Eclipse (mainnet since Nov 2024, 1,000+ TPS sustained) and Termina-class SVM rollups make "own SVM
+chain" real in 2026, and Grass shows a DePIN peer going that way. But every example is young, the
+operational burden returns (driver #2), and none of the distribution benefits of Solana mainnet
+apply. Excluded as a candidate; noted as a plausible *future* scaling/sovereignty move that the Solana
+program suite (03) would port to with minimal change (a cheap option to hold).
+
+### 3.6 Option D: Stay Cosmos with shared security (prior RFP)
+
+The ICS consumer-chain path solves part of driver #1 (bonding) and little of driver #2 (still a
+chain to run, now with a partner's release train too), and none of driver #4. Since that RFP was
+drafted, the ground shifted: Neutron exited ICS for sovereignty, the consumer-chain roster shrank,
+and the ecosystem's own stablecoin hub left entirely. IBC Eureka (live to Ethereum since 2025-04) is
+excellent transitional plumbing ([05](./05-token-migration.md) uses it as an optional rail on the
+Ethereum path), but it is a bridge, not a demand engine. Superseded by this program; the RFP document
+remains in-repo as the record of that analysis.
+
+### 3.7 Option E: Status quo
+
+Zero migration risk; all four drivers unaddressed and compounding (fork maintenance alone is a
+growing liability as upstream Cosmos consolidates). Baseline, not a plan.
+
+## 4. Gate 0 selection
+
+### 4.1 D-01: two candidate paths, one selection at Gate 0
+
+Both candidate paths clear the §2 requirements as of 2026-08. They differ in the *kind* of strength
+they offer, and Gate 0 weighs verified evidence of each:
+
+- **What weighs toward A (Solana):** the DePIN category and both relevant migration precedents live
+  there (Akash would follow a proven playbook into its own buyer/seller ecosystem rather than
+  pioneering into an empty one); runtime fit removes whole subsystems (the CosmWasm/oracle apparatus)
+  rather than re-hosting them; fee/latency characteristics fit a chatty marketplace with the most
+  headroom.
+- **What weighs toward B1 (existing EVM L2):** the deepest engineering, audit, and tooling market;
+  enterprise perception and exchange-affiliated distribution funnels (e.g. Base's Coinbase
+  relationship, Robinhood Chain's brokerage funnel); commodity claims, vesting, and governance
+  infrastructure; the lowest execution novelty of any option.
+
+[03](./03-solana-architecture.md) and [04](./04-ethereum-architecture.md) are maintained at the same
+specification depth deliberately: it keeps Gate 0 a real decision and keeps Vendor bids honest on
+both paths.
+
+### 4.2 Gate 0 evidence items
+
+**REQ-GEN-016** The kickoff verification sprint SHALL re-test each evidence item and present results
+at Gate 0:
+
+1. Token-2022 acceptance across venues covering ≥80% of AKT volume fails AND the legacy-SPL fallback
+   (D-03) is judged to materially harm the ACT design (D-19 depends on Token-2022
+   non-transferability; fallback = program-ledger ACT, acceptable but weaker wallet UX).
+2. Alpenglow rollout enters a visibly unstable period (halts, rollbacks) with no credible
+   stabilization before our P3 testnet phase.
+3. Two or more top-5 AKT venues state they cannot support a Solana-chain swap on our timeline but
+   can support an EVM one.
+4. The Q-15 provider-daemon prototype reveals integration costs on Solana exceeding the EVM path by
+   >50% effort with no mitigation.
+5. Every candidate host chain fails the [04 §1](./04-ethereum-architecture.md) chain criteria on
+   commercial-policy stability or infrastructure coverage (native settlement stablecoin, Pyth, keeper/paymaster
+   support) as re-verified at kickoff (Q-42).
+6. The EVM claims-verification gas benchmark and paymaster viability at projected claim volumes miss
+   the [04](./04-ethereum-architecture.md) targets with no mitigation.
+
+Gate 0 selects the path whose verified evidence pack is stronger. A failed viability check on either
+path moves the selection to the other, with Stage A work carrying over intact (the migration engine,
+tokenomics model, and off-chain adapter design are target-neutral by construction).
+
+### 4.3 Gate 0 process
+
+**REQ-GEN-017** Gate 0 SHALL comprise: (i) publication of the kickoff verification report
+(evidence items + volatile-fact re-verification per [13 §4](./13-open-questions-and-assumptions.md));
+(ii) a community signal proposal on `akashnet-2` presenting this document and the verification
+report; (iii) leadership/steering sign-off recorded in the decision log; (iv) Vendor Stage B
+authorization for exactly one path. Gate 0 closes phase P0
+([10](./10-rollout-and-cutover.md)).
+
+**REQ-GEN-018** No Stage B (single-path) implementation work SHALL begin before Gate 0; Stage A
+work SHALL be limited to target-neutral deliverables plus the two prototype spikes (Q-15 Solana
+daemon integration; EVM claims-verification gas benchmark).
+
+**REQ-GEN-019** The Gate 0 decision SHALL be recorded as a resolution of D-01 in
+[13](./13-open-questions-and-assumptions.md) with the evidence pack linked, and the not-selected
+architecture document SHALL be marked `[ALTERNATE - NOT SELECTED]` in its metadata table but
+retained in the set.
+
+**REQ-GEN-020** The community signal proposal SHALL disclose, plainly: the end of sovereign staking
+(and validator income), the claims process obligations on holders, the wind-down timeline for live
+leases, and the point of no return (S1), with no ambiguity about irreversibility.
+
+## 5. What Akash gives up, stated honestly
+
+1. **Sovereign blockspace and upgrade authority.** Protocol changes become program upgrades gated by
+   our own governance (D-11/D-15), but consensus-level evolution belongs to the host chain.
+2. **Validator community.** ~100 validator operators lose an income stream and a role; the program
+   owes them a respectful wind-down (Q-13, [06](./06-state-and-data-migration.md) §validator
+   continuity) and, where possible, a future as providers, RPC operators, or crank runners.
+3. **IBC nativeness.** Cosmos-side AKT and integrations require the explicit handling in
+   [05](./05-token-migration.md); ongoing Cosmos interop becomes bridge-mediated (or IBC Eureka on
+   the Ethereum path).
+4. **The "own chain" narrative.** Akash's story changes from "sovereign appchain" to "protocol on
+   the best venue for its users." The drivers in §1 are the argument that this is a trade up.
+
+## Cross-references
+
+- [00. Executive summary](./00-executive-summary.md): condensed version of this analysis.
+- [03](./03-solana-architecture.md) / [04](./04-ethereum-architecture.md): the two target designs.
+- [13](./13-open-questions-and-assumptions.md): D-01/D-02 entries, evidence-linked questions
+  (Q-04, Q-05, Q-06, Q-15).
+- [12](./12-risk-register.md), risks cited: Alpenglow window, Token-2022 gaps, exchange slippage,
+  competitive adjacency.
+
+## Feeds into
+
+Gate 0 (via [10](./10-rollout-and-cutover.md)); Vendor Stage A scope ([11](./11-scope-of-work.md));
+the community signal proposal.

--- a/spec/aep-79/doc/03-solana-architecture.md
+++ b/spec/aep-79/doc/03-solana-architecture.md
@@ -1,0 +1,738 @@
+# 03. Solana Target Architecture
+
+| | |
+|---|---|
+| **Document** | 03. Solana Target Architecture |
+| **Doc ID** | AKASH-MIG-03 |
+| **Version** | 0.9 (draft for review) |
+| **Date** | 2026-08-10 |
+| **Owner** | Overclock Labs |
+| **Audience** | Vendor engineering |
+| **Status** | Normative where marked (MUST/SHALL); informative otherwise |
+
+## Purpose
+
+- Specify the complete on-chain design of the Akash protocol on Solana mainnet (Path A per D-01): program suite, accounts/PDAs, instructions, events, errors, cranks, fees, tokens, oracles, and governance wiring.
+- Preserve the marketplace semantics of the current Cosmos chain (D-09) at a depth sufficient for a senior Anchor team to begin implementation without a discovery phase.
+- Define the intentional behavior deltas versus the current chain, each justified and cross-referenced.
+
+## In scope
+
+- The nine protocol programs (`akash-deployment`, `akash-market`, `akash-escrow`, `akash-bme`, `akash-provider-registry`, `akash-audit`, `akash-config`, `akash-claims`, `akash-emissions`) and their CPI topology.
+- AKT and ACT token design on Solana (Token-2022), settlement-stablecoin integration (D-14).
+- Transaction composition, compute budgets, priority fees, rent economics, congestion behavior, idempotency, and crank/relayer interfaces.
+
+## Out of scope
+
+- Token-migration mechanics, snapshots, claims logic, and emissions curve: [05. Token migration](./05-token-migration.md) (interfaces only here).
+- State/data migration and old-chain sunset: [06. State & data migration](./06-state-and-data-migration.md).
+- Off-chain services beyond their on-chain interfaces: provider daemon, Console, indexer, relayer operations, JWT verification ([07. Off-chain services & clients](./07-offchain-and-clients.md)).
+- Key management, audit plan, detailed multisig/timelock composition: [08. Security & audits](./08-security-and-audits.md).
+
+Cosmos-side facts cited here (module behavior, parameters, file paths) are established in [01. Current architecture](./01-current-architecture.md); the exhaustive per-message mapping is in [14. Protocol mapping](./14-appendix-protocol-mapping.md).
+
+---
+
+## 1. Design principles and toolchain
+
+Each principle is anchored to a fixed decision in [13](./13-open-questions-and-assumptions.md); do not re-litigate them.
+
+| # | Principle | Source |
+|---|---|---|
+| P1 | **Semantic parity.** Order→bid→lease flow, escrow streaming, dseq/gseq/oseq UX, SDL untouched. Where Solana forces a mechanical difference, observable economics stay equal and the difference is listed in §15. | D-09 |
+| P2 | **Working state only.** One account per live entity; accounts close and refund rent at terminal state; events are the indexer's system of record for history. No global order book. | D-23 |
+| P3 | **Time, not blocks.** All protocol time uses the Clock sysvar `unix_timestamp`. Escrow rates are per-second; BME epochs are timestamps. No slot-count arithmetic anywhere (Alpenglow-safe, A-13). | D-21, D-20 |
+| P4 | **Lazy + permissionless progress.** Settlement is computed on interaction; every liveness-critical step (settle, BME epochs, cascade reaps, losing-bid refunds) has a permissionless instruction so cranks can force progress. | D-21, D-20 |
+| P5 | **Two-token economics preserved.** ACT stays non-transferable and lease pricing stays ACT-denominated; BME queue + CR breaker + spread port intact. | D-19, D-20 |
+| P6 | **Oracle = Pyth pull.** Programs read Pyth price-update accounts directly with staleness/confidence bounds; no push oracle, no CosmWasm successor. | D-13, D-22 |
+| P7 | **Governance-mutable parameters, nothing else.** All tunables live in `akash-config` PDAs mutable only by the DAO path; everything else changes only via program upgrade behind multisig+timelock. | D-11, D-15 |
+| P8 | **No custom infrastructure.** Solana mainnet only: no appchain, no sequencer, no bespoke oracle network, no indexer consensus. | D-02 |
+
+### 1.1 Toolchain (normative)
+
+**REQ-SOL-001** Programs MUST be implemented with the Anchor framework, v1.x line (v1.1.2 current as of 2026-08; re-verify at kickoff per [13 §4](./13-open-questions-and-assumptions.md)).
+
+**REQ-SOL-002** The Vendor MAY implement individual CU-critical instructions or whole programs in Pinocchio (zero-dependency native Rust) where Anchor cannot meet the CU targets in this document, PROVIDED account layouts, 8-byte discriminators, instruction encodings, and the published IDL remain byte-compatible with the Anchor definition (clients MUST NOT be able to distinguish the implementations).
+
+**REQ-SOL-003** Programs MUST be deployed via loader-v4 (the current deploy path as of 2026-08; loader-v3 is disabled for new programs).
+
+**REQ-SOL-004** Every mainnet program deployment MUST be a verifiable build (deterministic container build, `solana-verify`-compatible), with the verified build hash published in the `akash-config` program registry (§5.2) and in release notes.
+
+**REQ-SOL-005** Each program MUST publish its Anchor IDL on-chain (IDL account) and the Vendor MUST generate typed TS and Rust clients from it (Codama or Anchor-native codegen) as deliverables consumed by [07](./07-offchain-and-clients.md).
+
+**REQ-SOL-006** No program instruction may exceed a declared CU budget target in this document by more than 20% at the p99 input bound; CU regression tests (Mollusk/LiteSVM) MUST gate CI per [09. Testing](./09-testing-and-verification.md).
+
+**REQ-SOL-007** Programs MUST NOT read or depend on slot numbers, slot cadence, or epoch schedule for any economic computation; only `Clock.unix_timestamp` is permitted (see §14.7 Alpenglow).
+
+---
+
+## 2. Program suite overview
+
+Nine programs (names fixed by BRIEF/13 terminology). Rust crate names mirror the kebab names.
+
+| Program | Purpose | Replaces (Cosmos) |
+|---|---|---|
+| `akash-deployment` | Deployments, groups, per-tenant dseq counters, deployment lifecycle | `x/deployment` |
+| `akash-market` | Orders, bids, leases, reclamation windows, bid matching | `x/market` |
+| `akash-escrow` | Streaming escrow accounts/payments, delegated-deposit allowances | `x/escrow` + authz `DepositAuthorization` seam |
+| `akash-bme` | AKT↔ACT burn-mint engine: vault, swap queues, CR circuit breaker, ACT gateway | `x/bme` (+ `x/oracle` consumption) |
+| `akash-provider-registry` | Provider records, attributes, JWT signing keys, collateral | `x/provider` (+ part of `x/cert` per D-10) |
+| `akash-audit` | Auditor attestations per (provider, auditor) | `x/audit` |
+| `akash-config` | Protocol parameters, program/version registry, governance authority glue | module params + discovery service |
+| `akash-claims` | Token migration: S1/S2 Merkle claims, Wind-down Reserve, residual distributions | (new; spec in [05](./05-token-migration.md)) |
+| `akash-emissions` | Post-migration AKT emissions to provider-incentive pool + community treasury | `x/mint` replacement (D-12) |
+
+Not ported: `x/cert` (D-10 → [07](./07-offchain-and-clients.md)), `x/take` (dead code on current chain), `x/oracle`+`x/epochs`+CosmWasm/`awasm` (collapse into direct Pyth pull reads + time-based cranks, D-22), staking/slashing/gov/IBC (sovereign-chain machinery, ends per D-05/D-18).
+
+### 2.1 CPI topology
+
+```mermaid
+graph TD
+  DEP[akash-deployment]
+  MKT[akash-market]
+  ESC[akash-escrow]
+  BME[akash-bme]
+  PRV[akash-provider-registry]
+  AUD[akash-audit]
+  CFG[akash-config]
+  CLM[akash-claims]
+  EMI[akash-emissions]
+  T22[(SPL/Token-2022 mints: AKT, ACT, settlement stablecoin)]
+  PYTH[(Pyth receiver price accounts)]
+
+  DEP -->|create_order| MKT
+  DEP -->|account_create / account_close| ESC
+  MKT -->|account_create, payment_create/close, account_close| ESC
+  MKT -->|hook_pause_group| DEP
+  ESC -->|ACT gateway: deposit_burn / payout_mint / refund_mint| BME
+  ESC -->|AKT and settlement-stablecoin vault transfers| T22
+  BME -->|ACT mint/burn, AKT vault transfers| T22
+  CLM -->|AKT mint during claim window| T22
+  EMI -->|AKT mint post-window| T22
+  MKT -.->|read| PRV
+  MKT -.->|read| AUD
+  ESC -.->|read price + BME status| PYTH
+  BME -.->|read price| PYTH
+  DEP & MKT & ESC & BME -.->|read params| CFG
+```
+
+Solid arrows are CPIs; dashed arrows are account reads (no CPI). This mirrors the Cosmos keeper-dependency graph (`app/types/app.go:421-491`): Deployment(escrow, market, oracle, authz, bank) → deployment CPIs escrow/market plus Pyth reads and allowance PDAs; Market(escrow) → market CPIs escrow; Escrow(bank, authz, oracle, bme) → escrow CPIs Token-2022/BME-gateway plus Pyth and BME-status reads; Bme(bank, oracle) → BME CPIs Token-2022 plus Pyth reads.
+
+**REQ-SOL-008** The CPI edges above are exhaustive: no program may CPI another protocol program except as drawn, and no protocol CPI chain may exceed invoke stack height 5 (top-level → market → escrow → bme → Token-2022 is the deepest permitted chain; the BME gateway MUST therefore call token programs directly with no further protocol hop).
+
+**REQ-SOL-009** The Cosmos escrow→market→deployment *hook* cascade (`x/market/hooks/hooks.go`) MUST NOT be reproduced as upward CPIs from `akash-escrow` (it would be indirect reentrancy, which Solana prohibits). It is replaced by the guarded-reap pattern of §3.4: escrow marks its own state and emits events; permissionless reap instructions on `akash-market`/`akash-deployment` verify escrow state and apply the cascade. The single permitted upward CPI is `market → deployment::hook_pause_group` (call chains through it never re-enter `akash-market`).
+
+### 2.2 Cross-program authorization
+
+**REQ-SOL-010** Cross-program calls that must be caller-restricted use signer PDAs: `akash-escrow` signs BME-gateway CPIs with its `["escrow_gateway"]` PDA; `akash-market` signs `hook_pause_group` with its `["hook_auth"]` PDA. Callee programs MUST validate these signer addresses against the pinned values in `akash-config` (§5), not against hardcoded constants.
+
+---
+
+## 3. Shared on-chain conventions
+
+### 3.1 Identifiers and encoding
+
+**REQ-SOL-011** Entity identity preserves the Cosmos ID tuples (D-09): `dseq: u64`, `gseq: u32`, `oseq: u32`, `bseq: u32` (always 0 at creation, as on the current chain), owner/provider as 32-byte pubkeys. All integers little-endian; all account data Borsh-encoded with Anchor 8-byte discriminators; amounts are `u64` in micro-units (6 decimals, parity with `uakt`/`uact`); internal fractional accrual and rates use `u128` fixed-point scaled by `RATE_SCALE = 10^18` (replaces cosmos `LegacyDec`; D-21.a: plain u64 loses precision on typical fractional rates); timestamps are `i64` unix seconds from the Clock sysvar.
+
+**REQ-SOL-012** dseq is assigned from a per-tenant counter account (§8.1), not derived from block height (Q-12). Clients MUST treat dseq as an opaque monotonic sequence.
+
+### 3.2 PDA seed registry (canonical)
+
+All PDAs derive from these exact seed tuples. `*_le` denotes little-endian byte encoding of the stated width.
+
+| Program | Account | Seeds |
+|---|---|---|
+| deployment | TenantCounter | `["tenant", owner]` |
+| deployment | Deployment | `["deployment", owner, dseq_le(8)]` |
+| deployment | Group | `["group", owner, dseq_le(8), gseq_le(4)]` |
+| market | Order | `["order", owner, dseq_le(8), gseq_le(4), oseq_le(4)]` |
+| market | Bid | `["bid", owner, dseq_le(8), gseq_le(4), oseq_le(4), provider, bseq_le(4)]` |
+| market | Lease | `["lease", owner, dseq_le(8), gseq_le(4), oseq_le(4), provider]` |
+| escrow | EscrowAccount | `["escrow", entity_pda]` (entity = Deployment or Bid PDA) |
+| escrow | EscrowVault (token acct) | `["vault", escrow_account_pda, mint]` |
+| escrow | Payment | `["payment", lease_pda]` |
+| escrow | Allowance | `["allowance", granter, grantee]` |
+| escrow | AllowanceVault (token acct) | `["allowance_vault", allowance_pda, mint]` |
+| escrow | gateway signer | `["escrow_gateway"]` |
+| bme | BmeState | `["bme_state"]` |
+| bme | Vault authority / AKT vault | `["bme_vault"]` |
+| bme | ACT mint authority | `["act_auth"]` |
+| bme | SwapRequest | `["swap", dir(1), seq_le(8)]` (dir: 0=mint ACT, 1=burn ACT) |
+| bme | TipTreasury | `["tip_treasury"]` |
+| provider-registry | Provider | `["provider", owner]` |
+| audit | Attestation | `["audit", provider_owner, auditor]` |
+| config | Params | `["params", module_tag]` (`module_tag` ∈ ascii: `deployment`, `market`, `escrow`, `bme`, `oracle`, `fees`) |
+| config | ProgramRegistry | `["registry"]` |
+| market | hook signer | `["hook_auth"]` |
+
+**REQ-SOL-013** PDA seed schemas are frozen at mainnet launch: any change is a breaking protocol upgrade requiring the full governance path of §13 and a client migration plan in [07](./07-offchain-and-clients.md).
+
+### 3.3 Events
+
+**REQ-SOL-014** Every state transition MUST emit exactly one Anchor event via the event-CPI pattern (`emit_cpi!`, self-CPI with the event-authority PDA), not `emit!`/log-only, because RPC log truncation would corrupt the indexer's record. Events are the system of record for history (D-23): they MUST carry full entity ID tuples (owner, dseq, gseq, oseq, provider) and all economically relevant amounts, since the underlying accounts close at terminal state and cannot be re-read.
+
+**REQ-SOL-015** Event schemas are append-only after mainnet launch (new fields at the tail, new events allowed; no removals or type changes), so the indexer ([07](./07-offchain-and-clients.md)) can replay history across program upgrades.
+
+### 3.4 Cascade closure (guarded reaps)
+
+The current chain closes deployment/group/order/bid/lease state atomically through keeper hooks when escrow accounts/payments close or overdraw (`x/market/hooks/hooks.go`). Solana transaction limits and the reentrancy rule make the atomic cascade impossible in the escrow-initiated direction. The port:
+
+| Trigger (event + state) | Follow-up instruction (permissionless) | Effect |
+|---|---|---|
+| `PaymentOverdrawn` / `PaymentClosed` on payment P | `akash-market::reap_lease` | lease → `insufficient_funds` (if overdrawn) or `closed`; order closed; winning bid closed |
+| `AccountOverdrawn` / `AccountClosed` on escrow account of deployment D | `akash-deployment::reap_deployment` (+ per-group `reap_group`) | deployment closed; groups → `closed`, or `insufficient_funds` when account overdrawn |
+| Lease created (order matched) | `akash-market::close_losing_bid` per losing bid | losing bid → `lost`; bid escrow closed; collateral + rent refunded |
+
+**REQ-SOL-016** Reap instructions MUST be permissionless, verify the triggering state on the referenced escrow/market account (ownership + discriminator + state field) before mutating, be idempotent, and emit the same closure events the atomic Cosmos cascade would have emitted.
+
+**REQ-SOL-017** The protocol crank service (operated per Q-07, but permissionless by construction) MUST complete any pending cascade within 60 s p95 of the triggering event; [09](./09-testing-and-verification.md) tests this under load. Until reaped, guard checks make stale state harmless: every value-moving instruction re-derives solvency from escrow state, never from market/deployment state alone.
+
+### 3.5 Rent lifecycle
+
+**REQ-SOL-018** Every protocol account stores `rent_payer: Pubkey`. On reaching terminal state the account MUST be closed in the same instruction where transaction limits permit, otherwise by a permissionless `close_*`/reap instruction; lamports return to `rent_payer`. An account MUST NOT close while a live child references it (deployment ← groups ← orders ← bids/leases ← payments; escrow account ← payments): close ordering is child-first and enforced by open-child counters on each parent.
+
+**REQ-SOL-019** Bounded vectors (normative caps, validated on write): escrow depositors ≤ 16 per account (§10.1); groups ≤ 8 per deployment; resource units ≤ 4 per group; attributes ≤ 24 per provider/group/attestation; `signed_by` auditors ≤ 4 per group; JWT signing keys ≤ 3 per provider; allowance mints ≤ 3. Caps exist because Solana accounts are fixed-size and instructions must enumerate accounts; the current chain bounds these only by gas. Validate caps against the mainnet SDL corpus before freeze (A: §15 note, recorded in 13).
+
+### 3.6 Oracle reads (Pyth pull)
+
+**REQ-SOL-020** Programs consume prices exclusively from Pyth pull-oracle price-update accounts (posted via the Pyth receiver program in the same transaction, D-13). Every read MUST validate: (a) account owner = Pyth receiver program and verification level = full; (b) feed id equals the AKT/USD feed id pinned in `["params","oracle"]`; (c) `publish_time ≥ now − max_price_staleness` (default 30 s, carrying `x/oracle` `MaxPriceStalenessPeriod`); (d) `conf/price ≤ max_conf_bps` (default 150 bps, carrying `MaxPriceDeviationBps`). Stale or wide prices MUST fail closed (BME → `halt_oracle` path; escrow fallback → error).
+
+**REQ-SOL-021** BME collateral-ratio computation MUST use the Pyth EMA price (≈1h exponential average, replacing the current 1h TWAP the BME reads); spot price (with the same staleness/conf bounds) is used for swap execution pricing and the escrow AKT fallback. Delta DELTA-02, §15.
+
+---
+
+## 4. Tokens
+
+### 4.1 AKT: Token-2022 (D-03)
+
+**REQ-SOL-022** AKT is a Token-2022 mint, 6 decimals, with the metadata extension (metadata pointer self-referencing the mint; name "Akash Network", symbol "AKT") and NO other extensions: no transfer hooks, no permanent delegate, no transfer fees, no confidential transfers. Freeze authority MUST be `None` at creation (irrevocably).
+
+**REQ-SOL-023** AKT mint authority lifecycle: at token genesis the authority is the `akash-claims` migration PDA (claim-window minting per [05](./05-token-migration.md)); at claim-window close it is transferred to the `akash-emissions` schedule PDA whose minting is DAO+timelock-governed (D-12, §12). No other party ever holds AKT mint authority; each transfer emits an event and is a governance action per §13.
+
+**REQ-SOL-024** Q-05 fallback: if the kickoff exchange/custody verification (Q-05) fails the Token-2022 support threshold defined in [05](./05-token-migration.md), AKT falls back to a legacy SPL mint with Metaplex metadata. The fallback MUST change nothing else in this document (escrow/BME hold no AKT-side Token-2022 extension dependencies by design); ACT is unaffected (ACT never touches exchanges).
+
+### 4.2 ACT: Token-2022 NonTransferable (D-19)
+
+**REQ-SOL-025** ACT is a Token-2022 mint, 6 decimals, with the NonTransferable extension and metadata (name "Akash Compute Token", symbol "ACT", fixing the current chain's `Display: uact` metadata defect, which MUST NOT be ported). Mint authority is the `akash-bme` `["act_auth"]` PDA; freeze authority `None`. Wallet presentation questions are Q-16.
+
+NonTransferable means no transfers ever, including to program vaults. ACT therefore cannot be escrowed as tokens; every protocol movement is a burn or mint at the protocol boundary, exactly as D-19 prescribes and mirroring the current chain's `SendEnabled(uact)=false` (`cmd/akash/cmd/genesis.go:121-130`):
+
+| Protocol movement | Token operation | Ledger effect |
+|---|---|---|
+| Escrow deposit (tenant/bid collateral in ACT) | burn from depositor's ACT account (depositor signs) | escrow account `funds_act` += amount; BME `act_escrowed` += amount |
+| Settlement payout to provider | mint to provider's ACT account | payment `balance_act` −= amount; `act_escrowed` −= amount |
+| Depositor refund on close | mint to depositor's ACT account (or credit allowance, §10.4) | escrow `funds_act` −= amount; `act_escrowed` −= amount |
+| BME swap AKT→ACT executed | mint to swapper | BME totals updated |
+| BME swap ACT→AKT requested | burn from swapper (swapper signs) | `pending_act` += amount (remint credit on cancel) |
+
+**REQ-SOL-026** All ACT mints and burns MUST flow through the three `akash-bme` gateway instructions (`gateway_deposit_burn`, `gateway_payout_mint`, `gateway_refund_mint`) or BME's own swap execution, so that BME maintains `act_escrowed`, the ledger of ACT burned into escrow but still owed. Rationale: burning on deposit shrinks `mint.supply`, which would otherwise inflate the collateral ratio; on the Cosmos chain escrowed `uact` sits in module accounts and still counts in `TotalSupply` (`x/bme/keeper/keeper.go:742-784`). The CR denominator on Solana is therefore `act_outstanding = act_mint.supply + act_escrowed` (§11.4).
+
+**REQ-SOL-027** Gateway instructions MUST require the `akash-escrow` `["escrow_gateway"]` PDA as signer (validated against `akash-config`), reject all other callers, and CPI Token-2022 directly (stack-height ceiling, REQ-SOL-008).
+
+CPI pattern (informative, Anchor v1.x pseudocode) for escrow deposit and refund of ACT:
+
+```rust
+// akash-escrow::account_deposit (source = wallet balance), ACT leg
+// depth: top-level(1) -> escrow(1 if top-level, else 2) -> bme(+1) -> token-2022(+1)
+bme::cpi::gateway_deposit_burn(
+    CpiContext::new_with_signer(
+        bme_program,
+        bme::cpi::accounts::GatewayDepositBurn {
+            gateway: escrow_gateway_pda,      // signer PDA ["escrow_gateway"]
+            bme_state,                        // writable: act_escrowed += amount
+            act_mint,                         // writable
+            from_act_account: depositor_act_ata, // writable; owner co-signed the outer ix
+            depositor,                        // signer (burn authority)
+            token_program: token_2022,
+        },
+        &[&[b"escrow_gateway", &[bump]]],
+    ),
+    amount,
+)?;
+
+// akash-escrow::account_close, ACT refund leg (mint back to depositor)
+bme::cpi::gateway_refund_mint(
+    CpiContext::new_with_signer(
+        bme_program,
+        bme::cpi::accounts::GatewayMint {
+            gateway: escrow_gateway_pda,
+            bme_state,                        // writable: act_escrowed -= amount
+            act_mint,                         // writable
+            to_act_account: depositor_act_ata, // writable; created idempotently by closer
+            act_mint_authority: act_auth_pda, // PDA ["act_auth"], signs inside akash-bme
+            token_program: token_2022,
+        },
+        &[&[b"escrow_gateway", &[bump]]],
+    ),
+    amount,
+)?;
+```
+
+### 4.3 The settlement stablecoin (D-14)
+
+**REQ-SOL-028** The settlement stablecoin (**STABLE** in tables below): a natively-issued, deeply-liquid USD stablecoin, selected per Q-43 (candidates e.g. USDC, PYUSD, USDT where natively issued) and held as the governed parameter `config.settlement_stable_mint` (pinned in `["params","escrow"]`), is a first-class escrow deposit and settlement asset; the asset is a configurable protocol parameter and the protocol MUST NOT hard-depend on a single issuer. Lease pricing stays ACT-denominated (D-19); STABLE satisfies ACT-denominated obligations at par (1 STABLE micro-unit = 1 uact; decimals normalized if the selected asset is not 6-decimal) under the `stable_act_parity_bps` parameter (default 10000; D-14.a, ratification Q-22). Justification: ACT is the protocol's USD-denominated compute credit (BME mints it against AKT at the oracle USD price), so par settlement introduces no new price risk beyond the peg parameter, which governance can adjust. Delta DELTA-08, §15. `[TO-VERIFY: current-chain source of the uact/USD price used in BME CR (assumed constant 1 USD peg); confirm in x/bme keeper during 14-appendix mapping]`
+
+---
+
+## 5. `akash-config`
+
+Purpose: single home for every governed parameter (successor to module params) and for the program/version registry (successor to the `akash.discovery.v1` service, `app/app.go:538-578`).
+
+### 5.1 Parameter accounts
+
+One PDA per module tag, each ≤ 512 bytes, mutable only by the governance authority (§13). Every parameter carried over from the current chain, with defaults:
+
+| PDA `["params", tag]` | Parameter | Default (carry-over source) |
+|---|---|---|
+| `deployment` | `min_deposits: Vec<(mint, u64)>` | ACT 500_000 (0.5 ACT); AKT 500_000 (top-up only); STABLE 500_000 (§4.3); carries `MinDeposits = 500000uakt,500000uact` |
+| `market` | `bid_min_deposits: Vec<(mint, u64)>` | AKT 500_000; ACT 500_000; STABLE 500_000; carries `BidMinDeposits` |
+| `market` | `order_max_bids: u32` | 20 (hard max 500); carries `OrderMaxBids` |
+| `market` | `min_reclamation_window_secs: i64` | 3_600 (1 h); carries `MinReclamationWindow` (D-24) |
+| `market` | `max_reclamation_window_secs: i64` | 2_592_000 (720 h); carries `MaxReclamationWindow` (D-24) |
+| `escrow` | `max_depositors: u8` | 16 (§10.1) |
+| `escrow` | `allowed_mints: Vec<Pubkey>` | [ACT, AKT, STABLE] |
+| `escrow` | `settlement_stable_mint: Pubkey` | the settlement-stablecoin mint, selected per Q-43 (new; D-14, §4.3) |
+| `escrow` | `stable_act_parity_bps: u16` | 10_000 (§4.3) |
+| `bme` | `cr_warn_bps: u16` / `cr_halt_bps: u16` | 9_500 / 9_000; carries `CircuitBreakerWarnThreshold`/`HaltThreshold` |
+| `bme` | `mint_spread_bps: u16` / `settle_spread_bps: u16` | 25 / 0 |
+| `bme` | `min_epoch_secs: i64` | 65 (carries `MinEpochBlocks=10` × 6.5 s = 65 s exactly; DELTA-03) |
+| `bme` | `epoch_backoff_pct: u16` / `epoch_backoff_cap_secs: i64` | 10 / 93_600 (carries 14_400-block cap × 6.5 s) |
+| `bme` | `max_records_per_epoch: u16` | 50; carries `MaxEndblockerRecords` |
+| `bme` | `min_mint: u64` | 10_000_000 uact (10 ACT); carries `MinMint` |
+| `bme` | `max_pending_attempts: u8` | 3; carries `MaxPendingAttempts` |
+| `oracle` | `akt_usd_feed_id: [u8;32]` | Pyth AKT/USD feed id `[TO-VERIFY: Pyth AKT/USD feed id on Solana mainnet at kickoff; 13 §4 volatile list]` |
+| `oracle` | `max_price_staleness_secs: i64` | 30; carries `MaxPriceStalenessPeriod` |
+| `oracle` | `max_conf_bps: u16` | 150; carries `MaxPriceDeviationBps` (as Pyth confidence bound) |
+| `fees` | `tip_per_record_lamports: u64`, `reap_tip_lamports: u64` | crank tips (Q: funding + rate, recorded in 13) |
+
+Not carried (obsolete on Solana): `x/oracle` `Sources`/`MinPriceSources`/`TwapWindow`/`PriceRetention`/prune params (push oracle removed, D-22); `awasm` `BlockedAddresses` (D-22); `x/take` params (dead code); gov/staking/slashing params (chain machinery, D-05).
+
+**REQ-SOL-029** Parameter PDAs MUST be updatable only by an instruction whose authority signer equals `governance_authority` stored in the registry (§5.2), with range validation matching the current chain (warn > halt, both ≤ 10 000 bps; spreads ≤ 1 000 bps; `order_max_bids ≤ 500`; reclamation min < max) plus new-cap validation per REQ-SOL-019. Every update emits `ParamsUpdated{tag, old_hash, new_hash}`.
+
+**REQ-SOL-030** All programs MUST read parameters from these PDAs at execution time (passed read-only); no protocol constant that exists as a parameter here may be compiled in.
+
+### 5.2 Program registry (discovery successor)
+
+PDA `["registry"]` (~512 bytes): `governance_authority: Pubkey` (Realms-executed timelock, §13), `upgrade_authority: Pubkey` (Squads vault), `min_client_version: [u8;16]` (semver string), and per program: `{name: [u8;16], program_id: Pubkey, api_version: u16, verified_build_hash: [u8;32], idl_account: Pubkey}`; plus pinned cross-program addresses (`escrow_gateway`, `hook_auth`, ACT/AKT/STABLE mints, Pyth receiver program id).
+
+**REQ-SOL-031** SDKs and the provider daemon MUST perform version negotiation against this account at session start (replacing `GET /akash/discovery/v1/info` and its `min_client_version` contract): a client whose version is below `min_client_version` MUST refuse to submit transactions. `api_version` bumps accompany any instruction/event schema addition. Client behavior detail in [07](./07-offchain-and-clients.md).
+
+**REQ-SOL-032** Registry mutations (program registered/retired, `min_client_version` raise, authority rotation) are governance actions (§13) and emit events; `min_client_version` raises MUST be announced ≥ 14 days before enforcement (indexer/Console coordination, [07](./07-offchain-and-clients.md)).
+
+Events: `ParamsUpdated`, `ProgramRegistered`, `MinClientVersionRaised`, `AuthorityRotated`. Errors (6000-6019): `UnauthorizedAuthority`, `ParamOutOfRange`, `UnknownModuleTag`, `RegistryFull`.
+
+---
+
+## 6. `akash-provider-registry`
+
+Purpose: provider identity, attributes for bid matching, JWT signing keys (D-10), and registration collateral (Q-08). Carries `x/provider` semantics (`x/provider/handler/server.go`).
+
+### 6.1 Accounts
+
+| Account | Seeds | Size / rent (SOL ≈ $150) | Close |
+|---|---|---|---|
+| Provider | `["provider", owner]` | ≤ 3,072 B → 0.0223 SOL ≈ $3.34 | closeable after `deactivate` + no live leases/bids + collateral withdrawn |
+
+Provider fields: `owner` (the cold owner authority, per D-10.a / 07), `state: u8` (active / deactivated), `host_uri: String ≤ 128 B`, `attributes: Vec<(key ≤ 32 B, value ≤ 64 B)> ≤ 24`, `info: {email ≤ 64 B, website ≤ 64 B}`, `signing_keys: Vec<{alg: u8 (0=Ed25519), pubkey: [u8;32], added_at: i64, revoked_at: i64}> ≤ 3` (rotating operator hot keys for JWT signing, per D-10.a / 07), `tls_spki_hashes: Vec<[u8;32]> ≤ 3` (provider TLS SPKI hash anchors, per D-10.a / 07), `collateral: {mint, amount: u64, withdraw_after: i64}`, `created_at`, `bump`.
+
+### 6.2 Instructions
+
+| Ix | Signer | Args | Validation / effects | CU |
+|---|---|---|---|---|
+| `create_provider` | owner | host_uri, attributes, info, first signing key | PDA init; attribute caps; transfers collateral (AKT, amount from Q-08 outcome; mechanism normative, size open) into program-owned vault; emits `ProviderCreated` | 60k |
+| `update_provider` | owner | host_uri?, attributes?, info? | active providers only; no active-lease check (parity: check removed on current chain in v0.32.0 and not reintroduced); `ProviderUpdated` | 40k |
+| `add_signing_key` / `revoke_signing_key` | owner | key / key index | ≤ 3 live keys; revocation sets `revoked_at` (kept for JWT grace, prunable after 30 d); `SigningKeyAdded/Revoked` | 20k |
+| `deactivate_provider` | owner | none | blocks new bids (checked by `market::create_bid`); starts collateral timer `withdraw_after = now + max_reclamation_window`; `ProviderDeactivated` | 20k |
+| `withdraw_collateral` | owner | none | requires deactivated + `now ≥ withdraw_after`; returns collateral; account closeable | 30k |
+
+**REQ-SOL-033** `create_provider` MUST lock registration collateral (denom AKT; amount and slashing conditions are Q-08, Vendor proposes at G1) and `withdraw_collateral` MUST enforce deactivation plus a delay ≥ `max_reclamation_window_secs`, so a provider cannot exit collateral while any lease could still be in a reclamation window.
+
+**REQ-SOL-034** JWT signing keys registered here are the on-chain trust root for provider-gateway auth (D-10), replacing the `x/cert` x509 registry: provider daemons sign JWTs with a registered Ed25519 key; verifiers resolve keys by reading this account. Token format, scopes, and mTLS transport anchoring are specified in [07](./07-offchain-and-clients.md); this program only stores/rotates keys.
+
+**REQ-SOL-035** There is no `delete_provider` while any lease or bid references the provider (the current chain's `MsgDeleteProvider` is unimplemented; `x/provider/handler/server.go:74-88` returns NOTIMPLEMENTED); `deactivate_provider` + close-after-quiescence is the supported exit.
+
+Events: `ProviderCreated`, `ProviderUpdated`, `ProviderDeactivated`, `SigningKeyAdded`, `SigningKeyRevoked`, `CollateralWithdrawn`. Errors (6000-6029): `AttributeCapExceeded`, `KeyCapExceeded`, `ProviderDeactivated`, `CollateralLocked`, `HostUriTooLong`, `InvalidKeyAlg`.
+
+---
+
+## 7. `akash-audit`
+
+Purpose: auditor-signed attribute attestations per (provider, auditor), consumed by bid matching. Carries `x/audit` (`x/audit/handler/`).
+
+| Account | Seeds | Size / rent | Close |
+|---|---|---|---|
+| Attestation | `["audit", provider_owner, auditor]` | ≤ 2,688 B, typical 600 B → ~0.0051 SOL ≈ $0.76 | closed when last attribute deleted; rent → auditor |
+
+Fields: `provider_owner`, `auditor`, `attributes ≤ 24` (same encoding as provider), `created_at`, `updated_at`, `bump`.
+
+| Ix | Signer | Args | Effects | CU |
+|---|---|---|---|---|
+| `sign_provider_attributes` | auditor | provider, attributes | init-or-update (upsert semantics of `MsgSignProviderAttributes`); `AttestationSigned` | 35k |
+| `delete_provider_attributes` | auditor | provider, keys: Vec<String> | removes listed keys (empty list = all, mirroring `MsgDeleteProviderAttributes`); closes account when empty; `AttestationDeleted` | 25k |
+
+**REQ-SOL-036** Attestations MUST be independently writable per (provider, auditor) pair with auditor as sole write authority; providers cannot modify or delete attestations about themselves.
+
+Events: `AttestationSigned{provider, auditor, attributes}`, `AttestationDeleted{provider, auditor, keys}`. Errors (6000-6009): `AttributeCapExceeded`, `EmptyAttestation`, `KeyNotFound`.
+
+---
+
+## 8. `akash-deployment`
+
+Purpose: deployment + group lifecycle and dseq issuance. Carries `x/deployment` v1beta4 semantics (`x/deployment/handler/server.go:41-268`).
+
+### 8.1 Accounts
+
+| Account | Seeds | Fields (beyond §3 conventions) | Size / rent | Close |
+|---|---|---|---|---|
+| TenantCounter | `["tenant", owner]` | `next_dseq: u64` | 64 B → 0.00134 SOL ≈ $0.20 | never (per-tenant singleton; negligible rent) |
+| Deployment | `["deployment", owner, dseq_le]` | `state: u8` (pending / active / closing / closed), `version_hash: [u8;32]` (SDL manifest hash, `Deployment.Hash`), `created_at`, `reclamation_min_window_secs: i64` (0 = none), `group_count: u32`, `open_group_count: u32` | 128 B → 0.00178 SOL ≈ $0.27 | on `closed` with all groups closed; rent → tenant |
+| Group | `["group", owner, dseq_le, gseq_le]` | `state: u8` (open / paused / insufficient_funds / closed), `spec: GroupSpec`, `created_at` | ≤ 3,072 B, typical 1,200 B → ~0.0092 SOL ≈ $1.39 | on `closed`; rent → tenant |
+
+`GroupSpec` (Borsh; caps per REQ-SOL-019): `name ≤ 32 B`; `requirements: {signed_by_all_of ≤ 2, signed_by_any_of ≤ 4 (auditor pubkeys), attributes ≤ 24}`; `resources: Vec<ResourceUnit> ≤ 4` where ResourceUnit = `{cpu_milli: u64, memory_bytes: u64, gpu_units: u64, gpu_attributes ≤ 8, storage: Vec<{name ≤ 32 B, size_bytes: u64, attributes ≤ 4}> ≤ 3, endpoints: Vec<{kind: u8, seq: u32}> ≤ 8, count: u32, price_rate: u128}` (`price_rate` = uact per second × `RATE_SCALE`, converted from the current per-block DecCoin; see DELTA-01).
+
+**REQ-SOL-037** dseq assignment: `init_deployment` reads-and-increments `TenantCounter.next_dseq` (creating the counter at first use, starting at 1). Deployment PDAs are therefore dense per tenant and never collide; block height is not involved (Q-12, DELTA-09).
+
+### 8.2 Instructions
+
+| Ix | Signer / writable accounts | Args | Validation | Effects / CPIs | CU |
+|---|---|---|---|---|---|
+| `init_deployment` | tenant (s,w payer); TenantCounter(w), Deployment(init), EscrowAccount(init via CPI), deposit accounts | `version_hash`, `reclamation_min_window?`, `deposit {amount, mint, sources}` | deposit ≥ `min_deposits[mint]`; **mint MUST NOT be AKT** (parity: create rejects `uakt` deposits, `server.go:60-62`); mint ∈ {ACT, STABLE} (§4.3); reclamation window within market params (D-24) | Deployment(state=pending); CPI `escrow::account_create` with deposit (§10.2); `DeploymentInitialized` | 120k |
+| `add_group` | tenant; Deployment(w), Group(init) | `gseq` (must equal `group_count+1`), `spec` | deployment pending; spec caps; **every `price_rate` denominated in ACT** (parity: group price denom MUST be `uact`, `server.go:93`); gseq dense 1..N ≤ 8 | Group(state=open); `group_count++` | 60k |
+| `activate_deployment` | tenant; Deployment(w), Groups(r), Orders(init via CPI ×N) | none | pending, `group_count ≥ 1` | per open group: CPI `market::create_order{oseq=1, reclamation}`; state=active; `DeploymentCreated` (carries full group specs for the indexer) | 30k + 25k/group |
+| `update_deployment` | tenant; Deployment(w) | `version_hash` | active only; hash ≠ current (parity `server.go:132-157`) | updates hash; `DeploymentUpdated` | 15k |
+| `close_deployment` | tenant; Deployment(w), Groups(w), EscrowAccount(w via CPI) + refund accounts | none | active or closing | if any lease payments open → state=closing (barrier: blocks new orders/bids; leases closed via `market::close_lease` ixs composed in the same tx or cranked, §3.4); when no open payments: CPI `escrow::account_close` (settle + refund depositors, §10.3); groups+deployment → closed; `DeploymentClosed` | 80k + refunds |
+| `close_group` / `pause_group` | tenant; Group(w) (+ lease-close guards) | gseq | group open/paused; associated order/lease closure guarded as in §3.4 (market ixs composed first) | state → closed / paused; `GroupClosed`/`GroupPaused` | 30k |
+| `start_group` | tenant; Group(w), Deployment(r), Order(init via CPI) | gseq | group paused or insufficient_funds; deployment active | CPI `market::create_order{oseq+1}` with deployment reclamation (parity `server.go:226-253`); state=open; `GroupStarted` | 60k |
+| `hook_pause_group` | market `["hook_auth"]` PDA (s); Group(w) | none | caller PDA = pinned market hook (REQ-SOL-010); group open | state=paused (Cosmos `deployment.OnBidClosed → OnPauseGroup`, `keeper.go:421-427`); `GroupPaused` | 10k |
+| `reap_deployment` / `reap_group` | anyone; Deployment/Group(w), EscrowAccount(r) | none | escrow account state ∈ {closed, overdrawn} (REQ-SOL-016) | deployment closed; group → closed, or insufficient_funds when overdrawn (parity with `OnEscrowAccountClosed`); events as above | 25k |
+
+**REQ-SOL-038** `init_deployment`/`add_group`/`activate_deployment` MUST be composable into a single transaction (the atomic-create fast path used by SDKs when the SDL fits in one transaction) and equally valid across transactions with `state=pending` in between; orders MUST NOT exist and bids MUST NOT be accepted before activation.
+
+**REQ-SOL-039** `close_deployment` MUST be terminal and irreversible once state=closing (no new orders, no `start_group`), mirroring the one-way `MsgCloseDeployment` (`server.go:159-177`); full cascade completion (all leases/payments closed, all refunds out) MUST satisfy the 60 s p95 bound of REQ-SOL-017 via composed instructions or cranks.
+
+Events (all carry `{owner, dseq}` + listed fields): `DeploymentInitialized{deposit}`, `DeploymentCreated{groups: full specs}`, `DeploymentUpdated{version_hash}`, `DeploymentClosed{}`, `GroupStarted/GroupPaused/GroupClosed{gseq, reason}`, a superset of the Cosmos typed events (`x/deployment/keeper/keeper.go:228-379`). Errors (6000-6049): `DeploymentExists`, `InvalidDeposit`, `AktDepositForbidden`, `InvalidGroupPriceDenom`, `GroupCapExceeded`, `SpecBoundExceeded`, `InvalidState`, `HashUnchanged`, `ReclamationWindowOutOfBounds`, `OpenChildrenRemain`.
+
+---
+
+## 9. `akash-market`
+
+Purpose: order/bid/lease lifecycle, bid matching against provider + audit attributes, bid collateral, reclamation windows. Carries `x/market` v1beta5 (`x/market/handler/server.go:29-392`).
+
+### 9.1 Accounts
+
+| Account | Seeds | Fields | Size / rent | Close |
+|---|---|---|---|---|
+| Order | `["order", owner, dseq_le, gseq_le, oseq_le]` | `state: u8` (open / matched / closed), `group: Pubkey`, `spec_hash: [u8;32]`, `created_at`, `reclamation_window_secs: i64` (copied from deployment), `bid_count: u32`, `winner: Pubkey` (default) | 192 B → 0.00223 SOL ≈ $0.33 | on closed AND lease closed AND all bids resolved; rent → tenant |
+| Bid | `["bid", owner, dseq, gseq, oseq, provider, bseq_le]` | `state: u8` (open / active / lost / closed), `price_rate: u128` (uact/s × RATE_SCALE), `created_at`, `resources_offer` (≤ 4 units, same encoding as GroupSpec resources), `reclamation_window_secs: Option<i64>` | ≤ 1,024 B → 0.0080 SOL ≈ $1.20 | on lost/closed after bid-escrow close; rent → provider |
+| Lease | `["lease", owner, dseq, gseq, oseq, provider]` | `state: u8` (active / insufficient_funds / closed / reclaiming), `price_rate: u128`, `created_at`, `closed_on: i64`, `reason: u32` (LeaseClosedReason enum values preserved: 1, 10000-10003, 20000), `reclamation: Option<{window_secs, started_at, deadline}>` | 224 B → 0.00245 SOL ≈ $0.37 | on closed after payment closed; rent → tenant |
+
+Orders reference their Group PDA and store only `spec_hash` rather than copying the full `GroupSpec` (the Cosmos `Order.Spec` copy); group specs are immutable while any order is open, so bid validation reads the Group account directly. Normalization delta DELTA-11.
+
+### 9.2 Instructions
+
+| Ix | Signer / key accounts | Args | Validation (parity source) | Effects / CPIs | CU |
+|---|---|---|---|---|---|
+| `create_order` | deployment program CPI only (payer = tenant); Order(init), Group(r) | oseq, reclamation | caller = `akash-deployment` (CPI-only ix); oseq = previous+1 | Order(open); `OrderCreated` | 25k |
+| `create_bid` | provider (s, payer); Order(w: bid_count), Group(r), Provider(r), Attestations(r, remaining ≤ 4), Bid(init), EscrowAccount(init via CPI), deposit accounts, params(r) | `price_rate`, `resources_offer`, `reclamation_window?`, `deposit {amount, mint, sources}` | order open; `bid_count < order_max_bids` (=20) `[TO-VERIFY: whether BidCountForOrder on the current chain counts closed bids (x/market keeper); if open-only, decrement on bid close]`; bseq == 0 (`server.go:29-136`); `price_rate ≤` group unit price sum (bid not above order); `resources_offer` matches group spec (`MatchGSpec`); provider active in registry; attribute match: group requirements vs provider attributes with audit attestations satisfying `signed_by` (self-attributes prepended, parity with `audit.GetProviderAttributes` use); deposit ≥ `bid_min_deposits[mint]`; reclamation within bounds | Bid(open); `bid_count++`; CPI `escrow::account_create` (bid collateral); `BidCreated` | 100k |
+| `close_bid` | provider; Bid(w), Order(w), Lease(w?), Payment(w via CPI), Group(w via hook) | reason | open bid: close + escrow account close (refund collateral). Active bid (lease exists): reclamation gate. Lease active with `reclamation ≠ None` → `ErrReclamationNotStarted`; lease reclaiming with `now < deadline` → `ErrReclamationWindowNotElapsed` (`server.go:138-192`) | CPI `deployment::hook_pause_group`; lease closed (reason preserved); order closed; CPI `escrow::payment_close`; CPI `escrow::account_close` (bid); `BidClosed`, `LeaseClosed` | 140k |
+| `create_lease` | tenant (s, payer); Bid(w), Order(w), Group(r), Lease(init), deployment EscrowAccount(w), Payment(init via CPI), sibling payments(w, remaining) | none | bid open, order open, group open (`server.go:209-283`) | CPI `escrow::payment_create{rate = bid.price_rate}` (settles account first, §10.3); Lease(active) with `reclamation.window = bid.reclamation_window`; order → matched, `winner = provider`; bid → active; `LeaseCreated`, `OrderMatched` | 150k |
+| `close_losing_bid` | anyone; Bid(w), Order(r), losing-bid EscrowAccount(w via CPI) + refund accounts | none | order matched AND `bid.provider ≠ order.winner` AND bid open (REQ-SOL-016) | bid → lost; CPI `escrow::account_close` (collateral + rent refund to provider); `BidClosed{state=lost}` | 80k |
+| `close_lease` | tenant; Lease(w), Order(w), Bid(w), Group(r), Payment(w via CPI), new Order(init, optional) | reason=owner | lease active/reclaiming (`server.go:285-336`) | lease/bid/order closed; CPI `escrow::payment_close` (final settle + payout); **if group still open: create new Order with oseq+1 in the same instruction (re-list, tenant pays rent)**; `LeaseClosed`, `OrderCreated?` | 150k |
+| `withdraw_lease` | anyone; Payment(w via CPI) + settle set | none | permissionless (payout only to payment owner; supersedes provider-signed `MsgWithdrawLease`, DELTA-05) | CPI `escrow::payment_withdraw` | 20k + escrow |
+| `lease_start_reclaim` | provider; Lease(w) | reason | lease active; `reclamation ≠ None`; `started_at == 0` (`server.go:338-379`) | `started_at = now`, `deadline = now + window`, state=reclaiming; `LeaseReclaimStarted` | 25k |
+| `reap_lease` | anyone; Lease(w), Order(w), Bid(w), Payment(r) | none | payment state ∈ {overdrawn, closed} while lease not closed (§3.4) | lease → insufficient_funds (reason 20000) if overdrawn else closed; order/bid closed; events as `OnEscrowPaymentClosed` cascade | 40k |
+
+**REQ-SOL-040** `create_bid` MUST enforce the full matching pipeline of the current chain in this order: order/group state, bid count cap, price ceiling, resource-offer match, provider existence/active flag, placement-attribute match including `signed_by` audit requirements, deposit minimums, reclamation bounds, each failure mapping to a distinct error code (below) for provider-daemon diagnostics.
+
+**REQ-SOL-041** Attribute matching MUST treat the provider's self-declared attributes as lowest precedence and auditor attestations as authoritative for `signed_by` requirements: for every auditor in `signed_by_all_of` (and at least one of `signed_by_any_of`) the corresponding Attestation PDA MUST be present in remaining accounts, owner-checked, and MUST contain every required attribute key/value.
+
+**REQ-SOL-042** Bid collateral MUST live in a dedicated escrow account (`["escrow", bid_pda]`) created at bid time and MUST be refunded in full (with rent) on: losing the order (`close_losing_bid`), closing an open bid, or closing an active bid after lease close; never slashed by the marketplace (parity: no bid slashing exists on the current chain).
+
+**REQ-SOL-043** Losing-bid refunds are asynchronous (DELTA-06): `create_lease` MUST NOT require losing-bid accounts in its transaction; `close_losing_bid` MUST be executable by anyone immediately after the lease exists, and the crank SLA of REQ-SOL-017 applies. Collateral remains custody-safe in the bid escrow until then.
+
+**REQ-SOL-044** Re-listing on tenant lease close MUST be synchronous within `close_lease` when the group is open (parity: `MsgCloseLease` re-opens a new order, `server.go:285-336`); provider-initiated (`close_bid`) and insolvency (`reap_lease`) paths MUST NOT re-list: they pause the group / mark insufficient_funds respectively, exactly as the Cosmos hook cascade does.
+
+**REQ-SOL-045** Reclamation (D-24): `lease_start_reclaim` + windowed `close_bid` MUST port 1:1 with window bounds `[min_reclamation_window, max_reclamation_window]` = [1 h, 720 h] validated at bid and lease creation; deadlines are wall-clock (`now + window`).
+
+Events: `OrderCreated{order id, group, spec_hash, reclamation}`, `OrderMatched{order id, winner}`, `OrderClosed`, `BidCreated{bid id, price_rate, deposit}`, `BidClosed{bid id, state, reason}`, `LeaseCreated{lease id, price_rate}`, `LeaseClosed{lease id, reason, closed_on}`, `LeaseReclaimStarted{lease id, deadline}`, a superset of `x/market` typed events. Errors (6000-6079): `OrderNotOpen`, `MaxBidsReached`, `BseqNotZero`, `BidOverOrderPrice`, `ResourceOfferMismatch`, `ProviderNotFound`, `ProviderInactive`, `AttributeMismatch`, `AuditRequirementUnmet`, `InsufficientBidDeposit`, `ReclamationNotStarted`, `ReclamationWindowNotElapsed`, `ReclamationWindowOutOfBounds`, `GroupNotOpen`, `NotWinner`, `AlreadyReaped`.
+
+---
+
+## 10. `akash-escrow`
+
+Purpose: generic streaming-payment escrow for deployments and bids (multi-denom funds, ordered depositor list, per-second payment rates, lazy settlement, overdrawn semantics, AKT fallback, delegated-deposit allowances). Carries `x/escrow` (`x/escrow/keeper/keeper.go`) with the D-21 time basis.
+
+### 10.1 Accounts
+
+| Account | Seeds | Size / rent | Close |
+|---|---|---|---|
+| EscrowAccount | `["escrow", entity_pda]` | init 832 B (4 depositor slots) → 0.0067 SOL ≈ $1.00; realloc to 1,984 B max (16 slots) | on closed with all payments closed and funds refunded; rent → rent_payer |
+| EscrowVault | `["vault", escrow_pda, mint]` (Token-2022/SPL token account) | ~182 B → 0.0022 SOL ≈ $0.32 | closed with parent; lazily created on first deposit of that mint (AKT, STABLE only; ACT holds no vault, §4.2) |
+| Payment | `["payment", lease_pda]` | 224 B → 0.00245 SOL ≈ $0.37 | on closed with balance withdrawn; rent → rent_payer |
+| Allowance | `["allowance", granter, grantee]` | 256 B + per-mint vaults | on revoke; rent → granter |
+
+EscrowAccount fields: `entity: Pubkey`, `scope: u8` (deployment / bid; `escrowid.Account.Scope`), `owner: Pubkey`, `state: u8` (open / closed / overdrawn), `settled_at: i64` (**frozen while overdrawn**, parity `accountSettle` `keeper.go:535-604`), `funds: [(mint, u128 scaled)] ≤ 3`, `transferred: [(mint, u128)] ≤ 3` (lifetime settled, parity `AccountState.Transferred`), `deposits: Vec<Depositor> ≤ 16` where Depositor = `{owner: Pubkey, source: u8 (balance=0 / allowance=1), deposited_at: i64, mint: Pubkey, balance: u128}` in strict insertion order (FIFO, replaces height ordering), `open_payment_count: u32`, `payment_seq: u32`, `rent_payer`, `bump`.
+
+Payment fields: `account: Pubkey`, `lease: Pubkey`, `owner: Pubkey` (provider payee), `state: u8` (open / closed / overdrawn), `rate: u128` (uact/s × RATE_SCALE), `balance_act: u128`, `balance_stable: u128` (accrued, unwithdrawn, per settlement denom), `unsettled: u128` (uact-denominated debt while overdrawn; `PaymentState.Unsettled`), `withdrawn_act: u64`, `withdrawn_stable: u64`, `withdrawn_akt: u64`, `created_seq: u32` (settlement iteration order), `rent_payer`, `bump`.
+
+**REQ-SOL-046** The depositor vector is bounded by the DAO-config parameter `escrow.max_depositors` (initial value 16). Justification: the current chain caps depositors only by gas, and observed usage is ≤ 2 (tenant + one Console sponsor; the v0.34.0 authz semantics permit only one grant depositor per deployment). 16 gives 8× headroom while bounding account size (1,984 B) and refund-instruction account counts. Accounts init with 4 slots and realloc up to 16 on demand (deposit pays the realloc rent delta).
+
+### 10.2 Deposits and allowances
+
+`Deposit{amount, mint, sources: Vec<(kind, amount)>}` walks sources in order, exactly like `AuthorizeDeposits` (`keeper.go:176-345`): `balance` draws from the signer's token balance (capped at spendable); `allowance` draws from the named Allowance PDA (granter recorded as depositor). A non-zero remainder after all sources fails the instruction (`ErrInvalidDeposit`). Exactly one wallet signer per deposit.
+
+Allowance semantics (replaces authz `DepositAuthorization`, D-21):
+
+- `create_allowance{grantee, limits: Vec<(mint, amount)> ≤ 3, scopes: bitmask{deployment, bid}, expires_at?}`: granter signs. **Funded at grant**: AKT/STABLE transfer into `allowance_vault`; ACT is burned via the BME gateway and held as allowance credit (`act_escrowed` accounting, §4.2).
+- Deposit draw: decrements `limits[mint]`, moves value allowance→escrow (vault-to-vault transfer, or pure ledger move for ACT); Depositor entry records `owner = granter`, `source = allowance`.
+- **Restore-on-refund**: refunds attributable to an allowance-sourced Depositor return value to the allowance (vault + `limits` restored), NOT to the granter's wallet (parity with grant-refund semantics, `keeper.go:1050-1075`). Console fee-sponsorship flows depend on this (D-21).
+- `revoke_allowance`: granter signs; returns unspent vault balances (ACT re-minted) to granter; closes PDA.
+
+**REQ-SOL-047** Allowances MUST be funded at grant time (tokens locked in allowance vaults / burned-with-credit for ACT). This intentionally differs from authz spend limits, which reserve nothing until drawn (DELTA-07): Solana cannot pull tokens from a non-signing wallet without standing token delegates, which are per-token-account, single-slot, and unusable on a NonTransferable mint. Restore-on-refund and revoke-returns-remainder MUST hold exactly.
+
+**REQ-SOL-048** Scope enforcement: an allowance with only the `deployment` scope MUST be unusable for bid collateral and vice versa, mirroring `DepositAuthorization.Scopes`.
+
+### 10.3 Settlement engine
+
+Definitions (all math in u128 × RATE_SCALE; parity `accountSettle`/`accountSettleFullBlocks`/`deductFromBalance`, `keeper.go:535-604, 1211-1333`):
+
+1. `elapsed = now − settled_at`; if account overdrawn, `settled_at` is frozen and only debt-clearing (step 5) runs.
+2. Settlement set = all payments with state overdrawn ∪ (open if elapsed > 0). **The instruction MUST receive every open/overdrawn payment of the account** (validated: distinct payment PDAs with `account == escrow`, count == `open_payment_count` + overdrawn presented); iteration order = ascending `created_seq`.
+3. Per payment: `owed = rate × elapsed` (or `unsettled` first if overdrawn). Drain FIFO over `deposits`: pass 1 over ACT entries, pass 2 over STABLE entries at par (§4.3). Drained amounts credit `balance_act`/`balance_stable` and accumulate `transferred`; zero-balance depositor entries are pruned.
+4. Shortfall on a payment ⇒ that payment → overdrawn, `unsettled += shortfall`; continue the walk (later payments see empty funds and go overdrawn too, mirroring the sequential negative-funds walk).
+5. **AKT fallback** (parity `settleFromAktFallback` `keeper.go:609-687`): if any payment is overdrawn AND `funds[AKT] > 0` AND BME status ≥ `halt_cr` (read from `BmeState`) AND a valid Pyth price is supplied (REQ-SOL-020): convert `unsettled` (uact ≡ micro-USD) to AKT at spot (`akt = unsettled / price`), drain AKT FIFO, transfer vault→provider immediately, clear `unsettled`, payment → open. Debt is not carried beyond funds (funds zeroed if exhausted).
+6. Any payment still overdrawn ⇒ account → overdrawn: every payment → overdrawn, accrued balances paid out (`payment_withdraw` semantics), remaining deposits refunded FIFO with allowance restore, `AccountOverdrawn` emitted (cascade reaps follow, §3.4).
+
+Settlement triggers (parity list `keeper.go` §settlement trigger points): `account_close`, `account_deposit` (when overdrawn: clears debt first, remainder refunded), `payment_create`, `payment_withdraw`, `payment_close`, and the standalone permissionless `settle` (D-21, the explicit replacement for consensus-driven detection).
+
+### 10.4 Instructions
+
+| Ix | Signer | Key accounts | Effects | CU |
+|---|---|---|---|---|
+| `account_create` | CPI-only (deployment/market) | EscrowAccount(init), deposit accounts, BME gateway set (ACT) | validates deposit mins (caller passes params); records depositors; `AccountCreated`, `AccountDeposited` | 40k + 25k/ACT leg |
+| `account_deposit` | depositor | EscrowAccount(w), vaults, Allowance(w)?, BME set | open or overdrawn accounts; **the only path that accepts AKT** (parity: `MsgAccountDeposit`, `handler/server.go:31-44`); overdrawn: settle-clear-refund per §10.3(5-6) | 60k |
+| `settle` | anyone | EscrowAccount(w), all open payments(w), Pyth(opt), BME state(r), provider ATAs(w, fallback) | §10.3; no-op if elapsed == 0 (idempotent) | 25k + 15k/payment (+60k fallback) |
+| `payment_create` | CPI-only (market) | EscrowAccount(w), Payment(init), settle set | settles account first; rejects if account not open; rate > 0; `PaymentCreated` | 30k + settle |
+| `payment_withdraw` | anyone | Payment(w), EscrowAccount(w), settle set, provider ACT+STABLE ATAs(w), BME gateway set | settle, then pay `floor(balance_*)` to payment.owner: ACT via `gateway_payout_mint`, STABLE via vault transfer; `withdrawn_* +=`; **no protocol take: provider receives 100%** (parity: no fee deduction exists, `paymentWithdraw` `keeper.go:1187-1209`; `x/take` is dead code) | 60k + settle |
+| `payment_close` | CPI-only (market) | Payment(w), EscrowAccount(w), settle set, payee ATAs | settle + final withdraw + state=closed; `open_payment_count--`; `PaymentClosed` | 50k + settle |
+| `account_close` | CPI-only (deployment/market) | EscrowAccount(w), settle set, depositor ATAs(w) + Allowances(w) (remaining, one per live depositor) | requires `open_payment_count == 0` unless invoked on overdrawn path; settle; refund every remaining depositor FIFO (ACT re-mint / STABLE+AKT vault transfer; allowance-sourced → restore, §10.2); close vaults + account; `AccountClosed` | 40k + 20k/depositor |
+| `create_allowance` / `revoke_allowance` | granter | Allowance(init/close), vaults, BME set | §10.2; `AllowanceCreated/Revoked` | 60k |
+
+**REQ-SOL-049** Settlement MUST be fully lazy: no instruction other than the triggers above performs accrual, and accrual is a pure function of (`rate`, `settled_at`, `now`, funds); replaying the same second twice MUST be a no-op (idempotency, §14.6).
+
+**REQ-SOL-050** `settle` and `payment_withdraw` MUST be permissionless with funds movable only to protocol-defined destinations (payment owner, depositors, allowances); missing payee ATAs are created idempotently with the caller as rent payer.
+
+**REQ-SOL-051** Overdrawn semantics MUST match the current chain observably: overdrawn is terminal for the account (leases die via reaps); `settled_at` freezes at the overdraw point; per-payment `unsettled` debt is cleared only by the AKT fallback or post-mortem deposits; depositor refunds occur exactly once.
+
+**REQ-SOL-052** The AKT fallback MUST activate only when BME status ≥ `halt_cr` and the supplied Pyth price passes REQ-SOL-020 bounds with a positive price, mirroring `bme.GetMintStatus() >= MintStatusHaltCR` + positive-oracle gating; under `halt_oracle` the fallback is unreachable (no valid price exists), matching current behavior.
+
+**REQ-SOL-053** Escrow conservation invariant (tested per [09](./09-testing-and-verification.md)): for every account and mint, `Σ deposits − Σ refunds = funds + transferred`, and for ACT globally `act_escrowed = Σ open accounts' funds_act + Σ allowance ACT credits`. Any violation MUST abort the instruction.
+
+Events (escrow gains first-class events: the current module has none and surfaces via hooks; the indexer needs them, DELTA-13): `AccountCreated`, `AccountDeposited{depositor, mint, amount, source}`, `AccountSettled{transferred deltas}`, `AccountOverdrawn`, `AccountClosed{refunds}`, `PaymentCreated{rate}`, `PaymentWithdrawn{act, stable, akt}`, `PaymentOverdrawn{unsettled}`, `PaymentClosed`, `AllowanceCreated/Drawn/Restored/Revoked`. Errors (6000-6099): `InvalidDeposit`, `DepositorCapExceeded`, `MintNotAllowed`, `AccountNotOpen`, `PaymentSetIncomplete`, `RateZero`, `NothingToWithdraw`, `AllowanceExpired`, `AllowanceScopeViolation`, `AllowanceInsufficient`, `FallbackUnavailable`, `StalePrice`, `ConfidenceTooWide`, `ConservationViolated`, `OpenPaymentsRemain`.
+
+---
+
+## 11. `akash-bme`
+
+Purpose: the AKT↔ACT burn-mint engine, comprising swap queues executed in time-based epochs by permissionless cranks, collateral-ratio circuit breaker, vault, spreads, and the ACT gateway (§4.2). Carries `x/bme` (`x/bme/keeper/`, `x/bme/handler/server.go`) per D-20.
+
+### 11.1 Accounts
+
+| Account | Seeds | Fields | Size / rent | Close |
+|---|---|---|---|---|
+| BmeState | `["bme_state"]` | `status: u8` (1=healthy, 2=warning, 3=halt_cr, 4=halt_oracle; enum values preserved), `previous_status: u8`, `epoch_secs: i64` (current, backoff-adjusted), `next_mint_epoch_at: i64`, `next_burn_epoch_at: i64`, `total_burned_akt/act: u64`, `total_minted_akt/act: u64`, `remint_credit_act: u64`, `act_escrowed: u128` (§4.2), `pending_akt: u64`, `pending_act: u64` (in-flight, excluded from CR; parity `ledgerPendingBalances`), `mint_head/tail: u64`, `burn_head/tail: u64`, `last_cr_bps: u16` | 256 B → 0.0040 SOL ≈ $0.60 | never |
+| Vault | `["bme_vault"]` (AKT token account, authority = same PDA) | AKT collateral; seeded from the migrated `bme` module account via the Wind-down Reserve ([05](./05-token-migration.md)) | token account | never |
+| SwapRequest | `["swap", dir, seq_le]` | `owner`, `to: Pubkey` (recipient, parity `MsgBurnMint.To`), `amount_in: u64`, `state: u8` (pending / executed / canceled), `attempts: u8`, `created_at` | 128 B → 0.0018 SOL ≈ $0.27 | on executed/canceled (immediately); rent → owner |
+| TipTreasury | `["tip_treasury"]` | lamports pool for crank tips (Tuk Tuk-compatible; funding source Q in 13) | 0 B system acct | never |
+
+### 11.2 Instructions
+
+| Ix | Signer | Args / key accounts | Validation (parity `RequestBurnMint` `keeper.go:786-865`) | Effects | CU |
+|---|---|---|---|---|---|
+| `request_swap` | owner | dir, amount, `to`; BmeState(w), SwapRequest(init), vault or ACT accounts, Pyth(r) | mints ∈ {AKT→ACT, ACT→AKT} only; valid fresh price (REQ-SOL-020); `status < halt_cr`, EXCEPT dir=ACT→AKT allowed when `status == halt_cr` (**blocked under `halt_oracle`**), the halt_cr-allows-ACT-burns rule; dir=AKT→ACT: `amount` yields ≥ `min_mint` ACT | seq = tail++; AKT→ACT: transfer owner→vault, `pending_akt += amount`; ACT→AKT: burn owner's ACT, `pending_act += amount`; `SwapRequested` | 60k |
+| `cancel_swap` | owner | SwapRequest(w), BmeState(w), refund accounts | pending only; owner-initiated cancel or crank-driven at `attempts == max_pending_attempts` (reason preserved: `BMCancelReasonMaxAttempts`) | AKT returned from vault, or ACT re-minted (remint credit accounting, parity `remintCredits`); pending_* decremented; close PDA; `SwapCanceled{reason}` | 45k |
+| `crank_status` | anyone | BmeState(w), ACT mint(r), vault(r), Pyth(r) | none | recompute CR + status per §11.4; on change emit `MintStatusChange{previous, new, cr_bps}` (parity `mintStatusUpdate` `keeper.go:882-946`); breaker-reset recomputes `next_mint_epoch_at` (parity: EndBlocker step 3) | 30k |
+| `execute_swaps` | anyone (cranker, tipped) | dir, max_records ≤ `max_records_per_epoch`; BmeState(w), SwapRequests(w, ascending seq from head), recipient token accounts(w), vault(w), ACT mint(w), Pyth(r), TipTreasury(w) | `now ≥ next_*_epoch_at`; dir=mint requires status ∈ {healthy, warning}; dir=burn requires status ≠ halt_oracle (parity: EndBlocker executes the burn queue regardless of CR halt) | per record in seq order: price the swap at Pyth spot; AKT→ACT: mint `amount × P_akt / P_act × (1 − mint_spread_bps)` ACT to `to`, vault retains AKT; ACT→AKT: transfer `amount × P_act / P_akt × (1 − settle_spread_bps)` AKT from vault to `to`; failures: fatal → cancel, retriable (e.g. missing ATA) → `attempts++` and stop (head parks ≤ `max_pending_attempts` epochs); **abort walk if CR trips mid-batch** (post-condition, parity EndBlocker `abci.go:35-213`); head advances past resolved; `next_epoch_at = now + epoch_secs`; tip paid per record; `SwapExecuted{burned, minted, price, spread}` per record | 30k + 45k/record |
+| `gateway_deposit_burn` / `gateway_payout_mint` / `gateway_refund_mint` | escrow `["escrow_gateway"]` PDA | §4.2 | REQ-SOL-027 | ACT burn/mint + `act_escrowed` accounting | 20k |
+| `fund_vault` | governance authority | amount; source token account(w), vault(w) | authority check via config (parity `MsgFundVault` gov gate, `server.go:123-167`) | transfer AKT into vault; `VaultFunded` | 30k |
+
+**REQ-SOL-054** Epochs are time-based (D-20, DELTA-03): `next_mint_epoch_at`/`next_burn_epoch_at` timestamps replace `MinEpochBlocks` block counting. Execution is permissionless; the reference crank deployment is Tuk Tuk-style with per-record tips from `TipTreasury`, but any caller MUST be able to execute. The mint and burn queues have independent epoch clocks (parity: separate `"mint"`/`"burn"` epoch entries).
+
+**REQ-SOL-055** Backoff (parity `calculateCR` backoff, `keeper.go:742-784`): `epoch_secs = min_epoch_secs × (1 + epoch_backoff_pct/100)^steps` with `steps = max(0, (cr_warn_bps − cr_bps)/10)`, capped at `epoch_backoff_cap_secs` (93,600 s ≈ the current 14,400-block cap).
+
+**REQ-SOL-056** Swap execution order is strict FIFO per direction (ascending seq from head); `execute_swaps` MUST reject out-of-order or gapped presentation. Head-of-line blocking is bounded by `max_pending_attempts` (3) epochs, after which the crank cancels-and-advances.
+
+### 11.3 Flow of funds
+
+AKT→ACT (mint direction): user AKT enters the vault at request time and **stays in the vault as collateral** on execution; ACT is minted at the EMA-checked spot price minus `mint_spread_bps`. ACT→AKT (burn direction): user ACT is burned at request; on execution AKT is **paid from the vault**. `[TO-VERIFY: whether current-chain execution pays redemptions from the vault balance or fresh-mints uakt (x/bme keeper execution internals); if fresh-mint, list as an additional delta with supply-neutrality analysis in 14]`. On Solana, vault-payout is normative: post-migration AKT mint authority belongs exclusively to claims/emissions (REQ-SOL-023), so BME MUST NOT mint AKT.
+
+### 11.4 Collateral ratio and statuses
+
+**REQ-SOL-057** `cr_bps = (vault_akt − pending_akt) × P_akt / P_act × 10_000 / act_outstanding`, where `act_outstanding = act_mint.supply + act_escrowed + pending_act_refundable_credits` and `P_akt` is the Pyth EMA price (REQ-SOL-021), `P_act` the ACT/USD peg parameter (§4.3). Status mapping (parity): `cr ≥ warn` → healthy; `halt < cr < warn` → warning; `cr ≤ halt` → halt_cr; missing/stale/zero price → halt_oracle. Status transitions emit `MintStatusChange` and re-derive `epoch_secs` (REQ-SOL-055).
+
+**REQ-SOL-058** Status recomputation MUST run inside `request_swap`, `execute_swaps`, and `crank_status`, and the crank service MUST call `crank_status` at least every 60 s (the event-driven replacement for per-block `mintStatusUpdate`, DELTA-03). Escrow's fallback gate (REQ-SOL-052) reads the last committed status; the ≤ 60 s status lag is the accepted staleness bound, tested in [09](./09-testing-and-verification.md).
+
+Events: `SwapRequested`, `SwapExecuted` (the `LedgerRecordExecuted` analog; carries burned/minted CoinPrice pairs and spread for indexer ledger reconstruction), `SwapCanceled` (`LedgerRecordCanceled`), `MintStatusChange`, `VaultFunded`. Errors (6000-6059): `UnsupportedPair`, `MintHalted`, `OracleHalted`, `BelowMinMint`, `EpochNotDue`, `OutOfOrderExecution`, `CrTrippedMidBatch`, `NotPending`, `MaxAttemptsExceeded`, `UnauthorizedGateway`, `StalePrice`, `ConfidenceTooWide`.
+
+---
+
+## 12. `akash-claims` and `akash-emissions` (interfaces only)
+
+Both are specified in [05. Token migration](./05-token-migration.md); this section fixes only what the rest of the architecture depends on.
+
+**REQ-SOL-059** `akash-claims` holds the AKT mint authority during the claim window (REQ-SOL-023) and exposes: Merkle-root tranche accounts (S1, weekly residuals, S2 per D-05), `claim` (mints to claimant against an unclaimed-leaf proof, one-shot per leaf), the Wind-down Reserve PDA, and a governance-gated `seed_bme_vault` that funds `["bme_vault"]` from the Reserve (D-20). Vesting re-creation per D-06 uses per-beneficiary vesting PDAs with linear/cliff release, claimable as vested.
+
+**REQ-SOL-060** `akash-emissions` receives the AKT mint authority at claim-window close and mints per an on-chain schedule account (rate table with hard cap) to exactly two destinations: the provider-incentives treasury and the community treasury (both DAO-owned token accounts). The schedule is DAO-mutable within the immutable hard cap; the curve itself is the Q-01 modeling deliverable: the Vendor implements the mechanism, not a specific curve (D-12). Minting is executed by a permissionless, time-gated `mint_epoch` crank.
+
+---
+
+## 13. Governance and upgrade authority
+
+Per D-11/D-15; operational detail (signer sets, ceremony, transition plan) in [08. Security & audits](./08-security-and-audits.md).
+
+**REQ-SOL-061** DAO stack: Realms (SPL Governance) with AKT as the governance token; proposal execution flows through a governance-owned timelock authority; that executed authority is the `governance_authority` pinned in the registry (§5.2). Q-11 (Realms stock vs light fork; Token-2022 deposit support) MUST be resolved at G1; `[TO-VERIFY: spl-governance Token-2022 (AKT) deposit support as of kickoff; if unsupported, the Q-05 legacy-SPL fallback or a governance wrapper decides]`.
+
+**REQ-SOL-062** Program upgrade authority for all nine programs is a Squads v4 multisig vault, with execution subject to a timelock of ≥ 48 h for routine upgrades (emergency path per [08](./08-security-and-audits.md)). Upgrade authority MUST never be a hot wallet or a single signer; every upgrade publishes the verifiable build hash (REQ-SOL-004) before the timelock matures.
+
+**REQ-SOL-063** Mutability partition:
+
+| DAO-mutable (via `governance_authority`) | Immutable at launch (program upgrade required) | Permanently immutable |
+|---|---|---|
+| every `["params", *]` value in §5.1; oracle feed ids; tip rates; `min_client_version`; emissions schedule (≤ hard cap); BME vault funding; authority rotation | instruction logic, account layouts, event schemas (append-only), PDA seed schema (REQ-SOL-013) | AKT/ACT decimals; ACT NonTransferable extension; AKT no-hooks/no-freeze (REQ-SOL-022); emissions hard cap; published Merkle roots ([05](./05-token-migration.md)) |
+
+**REQ-SOL-064** A published path toward reduced upgradeability (D-15) MUST exist at launch: programs reaching stability criteria (defined in [08](./08-security-and-audits.md)) either burn upgrade authority (loader-v4 finalize) or move it to a pure on-chain-governed path; the escrow and token-adjacent programs are first in line.
+
+---
+
+## 14. Cross-cutting runtime design
+
+### 14.1 Transaction composition: six primary user flows
+
+**REQ-SOL-065** All protocol client transactions MUST be v0 (versioned) transactions using the protocol address lookup table (ALT) maintained by governance, containing: the nine program ids, Token-2022/SPL-Token/ATA/ComputeBudget/Pyth-receiver program ids, the three mints, all `["params", *]` PDAs, the registry, `BmeState`, and the vault. This keeps per-transaction unique-key overhead at ~1 byte for every protocol-static account.
+
+Notation: `CB(limit, price)` = `ComputeBudget::SetComputeUnitLimit` + `SetComputeUnitPrice`; `PYTH(feed)` = Pyth receiver `post_price_update` from a Hermes payload (needed only where an instruction takes a price account; budget it ~150k CU). Signers in parentheses.
+
+| # | Flow | Instruction sequence (one tx unless noted) | CU budget |
+|---|---|---|---|
+| F1 | Tenant creates deployment (1 group) | `CB(300k, p75)` → `deployment::init_deployment` → `deployment::add_group` → `deployment::activate_deployment` (tenant). Multi-group SDLs that exceed the 1,232-byte packet: one tx per `add_group`, then activate (REQ-SOL-038) | ≤ 300k |
+| F2 | Provider bids | `CB(150k, p75)` → `market::create_bid` (provider; order, group, provider PDA, ≤ 4 attestations, escrow init, AKT collateral transfer) | ≤ 150k |
+| F3 | Tenant awards lease | `CB(250k, p75)` → `market::create_lease` (tenant). Crank follow-ups: `market::close_losing_bid` × N (anyone, separate txs, ≤ 80k each) | ≤ 250k |
+| F4 | Provider withdraws earnings | healthy BME: `CB(250k, p75)` → `escrow::payment_withdraw` (anyone; payment + account + sibling payments + provider ACT/STABLE ATAs). BME halted (AKT fallback): `CB(450k, p75)` → `PYTH(AKT/USD)` → `escrow::payment_withdraw` (+ AKT vault, provider AKT ATA) | ≤ 250k / 450k |
+| F5 | Tenant closes deployment (1 lease) | `CB(400k, p75)` → `market::close_lease` (settles + pays provider + closes payment) → `deployment::close_deployment` (refunds depositors, closes escrow + groups + deployment) (tenant). Many-lease deployments: `close_lease` txs first (crankable), terminal tx last | ≤ 400k |
+| F6 | AKT↔ACT swap + crank | user: `CB(250k, p75)` → `PYTH(AKT/USD)` → `bme::request_swap` (owner). Cranker, each epoch: `CB(600k, p_crank)` → `PYTH(AKT/USD)` → `bme::crank_status` → `bme::execute_swaps{≤ 10}`; repeat until epoch batch (≤ 50) drained | ≤ 250k / 600k |
+
+Supporting flows (same conventions): escrow top-up `account_deposit` ≤ 150k; permissionless `settle` ≤ 250k; provider registration ≤ 100k; reaps ≤ 100k each.
+
+**REQ-SOL-066** SDK-built transactions MUST always prepend explicit ComputeBudget instructions (never rely on the 200k default) with limits from the table above, and MUST implement the simulate-then-send pattern: `simulateTransaction`, adjust limit to consumed × 1.1, then submit.
+
+### 14.2 Priority-fee strategy
+
+**REQ-SOL-067** Clients (SDKs, provider daemon, relayer, cranks) MUST set `SetComputeUnitPrice` from recent fee telemetry over the transaction's writable account set (`getRecentPrioritizationFees` p75, floor 1,000 μlam/CU), re-quoting on retry with exponential escalation capped per actor class: user flows 10⁶ μlam/CU, cranks 10⁵ μlam/CU (crank profitability bounds are tips-driven, §11.2). Rationale: fees are per-account local on Solana; marketplace writes touch disjoint accounts (§14.4), so the p75 of the specific account set is normally the base floor.
+
+Cost picture (base fee 5,000 lamports/sig, SOL ≈ $150, as of 2026-08): calm (≤ 1k μlam/CU) F2 bid ≈ 5,200 lamports ≈ $0.0008; elevated (10k μlam/CU) F5 close ≈ 9,000 lamports ≈ $0.0014; congested p99 (10⁶ μlam/CU) F4 withdraw ≈ 255,000 lamports ≈ $0.038. Median Solana tx fee ≈ $0.0008 as of 2026-08, three orders of magnitude below the current chain's per-message gas in absolute terms; fee-model delta DELTA-10.
+
+### 14.3 Rent and account-size economics (reference marketplace)
+
+Rent exemption ≈ `(bytes + 128) × 6,960 lamports` (≈ 6,960 lamports/byte, as of 2026-08; refundable deposit, not a fee). Reference steady state: 10,000 active leases, 8,000 deployments, 9,000 groups, 500 providers.
+
+| Account class | Count | Unit size | Unit rent (SOL / USD @ $150) | Subtotal SOL |
+|---|---|---|---|---|
+| TenantCounter | 5,000 | 64 B | 0.00134 / $0.20 | 6.7 |
+| Deployment | 8,000 | 128 B | 0.00178 / $0.27 | 14.2 |
+| Group | 9,000 | ~1,200 B | 0.00924 / $1.39 | 83.2 |
+| Order | 10,000 | 192 B | 0.00223 / $0.33 | 22.3 |
+| Bid (winning, live) | 10,000 | ~1,024 B | 0.00802 / $1.20 | 80.2 |
+| Lease | 10,000 | 224 B | 0.00245 / $0.37 | 24.5 |
+| EscrowAccount | 18,000 | ~832 B | 0.00668 / $1.00 | 120.2 |
+| Escrow vault token accts | 20,000 | ~182 B | 0.00216 / $0.32 | 43.2 |
+| Payment | 10,000 | 224 B | 0.00245 / $0.37 | 24.5 |
+| Provider | 500 | ~3,072 B | 0.02227 / $3.34 | 11.1 |
+| Attestation | 1,000 | ~600 B | 0.00507 / $0.76 | 5.1 |
+| Allowance (+vaults) | 3,000 | ~450 B | 0.00483 / $0.72 | 14.5 |
+| **Total working set** | | | | **≈ 450 SOL ≈ $67k** |
+
+All of it is refundable and churns with the marketplace (per-lease transient footprint ≈ 0.024 SOL ≈ $3.60, returned at close). Rent payers are the actors who create the accounts (tenant for deployment-side, provider for bid-side), so state cost is borne by its beneficiary and recovered at terminal state (REQ-SOL-018).
+
+**REQ-SOL-068** ZK compression (Light Protocol) is an approved optimization, not baseline (D-23): if adopted post-launch it MAY apply only to cold, read-rare account classes (attestations, closed-entity tombstones if ever needed) and MUST NOT change instruction interfaces; it adds a specialized-RPC dependency to be weighed in [07](./07-offchain-and-clients.md).
+
+### 14.4 Congestion behavior and hot accounts
+
+Solana schedules by writable account: 100M CU blocks with a 12M CU per-writable-account cap (as of 2026-08, SIMD-0286). Per-entity sharding (D-23) means the write set of any two unrelated marketplace actions is disjoint: deployments, orders, bids, leases, escrow accounts are all per-entity PDAs, so marketplace throughput scales with the block limit, not the per-account cap. Residual shared-write accounts, audited:
+
+| Account | Written by | Worst-case writes | Assessment / mitigation |
+|---|---|---|---|
+| `BmeState` | every swap request, gateway op (ACT deposits/payouts), status crank | ~3k-CU writes ⇒ ~4,000 writes per 12M CU budget per block | orders of magnitude above marketplace need (10k leases settling hourly ≈ 3 gateway ops/s). If ever contended: split `act_escrowed` into N shard counters summed at CR read, and move queue tails to per-direction accounts (see REQ-SOL-069) |
+| BME queue head (crank) | `execute_swaps` batches | one cranker at a time; contention self-limits to the epoch boundary | tips make first-come-first-served cranking race-tolerant; losing cranks fail cheaply on `EpochNotDue`/head mismatch |
+| Order under bid rush | `create_bid` (`bid_count++`) | capped at `order_max_bids` = 20 lifetime writes | bounded by protocol parameter; no mitigation needed |
+| TenantCounter | that tenant's `init_deployment` | self-contention only | none needed |
+| `TipTreasury` | every crank record | lamport transfers ~1.5k CU | shard into N tip vaults if crank volume ever warrants |
+| `["params",*]`, registry, ALT | governance only | read-only in steady state (reads don't count against the writable cap) | none |
+
+**REQ-SOL-069** Gateway and request instructions MUST keep their `BmeState` write cost ≤ 3k CU, and the account layout MUST allow splitting `act_escrowed` and the queue tails into shard accounts as a non-breaking upgrade if contention is ever observed.
+
+**REQ-SOL-070** The load tests in [09](./09-testing-and-verification.md) MUST include a hot-account scenario (BME epoch executing 50 records + 200 concurrent gateway ops + 1,000 concurrent unrelated market txs in one slot window) demonstrating no protocol instruction fails from the per-account CU cap.
+
+### 14.5 Fee sponsorship (relayer): interface sketch
+
+The current chain sponsors users via feegrant (tx fees) + authz deposit grants (deposits). On Solana: deposits are covered by allowances (§10.2); transaction fees are covered by a fee-payer relayer.
+
+**REQ-SOL-071** The relayer interface (implementation and operations in [07](./07-offchain-and-clients.md), ownership Q-07): client builds the transaction with relayer as fee payer and signs its own instructions; relayer validates (program-id allowlist = the nine programs; instruction allowlist; per-user quotas; simulation passes), co-signs as fee payer, attaches ComputeBudget per §14.2, submits, and returns the signature. Durable nonces are used for offline/queued signing (provider daemon). The relayer MUST be optional: every flow works with a self-paying wallet, and relayer compromise can at most spend its own SOL (it never holds user keys or protocol authority).
+
+### 14.6 Idempotency and replay
+
+**REQ-SOL-072** Protocol instructions MUST be safe under blind client retries: creates are idempotent by PDA (`AccountAlreadyInitialized` ⇒ client treats as success after state read-back); `settle`/`crank_status` are time-pure no-ops when nothing accrued; `execute_swaps` is guarded by head monotonicity; reaps are state-guarded no-ops when already applied. Solana's recent-blockhash dedup handles wire-level replay; clients MUST NOT sign two intentionally-distinct submissions of the same instruction with the same blockhash+nonce.
+
+Provider daemons and the relayer use durable nonce accounts for queued transactions; the daemon's chain adapter treats "nonce advanced but status unknown" as resolve-by-read (idempotent state machine), per [07](./07-offchain-and-clients.md).
+
+### 14.7 Alpenglow caveat (A-13)
+
+Solana's Alpenglow consensus rewrite (SIMD-0326; ~100–150 ms finality target) is expected to activate Q3–Q4 2026, inside this program's build window. Per A-13 the design assumes program semantics are unaffected: nothing in this document depends on slot cadence, vote transactions, or today's ~12.8 s finality (REQ-SOL-007).
+
+**REQ-SOL-073** Off-chain components MUST parameterize commitment levels (processed/confirmed/finalized) rather than hardcoding timing assumptions, and the Vendor MUST re-baseline crank cadences, fee telemetry, and indexer lag targets on Alpenglow-activated clusters as they become available ([09](./09-testing-and-verification.md) carries the test obligation; risk tracked in [12](./12-risk-register.md)).
+
+### 14.8 Local development and testing stack (pointer)
+
+Per [09. Testing & verification](./09-testing-and-verification.md), which owns the full matrix: LiteSVM/Mollusk for per-instruction unit + CU-regression tests (REQ-SOL-006); Surfpool for integration tests against mainnet-forked state (Pyth receiver accounts, Token-2022 mints, ALTs cloned); `solana-test-validator` only where RPC-surface behavior matters; parity fixtures replay recorded Cosmos-chain scenarios (escrow settle traces, BME epoch traces) against the Solana programs asserting identical economic outcomes (D-09 acceptance basis).
+
+---
+
+## 15. Intentional deltas vs the current chain
+
+Numbered, exhaustive for on-chain behavior; the per-message mapping in [14](./14-appendix-protocol-mapping.md) tags each affected message. Anything not listed here is required to match current-chain behavior observably.
+
+| # | Delta | Justification / cross-ref |
+|---|---|---|
+| DELTA-01 | Escrow rates per-second instead of per-block; the documented equivalence for translating historical per-block prices is ×2/13 (= ÷6.5 exactly; 6.5 s target block time, `util/network/network.go:8`). No on-chain rate migration occurs: live leases wind down on the old chain (D-08); the factor is a client/Console display contract fixed at S1 (D-21/D-21.a) | D-21; [05](./05-token-migration.md) |
+| DELTA-02 | Oracle: multi-source push + TWAP/median (`x/oracle`) → direct Pyth pull; BME CR uses Pyth EMA (≈1h) replacing the 1h TWAP; staleness 30 s / deviation 150 bps carried as Pyth staleness + confidence bounds. Mainnet today already has exactly one authorized source (the Pyth CosmWasm contract), so no trust breadth is lost | D-13, D-22; REQ-SOL-020/021 |
+| DELTA-03 | EndBlocker/BeginBlocker work (BME epochs, status recompute, oracle aggregation) → time-based permissionless cranks; status/settlement recomputation lag bounded at ≤ 60 s (REQ-SOL-017/058) instead of next-block | D-20; §11 |
+| DELTA-04 | Atomic keeper-hook cascades (escrow → market → deployment closures) → guarded reap instructions completed by cranks ≤ 60 s p95; value safety is state-guard-derived, never cascade-timing-derived | §3.4; REQ-SOL-016/017 |
+| DELTA-05 | `MsgWithdrawLease`/settlement become permissionless (`withdraw_lease`, `settle`); payouts can only reach the payment owner | D-21; REQ-SOL-050 |
+| DELTA-06 | Losing-bid refunds asynchronous (permissionless `close_losing_bid`, crank SLA) instead of atomic within lease creation (transaction account limits) | REQ-SOL-043 |
+| DELTA-07 | authz `DepositAuthorization` (unfunded spend limit) → funded-at-grant allowance PDA with restore-on-refund and revoke-returns-remainder | D-21; REQ-SOL-047 |
+| DELTA-08 | The settlement stablecoin settles ACT-denominated obligations at par (governed `stable_act_parity_bps`, default 10000); pricing remains ACT-only. Extension implementing D-14/D-14.a (ratification Q-22); current v2 chain settles uact + AKT-fallback only | §4.3 |
+| DELTA-09 | dseq from per-tenant counter, not block height (Q-12); dense per-tenant instead of globally height-correlated | REQ-SOL-037 |
+| DELTA-10 | Fee model: per-message uakt gas with flat min-gas-price → SOL base + priority fees; AKT is not a gas token; sponsorship via relayer (feegrant analog) + allowances (authz analog) | §14.2, §14.5 |
+| DELTA-11 | State normalization: orders reference the Group PDA + spec hash instead of copying `GroupSpec`; bounded vectors replace gas-bounded ones (REQ-SOL-019); a provider whose bid PDA was closed pre-match can re-bid the same order (closed-bid tombstones are not kept; still capped by `order_max_bids`) | D-23 |
+| DELTA-12 | Escrowed ACT is burned, not held (NonTransferable): protocol-wide ACT accounting = `mint.supply + act_escrowed`; explorers show mint supply, the indexer publishes outstanding ACT | §4.2; REQ-SOL-026 |
+| DELTA-13 | Escrow emits first-class events (current module emits none; state surfaces via hooks), required because events are the indexer's system of record | REQ-SOL-014; D-16/D-23 |
+| DELTA-14 | On-chain history queries (closed deployments/orders/leases, price history, BME ledger) do not exist on-chain; the indexer serves them (accounts close at terminal state) | D-23; [07](./07-offchain-and-clients.md) |
+| DELTA-15 | Not ported: x509 cert registry (D-10 → JWT keys, §6), `x/take` (already dead), CosmWasm/awasm layer (D-22), unordered transactions (Cosmos ante feature; Solana blockhash model; client impact in [07](./07-offchain-and-clients.md)) | D-10/D-22 |
+| DELTA-16 | Known current-chain defects intentionally not reproduced: ACT metadata `Display: uact`, `ContractDebugMode=true`, min-gas-price disagreement, gov-hook ordering hazard (see [01](./01-current-architecture.md) §defects) | REQ-SOL-025 |
+
+---
+
+## Cross-references
+
+- [01. Current architecture](./01-current-architecture.md): Cosmos-side semantics this design mirrors; all `x/...` path citations.
+- [05. Token migration](./05-token-migration.md): claims/emissions programs, Wind-down Reserve, BME vault seeding, S1 conversion factor.
+- [06. State & data migration](./06-state-and-data-migration.md): what state exists at launch (nothing live migrates, D-08).
+- [07. Off-chain services & clients](./07-offchain-and-clients.md): indexer (event consumption), relayer operations, JWT verification, SDK/version negotiation, provider chain adapter.
+- [08. Security & audits](./08-security-and-audits.md): Squads/timelock composition, authority ceremonies, audit scope per program.
+- [09. Testing & verification](./09-testing-and-verification.md): parity fixtures, CU regression, hot-account load tests, crank SLA verification.
+- [12. Risk register](./12-risk-register.md): Alpenglow, Token-2022 support, crank-liveness risks.
+- [13. Open questions](./13-open-questions-and-assumptions.md): D-03/09/10/11/13/14/15/19/20/21/22/23/24; Q-01/05/07/08/11/12/16/22; A-13.
+- [14. Appendix: protocol mapping](./14-appendix-protocol-mapping.md), per-message/query/event mapping to the instructions defined here.
+
+## Feeds into
+
+- [04. Ethereum architecture](./04-ethereum-architecture.md) (structural mirror), [05](./05-token-migration.md)/[06](./06-state-and-data-migration.md) (token/state interfaces defined here), [07](./07-offchain-and-clients.md) (IDs, events, IDLs, registry contract), [08](./08-security-and-audits.md) (authority model), [09](./09-testing-and-verification.md) (REQ-SOL acceptance basis), [11. Scope of work](./11-scope-of-work.md) (workstream decomposition per program), [14](./14-appendix-protocol-mapping.md).

--- a/spec/aep-79/doc/04-ethereum-architecture.md
+++ b/spec/aep-79/doc/04-ethereum-architecture.md
@@ -1,0 +1,1279 @@
+# 04. Ethereum Target Architecture
+
+| | |
+|---|---|
+| **Document** | 04. Ethereum Target Architecture |
+| **Doc ID** | AKASH-MIG-04 |
+| **Version** | 0.9 (draft for review) |
+| **Date** | 2026-08-10 |
+| **Owner** | Overclock Labs |
+| **Audience** | Vendor engineering (Solidity/EVM team) |
+| **Status** | Normative where marked (MUST/SHALL); informative otherwise |
+
+## Purpose
+
+- Specify the complete EVM target design for the Akash protocol to execution depth: contracts, storage,
+  functions, events, errors, invariants, oracle integration, gas/UX posture, and governance wiring.
+- Preserve the marketplace and escrow semantics of the current Cosmos chain (per D-09, D-19–D-21,
+  D-23, D-24) so that behavior-parity testing in [09](./09-testing-and-verification.md) is meaningful.
+- Define the primary deployment variant **B1 (contracts on an existing general-purpose EVM L2, the
+  host chain)** and the specified non-default variant **B2 (dedicated Arbitrum Orbit chain)** per D-02.
+
+## In scope
+
+- The full contract suite (§3–§12), per-contract storage layouts, external functions, events, custom
+  errors, and invariants.
+- Deployment-target structure as a parameter (B1 on a host chain selected per Q-42 against the §1
+  criteria; B2 Orbit), with no host chain fixed by this document.
+- Pyth oracle integration, keeper automation, gas/fee analysis, AKT-denominated gas UX, reorg posture.
+- Governance and parameter management (`AkashConfig`, `AkashGovernor`, `AkashTimelock`).
+- Numbered intentional deltas vs the current chain (§16).
+
+## Out of scope
+
+- Migration mechanics (snapshots, Merkle claims, Wind-down Reserve): [05](./05-token-migration.md)
+  (the `MigrationClaims` interface appears here in §11 only as consumed by this architecture).
+- Non-token state migration and old-chain sunset: [06](./06-state-and-data-migration.md).
+- Off-chain services beyond their on-chain interfaces (provider daemon, Console, indexer internals):
+  [07](./07-offchain-and-clients.md).
+- Key-management ceremonies, audit plan, threat model: [08](./08-security-and-audits.md).
+- The Solana design: [03](./03-solana-architecture.md); comparative scoring: [02](./02-target-selection.md).
+
+Cosmos-side terms (modules `x/deployment`, `x/market`, `x/escrow`, `x/bme`, denoms `uakt`/`uact`,
+dseq/gseq/oseq) are defined in [01. Current architecture](./01-current-architecture.md). This document
+uses "AKT"/"ACT" for the EVM tokens whose base unit (6 decimals) is 1:1 with `uakt`/`uact`.
+
+---
+
+## 1. Deployment target (variant structure per D-02)
+
+### 1.1 Variant B1 (primary): contracts on an existing general-purpose EVM L2 (the host chain)
+
+The primary Ethereum variant deploys the contract suite onto an existing general-purpose EVM L2,
+referred to throughout this document as **the host chain**. The host chain is deliberately not fixed
+by this architecture: it is selected per open question Q-42 against the criteria of REQ-EVM-071, with
+the Gate 0 evidence pack ([02 §4.2](./02-target-selection.md)), and every design element in §2–§14 is
+written to hold on any chain that clears those criteria.
+
+**REQ-EVM-001** The contract suite SHALL be written chain-agnostic EVM (Cancun/Prague feature level):
+no host-chain-specific predeploys, opcodes, or precompiles MAY be referenced from protocol contracts;
+chain-specific integrations (Pyth endpoint address, settlement-stablecoin address, keeper registry, paymaster) MUST be
+constructor/initializer parameters or `AkashConfig` entries.
+
+**REQ-EVM-002** The **host chain** is a parameterized deployment decision, resolved per Q-42 with the
+Gate 0 evidence pack; it is an input to deployment, not a property of the design. The contract suite
+SHALL contain no host-chain-specific dependencies, so that the selected host can change at any point
+before G1 at bounded cost: a retarget is confined to deployment scripts, the address book,
+oracle/keeper/paymaster endpoint configuration, and re-quoting the §14 fee table. Retargeting MUST
+NOT require contract-source changes beyond configuration.
+
+**REQ-EVM-071** Host-chain candidates SHALL be evaluated under Q-42 against the following criteria,
+each evidenced in the Gate 0 pack:
+
+1. At least one natively-issued, deeply-liquid stablecoin (issuer-supported, not bridged; settlement-stablecoin criteria per Q-43; D-14).
+2. Production Pyth pull-feed deployment (§9).
+3. Live ERC-4337 bundler and paymaster infrastructure (§13.2).
+4. Keeper-automation coverage: Chainlink Automation or Gelato in production (§12).
+5. Median complex-interaction fee within the §14 targets (REQ-EVM-063).
+6. Stage 1+ rollup maturity: permissionless fault proofs and forced inclusion (REQ-GEN-014,
+   [02](./02-target-selection.md)); no major L2 is at Stage 2 as of 2026-08, so Stage 1 is the
+   practical ceiling.
+7. A published sequencer-decentralization roadmap.
+8. At least two commercial RPC providers with websocket support.
+9. Indexer-framework support (the [07](./07-offchain-and-clients.md) stack runs against the chain).
+10. Commercial-policy stability: no app-level fee extraction or permissioning, and no unresolved
+    revenue/governance realignments affecting deployed applications.
+
+**Candidate landscape (informative; as of 2026-08, re-verify at kickoff per A-07; examples, not a
+ranking).** Base and Arbitrum One clear the REQ-EVM-071 criteria as of this draft; Robinhood Chain
+requires criteria verification at kickoff per Q-42; the candidate list is open until Q-42 resolves.
+
+| Candidate | Technical posture (as of 2026-08) | Policy notes (as of 2026-08) |
+|---|---|---|
+| Base | Simple transfers < $0.01, complex interactions $0.01–0.05 (post-Fusaka, blobs at 14/21 target/max); Flashblocks ~200 ms preconfirmations on a 2 s block cadence; 400–500 Mgas/s announced throughput target; Stage 1 fault proofs (Cannon/MIPS); native USDC with Circle Paymaster (A-08); production Pyth | Announced exit from the OP Superchain (Feb 2026), moving off Collective revenue terms: a governance/business realignment, not a change to the execution environment; roadmap set by a single commercial operator |
+| Arbitrum One | Comparable complex-interaction fee band; BoLD permissionless validation; native USDC; production Pyth; mature DeFi/custody support | Arbitrum DAO governance; AEP revenue terms apply to Orbit chains (§15), not to contracts deployed on Arbitrum One |
+| Robinhood Chain | Arbitrum Orbit-based, launched Jul 2026; brokerage-scale retail distribution (day-one tokenized-asset volume ≈$568M); REQ-EVM-071 criteria verification required at kickoff per Q-42: native stablecoin issuance, Pyth availability, ERC-4337/keeper infrastructure, RPC depth | Single commercial operator (brokerage-affiliated); commercial-policy stability (criterion 10) verified at kickoff per Q-42; the flagship-scale Orbit operating precedent cited in §15 |
+
+**REQ-EVM-003** The Vendor MUST maintain a single address-book artifact (JSON, versioned in the repo)
+enumerating every deployed contract/proxy/implementation address per network (host-chain mainnet,
+host-chain public testnet, any secondary candidate network exercised for REQ-EVM-002 portability,
+local devnet), consumed by [07](./07-offchain-and-clients.md) clients and the indexer.
+
+### 1.2 Variant B2 (specified, non-default): dedicated Arbitrum Orbit chain
+
+B2 moves the identical contract suite onto a dedicated Arbitrum Orbit L2/L3 with AKT as the custom gas
+token. It is fully specified in §15 and is NOT a default path (D-02): operating a sequencer/DA/upgrade train
+re-creates the consensus-operations burden that is migration driver #2 (see D-02,
+[02](./02-target-selection.md)). OP Stack was rejected for B2 because the custom-gas-token feature is
+deprecated in the OP Stack spec (fee token must be ETH) and Superchain commercial terms are in flux
+following Base's Superchain exit (Feb 2026). B2's revisit trigger is Q-06.
+
+**REQ-EVM-004** All requirements in §2–§14 apply to both B1 and B2 except where §15 states an explicit
+B2 override. Requirements marked "(B1 only)" do not apply to B2.
+
+---
+
+## 2. Platform conventions and contract suite
+
+### 2.1 Toolchain and upgradeability
+
+**REQ-EVM-005** Contracts SHALL target Solidity `^0.8.2x` (pin one compiler version repo-wide, ≥0.8.24
+for transient-storage and MCOPY availability on Cancun-level chains) and OpenZeppelin Contracts
+**v5.x** (`@openzeppelin/contracts` + `@openzeppelin/contracts-upgradeable`). Build/test framework:
+Foundry (forge) primary; Hardhat MAY be added for deployment orchestration.
+
+**REQ-EVM-006** All protocol contracts (every contract in Table 2-1 except noted) SHALL be deployed as
+**UUPS proxies** (ERC-1967 + OZ `UUPSUpgradeable`), with `_authorizeUpgrade` restricted to
+`AkashTimelock` (D-15). Rationale vs alternatives (steelman): *Transparent* proxies cost an extra
+admin-check indirection per call and a separate `ProxyAdmin` contract per deployment; more surface,
+more gas, no functional gain since we already centralize upgrade authority in one timelock. *Immutable*
+contracts are the long-term goal but unacceptable at launch: this is a semantics-parity port of a live
+protocol, and a parity defect discovered post-cutover must be fixable faster than a redeploy-and-migrate
+of escrow balances. *Beacon* proxies solve a many-instances pattern we do not have (escrow accounts are
+storage structs, not clones; D-23). The published path from UUPS to immutability (upgrade to an
+implementation whose `_authorizeUpgrade` reverts unconditionally) is specified in
+[08](./08-security-and-audits.md).
+
+**REQ-EVM-007** Every upgradeable contract SHALL use **ERC-7201 namespaced storage** (one namespace
+struct per contract, id `akash.storage.<ContractName>`), matching the OZ v5 convention. Plain
+sequential storage declarations are prohibited in upgradeable contracts. Any shared abstract base
+contract that cannot use ERC-7201 MUST reserve a `uint256[50] private __gap`. Storage structs are
+append-only: fields are never reordered, retyped, or removed across upgrades (enforced in CI with
+`forge inspect storage-layout` diffs; see [09](./09-testing-and-verification.md)).
+
+**REQ-EVM-008** All revert paths SHALL use custom errors (no revert strings); all magnitude/state
+fields use explicit sizes chosen in §4–§12; all external functions carry NatSpec sufficient for ABI
+documentation generation consumed by [07](./07-offchain-and-clients.md).
+
+**REQ-EVM-009** Events are the **system of record for history** (D-23): every semantic state
+transition MUST emit exactly one event carrying enough indexed keys for the indexer to reconstruct the
+full entity history without state reads. Storage holds working state only; terminal-state entities are
+deleted (storage refund) after their terminal event is emitted, except where a later flow reads them
+(exceptions listed per contract).
+
+### 2.2 Contract suite
+
+Table 2-1: contract inventory (names fixed by §5 of the program brief; see
+[14](./14-appendix-protocol-mapping.md) for the exhaustive Cosmos→EVM mapping):
+
+| Contract | Proxy | Replaces (Cosmos) | Responsibility |
+|---|---|---|---|
+| `AKT` | UUPS | `uakt` (bank) + x/mint supply | ERC-20, 6 decimals, EIP-2612 permit, ERC20Votes; mint gated to `MigrationClaims` + `EmissionsMinter` (D-04) |
+| `ACT` | UUPS | `uact` (bank, `SendEnabled=false`) | Restricted ERC-20, 6 decimals; transfers only via protocol contracts; mint/burn gated to `BurnMintEscrow` + `EscrowVault` (D-19) |
+| `DeploymentRegistry` | UUPS | `x/deployment` | Deployments + groups lifecycle, dseq issuance, SDL hash anchoring, reclamation config |
+| `Marketplace` | UUPS | `x/market` | Orders, bids, leases, attribute matching, reclamation windows, relist-on-close |
+| `EscrowVault` | UUPS | `x/escrow` | Streaming-payment escrow: accounts, payments, per-second rates, lazy settlement, FIFO depositors, delegated-deposit allowances |
+| `BurnMintEscrow` | UUPS | `x/bme` | AKT↔ACT queued epoch swaps, CR circuit breaker, spread, vault |
+| `ProviderRegistry` | UUPS | `x/provider` (+ x/cert replacement per D-10) | Provider records, attributes, JWT signing keys, collateral |
+| `AuditRegistry` | UUPS | `x/audit` | Auditor-signed provider attributes |
+| `AkashConfig` | UUPS | module params + discovery service | Parameter store, client-version registry, address book |
+| `MigrationClaims` | UUPS | none (new) | S1/S2 Merkle claims, Wind-down Reserve, vesting re-creation; **interface only here**; spec in [05](./05-token-migration.md) |
+| `EmissionsMinter` | UUPS | x/mint inflation (replacement per D-12) | Timelocked, hard-capped emissions to provider-incentives pool + community treasury |
+| `AkashGovernor` | UUPS | x/gov | OZ Governor over AKT (ERC20Votes) |
+| `AkashTimelock` | none (immutable) | gov execution authority | OZ `TimelockController`; owner/upgrader of everything above |
+
+`AkashTimelock` is deliberately non-upgradeable: it is the root of the upgrade-authority chain, and an
+upgradeable root would be circular. Replacing it is a governed migration (re-point every contract's
+roles), specified in [08](./08-security-and-audits.md).
+
+### 2.3 Dependency diagram
+
+```mermaid
+graph TD
+  GOV[AkashGovernor] -->|queue/execute| TL[AkashTimelock]
+  TL -->|owner + upgrade authority| CFG[AkashConfig]
+  TL --> DR & MKT & EV & BME & PR & AR & AKT & ACT & EM & MC
+  AKT[AKT ERC-20] -->|votes| GOV
+  DR[DeploymentRegistry] -->|open/close accounts| EV[EscrowVault]
+  DR -->|create orders| MKT[Marketplace]
+  MKT -->|bid collateral + lease payments| EV
+  MKT -->|attributes + audited attrs| PR[ProviderRegistry]
+  MKT --> AR[AuditRegistry]
+  EV -->|close/overdrawn hooks| MKT
+  EV -->|close hooks| DR
+  EV -->|transfer/burn ACT, AKT| ACT & AKT
+  EV -->|halt status + AKT fallback price| BME[BurnMintEscrow]
+  BME -->|mint/burn| ACT
+  BME -->|vault holds| AKT
+  BME & EV & MKT -->|prices| PYTH[(Pyth on target chain)]
+  DR & MKT & EV & BME & PR & AR -->|params| CFG
+  MC[MigrationClaims] -->|mint at claim| AKT
+  EM[EmissionsMinter] -->|scheduled mint| AKT
+  KEEP((Keeper automation + permissionless callers)) -.->|executeEpoch / settle| BME & EV
+```
+
+**REQ-EVM-010** Cross-contract calls SHALL follow the edges above; no other protocol-contract coupling
+is permitted without a version bump of this document. All inter-contract references are held as
+addresses in each contract's namespaced storage, settable only by `AkashTimelock` (initialization and
+re-pointing), and readable via public getters.
+
+**REQ-EVM-011** Reentrancy posture: every state-mutating external function in `DeploymentRegistry`,
+`Marketplace`, `EscrowVault`, `BurnMintEscrow`, `ProviderRegistry` SHALL apply checks-effects-
+interactions and an OZ `ReentrancyGuardTransient` guard; token transfers use `SafeERC20`. The
+settlement stablecoin (an external, issuer-upgradeable token) is treated as untrusted-callable;
+AKT/ACT are protocol-owned but guarded identically.
+
+**REQ-EVM-012** Pausability: `EscrowVault.deposit`, `Marketplace.createBid/createLease`,
+`DeploymentRegistry.createDeployment`, and all `BurnMintEscrow` swap entrypoints SHALL be pausable by a
+guardian role held by the security-council Safe (see §10.3 and [08](./08-security-and-audits.md)).
+Settlement, withdrawal, refund, and close paths MUST NOT be pausable (funds-exit paths stay live).
+
+---
+
+## 3. Tokens
+
+### 3.1 `AKT`
+
+**REQ-EVM-013** `AKT` SHALL be an OpenZeppelin v5 upgradeable ERC-20 with: `decimals() == 6` (base
+unit 1:1 with `uakt`), `ERC20PermitUpgradeable` (EIP-2612), and `ERC20VotesUpgradeable` with
+`clock() == block.timestamp` (ERC-6372 timestamp mode; block numbers are not a stable time base on
+L2s). Name `Akash Network`, symbol `AKT` (A-09).
+
+**REQ-EVM-014** Minting SHALL be restricted to exactly two addresses: `MigrationClaims` (claim-window
+mints per [05](./05-token-migration.md)) and `EmissionsMinter` (D-04, D-12), enforced via
+`MINTER_ROLE` grants administered by `AkashTimelock`. There is no cap in `AKT` itself; the supply
+invariant (claims ≤ snapshot totals; emissions ≤ hard cap) is enforced in the two minters where the
+accounting lives.
+
+**REQ-EVM-015** `AKT` SHALL expose `burn(uint256)`/`burnFrom(address,uint256)` (ERC20Burnable);
+`BurnMintEscrow` uses `burnFrom` on swap execution (§7). No freeze, no blacklist, no transfer hook, no
+fee-on-transfer: exchange/DeFi compatibility mirrors D-03's reasoning on the Solana side.
+
+**REQ-EVM-016** `AKT` upgrade authority follows §2.1 but with the timelock's **maximum** delay class
+(§10.3): the token is the highest-blast-radius contract. The path to renouncing AKT upgradeability is a
+Gate item in [08](./08-security-and-audits.md).
+
+### 3.2 `ACT` (restricted, D-19)
+
+ACT is the protocol's compute-credit unit: every lease is priced in ACT, and ACT only enters/exits
+supply through the BME engine. On the current chain `uact` has bank `SendEnabled=false`, so it moves
+only through module logic. The EVM mirror:
+
+**REQ-EVM-017** `ACT` SHALL be an ERC-20 (6 decimals, name `Akash Compute Token`, symbol `ACT`,
+non-votes, permit included for gasless approvals) whose `_update` override reverts with
+`TransfersRestricted()` on any transfer UNLESS at least one of {`msg.sender`, `from`, `to`} is in the
+protocol allowlist. Mints (`from == 0`) and burns (`to == 0`) are permitted only for holders of
+`MINTER_ROLE`/`BURNER_ROLE`.
+
+**REQ-EVM-018** The ACT allowlist SHALL contain exactly: `EscrowVault`, `BurnMintEscrow`,
+`MigrationClaims` (residual-distribution payouts of escrow-held ACT per [05](./05-token-migration.md)).
+`MINTER_ROLE` and `BURNER_ROLE` are granted to `BurnMintEscrow` and `EscrowVault` only. Allowlist and
+role changes only via `AkashTimelock`.
+
+**REQ-EVM-019** Consequences the Vendor MUST implement and document for clients
+([07](./07-offchain-and-clients.md)): tenants acquire ACT only via `BurnMintEscrow.mintACT` (§7);
+tenants fund escrow with `approve`/`permit` + `EscrowVault.deposit` (vault executes the pull as an
+allowlisted `msg.sender`); providers receive ACT payouts from the vault and can exit only via
+`BurnMintEscrow.burnACT` → AKT. Peer-to-peer ACT transfers revert by design (wallet presentation:
+Q-16).
+
+### 3.3 The settlement stablecoin (D-14)
+
+**REQ-EVM-020** The settlement stablecoin (**STABLE** in tables below): a natively-issued,
+deeply-liquid USD stablecoin on the host chain, selected per Q-43 (candidates e.g. USDC, PYUSD, USDT
+where natively issued; decimals normalized if the selected asset is not 6-decimal). STABLE SHALL be
+accepted by `EscrowVault` as a first-class deposit/settlement denomination alongside ACT and AKT
+(drain order and par rule: §6.6). The stablecoin is external infrastructure: the suite holds its
+address as `AkashConfig.settlementStable` (a configurable protocol parameter; the protocol MUST NOT
+hard-depend on a single issuer), never assumes mint/burn authority, and treats it as a denom
+identifier `DENOM_STABLE` alongside `DENOM_AKT`, `DENOM_ACT` (uint8 enum used in all escrow structs).
+
+---
+
+## 4. `DeploymentRegistry`
+
+Purpose: port of `x/deployment`. A **deployment** is a tenant's declared workload (identified by
+`(owner, dseq)`), holding the SDL manifest hash and 1..N **groups** (placeable resource bundles with
+ACT pricing). Creating a deployment opens one escrow account and one `Marketplace` order per group.
+
+### 4.1 Storage (namespace `akash.storage.DeploymentRegistry`)
+
+| Field | Type | Notes |
+|---|---|---|
+| `nextDseq` | `mapping(address owner => uint64)` | Per-tenant dseq counter, starts at 1 (delta Δ1, Q-12: current chain derives dseq from block height) |
+| `deployments` | `mapping(bytes32 deploymentKey => Deployment)` | `deploymentKey = keccak256(abi.encode(owner, dseq))` |
+| `groups` | `mapping(bytes32 groupKey => Group)` | `groupKey = keccak256(abi.encode(owner, dseq, gseq))` |
+| `groupCount` | `mapping(bytes32 deploymentKey => uint32)` | Number of groups created for the deployment (gseq high-water) |
+| `activeGroupCount` | `mapping(bytes32 deploymentKey => uint32)` | Non-closed groups; deployment storage deletable when 0 and closed |
+| `marketplace`, `escrowVault`, `config` | `address` | Wired contracts (REQ-EVM-010) |
+
+```solidity
+struct Deployment {            // mirrors v1.Deployment (RESEARCH-modules §1.1)
+  address owner;               // ID.Owner
+  uint64  dseq;                // ID.DSeq
+  DeploymentState state;       // 1=Active, 2=Closed   (enum mirrors active|closed)
+  bytes32 sdlHash;             // Deployment.Hash: SHA-256 of the SDL manifest (ADR-002); SDL itself stays off-chain (D-09)
+  uint64  createdAt;           // block.timestamp (current chain stores height; Δ3)
+  uint32  reclamationMinWindow;// seconds; 0 = reclamation not offered (mirrors Reclamation *{MinWindow})
+}
+struct Group {                 // mirrors v1beta4.Group
+  GroupState state;            // 1=Open, 2=Paused, 3=InsufficientFunds, 4=Closed
+  bytes32 specHash;            // keccak256 of canonical GroupSpec encoding (name, requirements, resources)
+  uint96  price;               // ACT base units/second, WAD-scaled by EscrowVault at payment creation (§6.2)
+  uint64  createdAt;
+  GroupSpec spec;              // full spec retained on-chain while non-terminal; needed for re-list + bid matching
+}
+struct GroupSpec {
+  string  name;
+  PlacementRequirements requirements;  // { address[] signedByAllOf; address[] signedByAnyOf; Attribute[] attributes; }
+  ResourceUnit[] resources;            // { ResourceValues cpu/memory/storage/gpu; uint32 endpointCount; uint32 count; uint96 pricePerBlockDenomACT→ per-second (Δ2) }
+}
+struct Attribute { string key; string value; }   // shared with ProviderRegistry/AuditRegistry
+```
+
+**REQ-EVM-021** Group specs SHALL be bounded to keep matching gas-bounded, using the cross-path parity
+bounds (A-18, validated by Q-38): ≤ 4 resource units per group, ≤ 24 requirement attributes, ≤ 4
+entries per signedBy list, key/value strings ≤ 64 bytes each
+(config-adjustable caps in `AkashConfig`; the current chain bounds these only implicitly via gas; see
+Δ10).
+
+### 4.2 External functions
+
+| Function | Args | Access | Checks → state transitions → events |
+|---|---|---|---|
+| `createDeployment` | `GroupSpec[] groups, bytes32 sdlHash, DepositInput deposit, uint32 reclamationMinWindow` | tenant (any EOA/AA) | groups 1..N (N ≤ 8, A-18); **every group price denominated ACT; AKT deposits revert** (`InvalidDepositDenom`; mirrors `x/deployment/handler/server.go:60-62,93`); deposit denom ∈ {ACT, STABLE} (§3.3), per-denom ≥ `AkashConfig.minDeposits[denom]`; `reclamationMinWindow` within market min/max (1h–720h, D-24) or 0; assigns `dseq = nextDseq[owner]++`; stores Deployment(Active) + Groups(Open, gseq = 1..N); `EscrowVault.accountCreate(scope=Deployment, key, owner, deposit)`; per group `Marketplace.createOrder(groupKey, spec, reclamationMinWindow)` → `DeploymentCreated`, N× `OrderCreated` (gas est. §14) |
+| `depositDeployment` | `bytes32 deploymentKey, DepositInput deposit` | anyone (self or delegated §6.4) | deployment Active; forwards to `EscrowVault.deposit`, **the only path that accepts AKT top-ups** (mirrors `MsgAccountDeposit`) → `AccountDeposited` |
+| `updateDeployment` | `deploymentKey, bytes32 newSdlHash` | owner | Active only; `newSdlHash != sdlHash` (`HashUnchanged`); updates hash → `DeploymentUpdated` |
+| `closeDeployment` | `deploymentKey` | owner | Active only; `EscrowVault.accountClose(key)`; ALL group/order/lease closure cascades via the escrow close hook (§6.7), mirroring `MsgCloseDeployment` → `DeploymentClosed` (+cascade events) |
+| `closeGroup` | `groupKey` | owner | group Open/Paused; sets Closed; `Marketplace.onGroupClosed(groupKey)` → `GroupClosed` |
+| `pauseGroup` | `groupKey` | owner | group Open; sets Paused; `Marketplace.onGroupClosed(groupKey)` (closes open order/bids) → `GroupPaused` |
+| `startGroup` | `groupKey` | owner | group Paused/InsufficientFunds; sets Open; `Marketplace.createOrder(...)` with deployment's reclamation window → `GroupStarted`, `OrderCreated` |
+| `onBidClosed` | `groupKey` | `Marketplace` only | pauses group when its active bid/lease closes without funds exhaustion (mirrors `keeper.go:421-427`) → `GroupPaused` |
+| `onAccountClosed` | `deploymentKey, bool overdrawn` | `EscrowVault` only | escrow close hook: if deployment Active → Closed; each non-terminal group → Closed, or InsufficientFunds when overdrawn (mirrors `x/market/hooks/hooks.go` OnEscrowAccountClosed) → `DeploymentClosed`, per-group `GroupClosed` |
+
+**REQ-EVM-022** `createDeployment` SHALL enforce, atomically in one transaction, the full current-chain
+create semantics listed above; partial creation is impossible (any group/order/escrow failure reverts
+the whole call).
+
+**REQ-EVM-023** dseq SHALL be a per-tenant monotonically increasing counter starting at 1, never
+reused, assigned by the contract (not caller-supplied). gseq/oseq numbering mirrors the current chain:
+gseq = 1..N at create; oseq starts at 1 per group and increments on each re-list (§5.4).
+
+**REQ-EVM-024** Deployment and group storage SHALL be deleted (`delete`) when the deployment is Closed
+and `activeGroupCount == 0` and its escrow account is settled-and-closed, after emitting terminal
+events (D-23). The indexer is the only source of closed-entity history.
+
+### 4.3 Events, errors, invariants
+
+Events (all carry `indexed owner`, `indexed dseq`, and gseq where applicable; one per current-chain
+typed event): `DeploymentCreated(owner, dseq, sdlHash, groupCount)`, `DeploymentUpdated(owner, dseq,
+newSdlHash)`, `DeploymentClosed(owner, dseq)`, `GroupClosed(owner, dseq, gseq)`, `GroupPaused(owner,
+dseq, gseq)`, `GroupStarted(owner, dseq, gseq)`.
+
+Custom errors: `DeploymentExists()`, `DeploymentNotActive()`, `GroupNotOpen()`, `GroupNotPaused()`,
+`InvalidDepositDenom()`, `DepositBelowMinimum(uint8 denom, uint256 min)`, `InvalidGroupPriceDenom()`,
+`ReclamationWindowOutOfBounds()`, `HashUnchanged()`, `SpecBoundsExceeded()`, `Unauthorized()`.
+
+Invariants (asserted in Foundry invariant suite, [09](./09-testing-and-verification.md)):
+I-DR-1 a deployment is Active iff its escrow account is Open; I-DR-2 `activeGroupCount(d)` equals the
+number of stored groups of `d` not in Closed; I-DR-3 every Open group of an Active deployment has
+exactly one non-Closed order or one active/reclaiming lease in `Marketplace`; I-DR-4 dseq values per
+owner are strictly increasing with no gaps.
+
+---
+
+## 5. `Marketplace`
+
+Purpose: port of `x/market`. Each Open group has one **order**; providers post **bids** (each backed by
+its own escrow account as collateral); the tenant matches one bid into a **lease**, which opens a
+streaming escrow payment at the bid price. Provider-initiated graceful shutdown uses the reclamation
+window (D-24).
+
+### 5.1 Storage (namespace `akash.storage.Marketplace`)
+
+| Field | Type | Notes |
+|---|---|---|
+| `orders` | `mapping(bytes32 orderKey => Order)` | `orderKey = keccak256(abi.encode(owner,dseq,gseq,oseq))` |
+| `bids` | `mapping(bytes32 bidKey => Bid)` | `bidKey = keccak256(abi.encode(owner,dseq,gseq,oseq,provider,bseq))`; `bseq` MUST be 0 at creation (reserved, mirrors `server.go:29-136`) |
+| `leases` | `mapping(bytes32 bidKey => Lease)` | lease id == winning bid id (mirrors LeaseID == BidID) |
+| `openBidKeys` | `mapping(bytes32 orderKey => bytes32[])` | Enumeration needed for losing-bid closure; length ≤ `orderMaxBids` |
+| `nextOseq` | `mapping(bytes32 groupKey => uint32)` | Increments on each re-list; starts at 1 |
+| `deploymentRegistry`, `escrowVault`, `providerRegistry`, `auditRegistry`, `config` | `address` | REQ-EVM-010 |
+
+```solidity
+struct Order {                 // mirrors v1beta5.Order
+  OrderState state;            // 1=Open, 2=Active(matched), 3=Closed
+  bytes32 groupKey;            // back-reference; spec read from DeploymentRegistry.groups[groupKey].spec
+  uint64  createdAt;
+  uint32  reclamationMinWindow;// copied from deployment at order creation (0 = none)
+}
+struct Bid {                   // mirrors v1beta5.Bid
+  BidState state;              // 1=Open, 2=Active, 3=Lost, 4=Closed
+  address provider;
+  uint256 priceWad;            // ACT base units/second, 1e18-scaled (Δ2: current chain DecCoin/block)
+  uint64  createdAt;
+  uint32  reclamationWindow;   // seconds; provider's offered window, ≥ order.reclamationMinWindow
+  ResourcesOffer[] offer;      // { ResourceValues resources; uint32 count; }. MUST cover the group spec
+}
+struct Lease {                 // mirrors v1.Lease
+  LeaseState state;            // 1=Active, 2=InsufficientFunds, 3=Closed, 4=Reclaiming
+  uint256 priceWad;
+  uint64  createdAt;
+  uint64  closedOn;
+  uint32  closedReason;        // enum values preserved: 0 Invalid, 1 Owner, 10000 Unstable, 10001 Decommissioned, 10002 Unspecified, 10003 ManifestTimeout, 20000 InsufficientFunds
+  uint32  reclamationWindow;   // seconds
+  uint64  reclamationStartedAt;// 0 until startReclaim
+  uint64  reclamationDeadline; // startedAt + window
+}
+```
+
+### 5.2 External functions
+
+| Function | Args | Access | Checks → state transitions → events |
+|---|---|---|---|
+| `createOrder` | `groupKey, oseq?` (internal seq), `reclamationMinWindow` | `DeploymentRegistry` only | assigns `oseq = nextOseq[groupKey]++`; stores Order(Open) → `OrderCreated` |
+| `createBid` | `orderKey, uint256 priceWad, DepositInput deposit, ResourcesOffer[] offer, uint32 reclamationWindow` | registered provider | mirrors `x/market/handler/server.go:29-136`, in order: per-denom deposit ≥ `bidMinDeposits` (default 500000 base units AKT and ACT); `openBidKeys.length < orderMaxBids` (default 20) else `TooManyBids`; caller has no existing bid on this order (bseq is always 0); order Open; **`priceWad ≤ order price`** (group spec price); offer covers spec (§5.3); provider exists in `ProviderRegistry`; attribute + audited-attribute match (§5.3); `reclamationWindow == 0 ? order.reclamationMinWindow == 0 : reclamationWindow ∈ [max(order.reclamationMinWindow, minReclamationWindow), maxReclamationWindow]`; stores Bid(Open); `EscrowVault.accountCreate(scope=Bid, bidKey, provider, deposit)` (collateral) → `BidCreated` |
+| `createLease` | `bidKey` | order owner (tenant) | bid Open, order Open, group Open; `EscrowVault.paymentCreate(deploymentAccountKey, leaseKey=bidKey, provider, DENOM_ACT, bid.priceWad)`; Lease(Active, reclamationWindow = bid.reclamationWindow); order → Active; bid → Active; **every other open bid → Lost + `EscrowVault.accountClose(otherBidKey)` (collateral refund)**; bounded loop ≤ 19 (mirrors `server.go:209-283`) → `LeaseCreated`, k× `BidClosed(lost)` |
+| `closeBid` | `bidKey, uint32 reason` | bid provider | Open bid: bid → Closed + `accountClose(bidKey)`. Active bid (lease exists): **reclamation gate** (lease Active ∧ `reclamationWindow != 0` ⇒ `ReclamationNotStarted`; lease Reclaiming ∧ `now < reclamationDeadline` ⇒ `ReclamationWindowNotElapsed`); then `DeploymentRegistry.onBidClosed(groupKey)` (pauses group), lease → Closed(reason), bid → Closed, order → Closed, `EscrowVault.paymentClose(leaseKey)`, `accountClose(bidKey)` (mirrors `server.go:138-192`) → `BidClosed`, `LeaseClosed`, `OrderClosed` |
+| `createLease` follow-ups | none | none | provider fetches manifest off-chain; on-chain nothing further (D-09; manifests never on-chain, A-10) |
+| `closeLease` | `leaseKey, uint32 reason=1(Owner)` | tenant (order owner) | lease Active/Reclaiming; lease → Closed(Owner), bid → Closed, order → Closed, `EscrowVault.paymentClose`; **if group still Open: `createOrder` re-list with oseq+1** (mirrors `server.go:285-336`) → `LeaseClosed`, `BidClosed`, `OrderClosed`, [`OrderCreated`] |
+| `withdrawLease` | `leaseKey` | anyone (payout to provider) | `EscrowVault.paymentWithdraw(leaseKey)` (settle + payout; mirrors `MsgWithdrawLease`) → `PaymentWithdrawn` |
+| `startReclaim` | `leaseKey, uint32 reason` | lease provider | lease Active; `reclamationWindow != 0`; `reclamationStartedAt == 0`; sets startedAt=now, deadline=now+window, state → Reclaiming (mirrors `MsgLeaseStartReclaim`, `server.go:338-379`) → `LeaseReclaimStarted` |
+| `onGroupClosed` | `groupKey` | `DeploymentRegistry` only | closes the group's open order + all open bids (with collateral refunds) or, when a lease is active, closes lease/bid/order + payment (mirror of market.OnGroupClosed cascade) |
+| `onPaymentClosed` | `leaseKey, bool overdrawn` | `EscrowVault` only | escrow hook (mirrors `hooks.go` OnEscrowPaymentClosed): if bid Active: order → Closed, bid → Closed, lease → InsufficientFunds/reason 20000 when overdrawn, else Closed/reason 10002 → events |
+
+**REQ-EVM-025** `createBid` SHALL enforce every check in the table above in the stated order; the
+matching truth table for attributes and resource offers is normative in
+[14](./14-appendix-protocol-mapping.md) and MUST reproduce `pkg.akt.dev/go` `MatchGSpec` /
+`MatchResourcesRequirements` / attribute-matching behavior, with audited attributes resolved from
+`AuditRegistry` and provider self-attributes taking precedence order "self-attributes prepended"
+(mirrors `server.go:72`).
+
+**REQ-EVM-026** `orderMaxBids` (default **20**, hard validation cap 500; mirrors
+`market/v1beta5/params.go`) SHALL bound `openBidKeys` per order; `createLease`'s losing-bid loop and
+`onGroupClosed`'s bid-closure loop are therefore gas-bounded by 20 iterations.
+
+**REQ-EVM-027** Reclamation windows port 1:1 (D-24): config bounds `minReclamationWindow = 3600 s`,
+`maxReclamationWindow = 2,592,000 s` (720 h); `closeBid` on an active lease MUST pass the reclamation
+gate exactly as specified above.
+
+**REQ-EVM-028** Bid collateral: every bid SHALL have its own escrow account funded at creation with at
+least `bidMinDeposits` per supplied denom; collateral is refunded via `accountClose` on Lost/Closed
+without lease, and on lease close after payment closure. Collateral slashing is NOT ported (none exists
+on the current chain); provider-registry collateral (§8) is a separate mechanism.
+
+**REQ-EVM-029** Terminal-state storage: Lost/Closed bids and Closed orders/leases SHALL be deleted
+after their terminal event, except a Closed lease's struct is retained until its escrow payment is
+Closed-and-withdrawn, then deleted (D-23).
+
+### 5.3 Matching (informative summary; normative table in 14)
+
+A bid matches an order iff: (a) every `Attribute` in the group's `requirements.attributes` is present
+(key and value equal) in the provider's effective attribute set (self-attributes from
+`ProviderRegistry` prepended, then audited attributes from `AuditRegistry`); (b) if
+`signedByAllOf`/`signedByAnyOf` are non-empty, the required attributes must be attested by all/at least
+one of the listed auditor addresses respectively; (c) the `ResourcesOffer` covers every `ResourceUnit`
+(resource vector and count) of the group spec. Loops are bounded by REQ-EVM-021 caps.
+
+### 5.4 Events, errors, invariants
+
+Events (mirror the current chain's typed events 1:1): `OrderCreated(owner, dseq, gseq, oseq)`,
+`OrderClosed(...)`, `BidCreated(owner, dseq, gseq, oseq, provider, priceWad)`, `BidClosed(..., state)`,
+`LeaseCreated(owner, dseq, gseq, oseq, provider, priceWad)`, `LeaseClosed(..., reason)`,
+`LeaseReclaimStarted(..., deadline, reason)`.
+
+Custom errors: `OrderNotOpen()`, `BidNotOpen()`, `BidExists()`, `TooManyBids()`, `BidOverOrderPrice()`,
+`OfferMismatch()`, `AttributeMismatch()`, `UnknownProvider()`, `InvalidBseq()`,
+`ReclamationNotStarted()`, `ReclamationWindowNotElapsed()`, `ReclamationAlreadyStarted()`,
+`ReclamationNotOffered()`, `LeaseNotActive()`, `Unauthorized()`.
+
+Invariants: I-MK-1 an order is Active iff exactly one of its bids is Active iff a non-Closed lease
+exists for that bid; I-MK-2 every non-Lost/Closed bid has an Open escrow account (scope Bid); I-MK-3
+`openBidKeys[order].length ≤ orderMaxBids`; I-MK-4 a Reclaiming lease has
+`0 < reclamationStartedAt ≤ now` and `reclamationDeadline = startedAt + window`; I-MK-5 lease price
+equals the matched bid price forever.
+
+---
+
+## 6. `EscrowVault`
+
+Purpose: port of `x/escrow`, a generic streaming-payment escrow used by deployments (funds accounts)
+and bids (collateral accounts). Accounts hold multi-denomination funds with an ordered depositor list;
+payments drain at a fixed rate; **settlement is fully lazy** (computed on interaction; no periodic
+sweep; mirrors `x/escrow/keeper/keeper.go`, EndBlocker removed), plus a permissionless `settle`
+(D-21).
+
+### 6.1 Denominations, precision, time basis
+
+**REQ-EVM-030** The vault SHALL support denoms `DENOM_AKT(1)`, `DENOM_ACT(2)`, `DENOM_STABLE(3)`
+(uint8). All internal fund/rate/balance accounting is **WAD-scaled** (base units × 1e18), mirroring the
+18-fractional-digit `LegacyDec` used on the current chain; external transfers truncate to integer base
+units (mirror of `TruncateInt`), leaving dust in the WAD field.
+
+**REQ-EVM-031** Rates are **per second** (D-21/D-21.a, Δ2). Migration-time conversion from per-block rates
+uses the exact rational **×2/13 (= ÷6.5 exactly**; 1 block = 6.5 s, `util/network/network.go:8`**)**, applied at S1 by the tooling in
+[06](./06-state-and-data-migration.md); this contract only ever sees per-second WAD rates. Accrual is
+`rateWad × (block.timestamp − settledAt)`.
+
+### 6.2 Storage (namespace `akash.storage.EscrowVault`)
+
+| Field | Type | Notes |
+|---|---|---|
+| `accounts` | `mapping(bytes32 accountKey => Account)` | `accountKey = keccak256(abi.encode(scope, xidKey))`; scope ∈ {Deployment=1, Bid=2}; single-key lookup (Δ12: current chain probes 3 state-prefixed keys) |
+| `funds` | `mapping(bytes32 => mapping(uint8 denom => int256))` | WAD; **negative value = overdrawn marker** (mirrors negative `Funds`) |
+| `transferred` | `mapping(bytes32 => mapping(uint8 => uint256))` | Cumulative WAD settled out, per denom |
+| `depositors` | `mapping(bytes32 => Depositor[])` | FIFO order preserved; length ≤ `maxDepositors` (DAO-config `escrow.max_depositors`, initial value 16 per [13](./13-open-questions-and-assumptions.md); D-21 bounded array; current chain effectively owner + 1 grant depositor) |
+| `payments` | `mapping(bytes32 paymentKey => Payment)` | `paymentKey = keccak256(abi.encode(accountKey, leaseKey))` |
+| `activePayments` | `mapping(bytes32 accountKey => bytes32[])` | Non-Closed payments; length ≤ 8 (max groups per deployment, A-18) |
+| `depositAllowances` | `mapping(address granter => mapping(address grantee => Allowance))` | §6.4 |
+| `deploymentRegistry`, `marketplace`, `bme`, `config`, token addresses | `address` | REQ-EVM-010 |
+
+```solidity
+struct Account {               // mirrors AccountState (escrow/types/v1)
+  address owner;
+  AccountState state;          // 1=Open, 2=Closed, 3=Overdrawn
+  uint64  settledAt;           // unix seconds (current chain: height; Δ3)
+  uint8   scope;               // Deployment | Bid
+}
+struct Depositor {             // mirrors Depositor{Owner, Height, Source, Balance}
+  address owner;
+  uint64  depositedAt;         // ordering key (FIFO by array order)
+  uint8   source;              // 1=Balance, 2=Allowance (mirrors balance|grant)
+  uint8   denom;
+  uint256 balanceWad;
+}
+struct Payment {               // mirrors PaymentState
+  address owner;               // provider
+  PaymentState state;          // 1=Open, 2=Closed, 3=Overdrawn
+  uint8   denom;               // DENOM_ACT for leases
+  uint256 rateWad;             // per second
+  uint256 balanceWad;          // accrued, unwithdrawn
+  uint256 unsettledWad;        // debt carried while overdrawn
+  uint256 withdrawn;           // integer base units paid out to owner
+}
+struct Allowance {             // replaces authz DepositAuthorization (D-21)
+  uint256[4] limitWad;         // per denom (index = denom), 0 = none
+  uint8   scopes;              // bitmask: 1=Deployment, 2=Bid (mirrors Scopes[])
+  uint64  expiresAt;           // 0 = no expiry
+}
+```
+
+### 6.3 External functions
+
+| Function | Args | Access | Checks → state transitions → events |
+|---|---|---|---|
+| `accountCreate` | `scope, accountKey, owner, DepositInput` | `DeploymentRegistry` (Deployment) / `Marketplace` (Bid) only | key unused; resolves + pulls deposits (§6.4); Account(Open, settledAt=now); funds credited; depositors appended → `AccountCreated`, `AccountDeposited` |
+| `deposit` | `accountKey, DepositInput` | anyone whose sources authorize it | account Open or Overdrawn-recoverable? **Open only** (mirror: closed accounts reject; overdrawn accounts are terminal on current chain); pulls deposits; **settles first iff account had negative funds** (mirror `AccountDeposit` settles only when overdrawn) → `AccountDeposited` |
+| `settle` | `accountKey` | **anyone** (permissionless, D-21) | runs §6.5; no-op if already settled this second → `AccountSettled` [+ `PaymentOverdrawn`/`AccountOverdrawn` cascade] |
+| `paymentCreate` | `accountKey, leaseKey, owner, denom, rateWad` | `Marketplace` only | settle first; account Open (not Overdrawn); rate > 0; Payment(Open) appended to `activePayments` → `PaymentCreated` |
+| `paymentWithdraw` | `paymentKey` | anyone (payout to `payment.owner`) | settle account; transfer `⌊balanceWad⌋` to owner; `withdrawn += amount`; `balanceWad -= amount·1e18` (mirrors `paymentWithdraw` `keeper.go:1187-1209`; **no take/fee; provider receives 100%**, parity with take-module removal) → `PaymentWithdrawn` |
+| `paymentClose` | `paymentKey` | `Marketplace` only | settle; payment → Closed; final withdraw; remove from `activePayments`; fire `Marketplace.onPaymentClosed` **after** payment persisted (ordering fix d7d0205d) → `PaymentClosed` |
+| `accountClose` | `accountKey` | `DeploymentRegistry`/`Marketplace` only | settle; close all payments (as `paymentClose`); refund depositors (§6.7); account → Closed; hooks → `AccountClosed` |
+| `grantDepositAllowance` | `grantee, uint256[4] limits, uint8 scopes, uint64 expiresAt` | granter (any) | overwrite-or-create → `DepositAllowanceGranted` |
+| `revokeDepositAllowance` | `grantee` | granter | delete → `DepositAllowanceRevoked` |
+
+`DepositInput = { DepositSource[] sources }`, `DepositSource = { uint8 denom; uint256 amount; uint8
+sourceType; address granter; }`.
+
+**REQ-EVM-032** Deposit resolution SHALL walk `sources` in caller order (mirrors `AuthorizeDeposits`,
+`keeper.go:176-345`): `sourceType=Balance` → `safeTransferFrom(caller → vault, amount)`;
+`sourceType=Allowance` → require allowance of (`granter` → caller) covers `amount` in `denom` and scope
+bit matches the account scope and not expired; decrement `limitWad`; `safeTransferFrom(granter →
+vault, amount)` (granter must have ERC-20-approved the vault); record `Depositor{granter, …,
+source=Allowance}`. Any unsatisfied remainder reverts (`InvalidDeposit`). Depositor entries with the
+same (owner, source, denom) merge into the existing entry (bounded array, `maxDepositors` initial
+value 16, DAO-config-adjustable); exceeding the bound reverts `TooManyDepositors`.
+
+### 6.4 Delegated-deposit allowances (authz replacement)
+
+The current chain funds deployments/bids on behalf of users through `x/authz`
+`DepositAuthorization` grants (Console fee sponsorship). There is no authz on EVM, so the seam becomes
+vault-native state (D-21): the `Allowance` struct above, consumed at deposit time, **restored on
+refund** (§6.7). Semantics preserved: partial spends decrement limits; refunds credit the granter's
+wallet AND restore the surviving allowance's limit (mirror of `keeper.go:1050-1075`); a revoked
+allowance is not resurrected by a later refund (funds still return to the granter's wallet).
+
+### 6.5 Settlement algorithm (normative)
+
+**REQ-EVM-033** `_settle(accountKey)` SHALL implement, in order (mirrors `accountSettle`
+`keeper.go:535-604` + `accountSettleFullBlocks` `:1282-1333`):
+1. Revert `AccountClosed()` if state Closed.
+2. `elapsed = block.timestamp − settledAt`; if any `funds[denom] < 0` the account is already in
+   overdrawn resolution: skip accrual (`elapsed` treated as 0; `settledAt` frozen; mirror).
+3. Else set `settledAt = block.timestamp`.
+4. Settle set = all Overdrawn payments ∪ (all Open payments if `elapsed > 0`).
+5. Per payment: `owedWad = state==Overdrawn ? unsettledWad : rateWad × elapsed`; deduct via §6.6;
+   credited amount → `balanceWad`; shortfall → payment state Overdrawn, `unsettledWad = shortfall`.
+6. AKT-fallback pass (§6.8) if account has any negative funds.
+7. If any `funds[denom]` still negative: zero the negative markers into `unsettledWad` bookkeeping,
+   set account → Overdrawn, force every payment → Overdrawn, run `paymentWithdraw` for each, then the
+   §6.7 refund-and-close path with `overdrawn=true` hooks. Overdrawn is terminal (no reopen, parity;
+   the v1.1.0 upgrade repaired historical violations of this).
+
+**REQ-EVM-034** `_deduct(accountKey, denom, owedWad)` SHALL drain the depositor array in FIFO order
+filtered by `denom` (mirrors `deductFromBalance` `keeper.go:1211-1280`): decrement
+`Depositor.balanceWad`, accumulate `transferred[denom]`, delete zero-balance entries preserving order;
+subtract the full `owedWad` from `funds[denom]` even on shortfall (negative funds = overdrawn marker);
+return (credited, shortfall).
+
+**REQ-EVM-035** Settlement MUST be triggered inside: `accountClose`, `deposit` (only when funds
+negative), `paymentCreate`, `paymentWithdraw`, `paymentClose`, and public `settle`; this is exactly the
+current chain's trigger set plus the now-permissionless `settle`. Keeper automation (§13) calls
+`settle` on accounts predicted to exhaust within the next epoch so overdrawn detection does not depend
+on user interaction (replaces the implicit EndBlocker-era guarantee, D-21).
+
+### 6.6 Denomination drain order (D-14 extension)
+
+**REQ-EVM-036** For ACT-denominated payments the deduction denom order SHALL be: `ACT`, then `STABLE` at
+the governed parity `stable_act_parity_bps` (default **10000** = par: 1 STABLE-base-unit = 1 ACT-base-unit;
+USD-denominated units, decimals normalized if the selected asset is not 6-decimal; ACT is the USD-denominated
+compute credit; see §7; held in `AkashConfig` as
+`escrow.stableActParityBps`, D-14.a). AKT funds are NEVER drained for ACT payments except via the §6.8 fallback.
+The stable-par rule is new relative to the current chain (which had no stablecoin denom in v2 escrow) and is flagged
+for governance ratification (Q-22 in [13](./13-open-questions-and-assumptions.md)).
+
+### 6.7 Refunds, close, hooks
+
+**REQ-EVM-037** On close/overdrawn (mirrors `saveAccount` `keeper.go:1022-1104`): for each remaining
+depositor with `balanceWad > 0`, transfer `⌊balanceWad⌋` base units to `Depositor.owner`; if
+`source==Allowance` and the (granter→original grantee) allowance still exists, ALSO restore
+`limitWad[denom]` by the refunded amount; zero `funds`; delete the depositor array; then invoke
+exactly one hook: `DeploymentRegistry.onAccountClosed(xid, overdrawn)` for Deployment scope (cascades
+deployment/group closure); Bid-scope closes have no hook (collateral refund only). Payment closure
+invokes `Marketplace.onPaymentClosed(leaseKey, overdrawn)` (lease/bid/order cascade). Hook ordering:
+payments persisted before account hooks fire (d7d0205d parity).
+
+### 6.8 AKT fallback settlement (BME-halt path)
+
+**REQ-EVM-038** Mirroring `settleFromAktFallback` (`keeper.go:609-687`): iff (a) the account is
+overdrawn on ACT, (b) `funds[AKT] > 0`, (c) `BurnMintEscrow.mintStatus() >= HALT_CR`, and (d) the Pyth
+AKT/USD price is positive and fresh (§9), the vault SHALL convert each payment's ACT
+`unsettledWad` to AKT at `aktOwedWad = unsettledWad / price_AKT_USD`, deduct from `funds[AKT]` (FIFO
+depositors), transfer AKT directly to `payment.owner`, clear `unsettledWad`, and return the payment to
+Open. Debt is not carried beyond available AKT (funds zeroed if exhausted; parity). This path exists
+so leases keep settling in AKT when the BME engine is halted; it is inert while BME is healthy.
+
+### 6.9 Events, errors, invariants
+
+Events (Δ4: the current chain's escrow emits NO events; the indexer needs them as system of record,
+REQ-EVM-009): `AccountCreated(scope, accountKey, owner)`, `AccountDeposited(accountKey, depositor,
+denom, amount, source, granter)`, `AccountSettled(accountKey, settledAt)`,
+`AccountOverdrawn(accountKey)`, `AccountClosed(accountKey)`, `DepositRefunded(accountKey, depositor,
+denom, amount, allowanceRestored)`, `PaymentCreated(accountKey, paymentKey, owner, denom, rateWad)`,
+`PaymentWithdrawn(paymentKey, amount)`, `PaymentOverdrawn(paymentKey, unsettledWad)`,
+`PaymentClosed(paymentKey)`, `AktFallbackSettled(paymentKey, aktAmount, priceUsed)`,
+`DepositAllowanceGranted/Revoked(granter, grantee)`.
+
+Custom errors: `AccountExists()`, `AccountNotOpen()`, `AccountClosed()`, `AccountOverdrawnErr()`,
+`PaymentExists()`, `PaymentNotOpen()`, `InvalidDeposit()`, `InvalidDenom()`, `TooManyDepositors()`,
+`AllowanceInsufficient()`, `AllowanceScopeMismatch()`, `AllowanceExpired()`, `InvalidRate()`,
+`Unauthorized()`.
+
+Invariants: I-EV-1 (solvency) per denom, vault ERC-20 balance ≥ Σ max(funds,0) + Σ payment
+`balanceWad`, all in truncated base units; I-EV-2 per Open account and denom, Σ depositor balances ==
+`funds[denom]` when non-negative; I-EV-3 `transferred` is monotone non-decreasing; I-EV-4 an Open
+payment's account is Open; I-EV-5 for every payment, `withdrawn·1e18 + balanceWad + unsettledWad` ==
+total ever deducted for it; I-EV-6 depositor array length ≤ `maxDepositors` and FIFO order is
+insertion order.
+
+---
+
+## 7. `BurnMintEscrow`
+
+Purpose: port of `x/bme`, the two-token engine. Users burn AKT to mint ACT (and back) at the Pyth
+AKT/USD price; swaps are **queued** and executed in **epoch batches**; a **collateral-ratio (CR)
+circuit breaker** gates ACT minting; a mint spread accrues to the vault. The module account becomes
+this contract's AKT balance ("the vault"), seeded at S1 from the migrated `bme` module account via the
+Wind-down Reserve ([05](./05-token-migration.md)).
+
+### 7.1 Storage (namespace `akash.storage.BurnMintEscrow`)
+
+| Field | Type | Mirrors |
+|---|---|---|
+| `status` | `Status { uint8 mintStatus; uint8 previousStatus; uint64 epochDurationSec; }` | status Item (`x/bme/keeper/key.go`); MintStatus enum preserved: 0 Unspecified, 1 Healthy, 2 Warning, 3 HaltCR, 4 HaltOracle |
+| `nextEpochAt` | `mapping(bytes32 kind => uint64)` | epochs Map ("mint","burn" → next execution time; Δ6 time-based) |
+| `pending` | `mapping(uint256 id => PendingSwap)` + `firstPendingId/nextPendingId` per direction (FIFO queue) | ledgerPending; LedgerRecordID(height,seq) → monotonic uint256 id |
+| `pendingBalance` | `mapping(uint8 denom => uint256)` | ledgerPendingBalances: in-flight escrowed coins, excluded from CR |
+| `totalBurned`, `totalMinted` | `mapping(uint8 denom => uint256)` | totals |
+| `remintCredit` | `mapping(uint8 denom => uint256)` | remintCredits (spread credit accounting; exact semantics mirrored per [01](./01-current-architecture.md)/[14](./14-appendix-protocol-mapping.md)) |
+| `params` | in `AkashConfig` (§10.1) | Params |
+
+```solidity
+struct PendingSwap {           // mirrors LedgerPendingRecord
+  address owner;               // burner
+  address to;                  // mint recipient
+  uint8   fromDenom;           // AKT or ACT
+  uint8   toDenom;
+  uint256 amount;              // escrowed at request time
+  uint8   attempts;            // cancel at maxPendingAttempts (default 3)
+}
+```
+
+Executed and canceled records are NOT stored (Δ: current chain keeps `ledger`/`ledgerCanceled` maps);
+they are emitted as events (`SwapExecuted` carries every `LedgerRecord` field: burned/minted coin +
+price, spread, remint credit issued/accrued) and live in the indexer (D-23).
+
+### 7.2 External functions
+
+| Function | Args | Access | Checks → state transitions → events |
+|---|---|---|---|
+| `requestSwap` | `to, uint8 fromDenom, uint8 toDenom, uint256 amount` | anyone | mirrors `RequestBurnMint` (`x/bme/keeper/keeper.go:786-865`): only AKT↔ACT; fresh positive Pyth price for BOTH legs (§9); AKT→ACT requires `amount·price ≥ minMint` (10_000_000 ACT base units) and `mintStatus ∈ {Healthy, Warning}`; **ACT→AKT allowed under HaltCR but NOT under HaltOracle** (D-20 halt_cr-allows-ACT-burns rule); `safeTransferFrom(caller → this, amount)` (ACT leg uses allowlisted pull); enqueue PendingSwap; `pendingBalance[fromDenom] += amount` → `SwapQueued(id, owner, to, fromDenom, toDenom, amount)` |
+| `mintACT` | `to, uint256 aktAmount` | anyone | sugar for `requestSwap(to, AKT, ACT, aktAmount)` (mirrors `MsgMintACT`) |
+| `burnACT` | `to, uint256 actAmount` | anyone | sugar for `requestSwap(to, ACT, AKT, actAmount)` (mirrors `MsgBurnACT`) |
+| `cancelPending` | none | none (no user cancel; parity: current chain has none; cancellation only via retry exhaustion) | none |
+| `fundVault` | `uint256 aktAmount, address source` | `AkashTimelock` only | mirrors gov-gated `MsgFundVault`: pulls AKT from `source` (non-protocol address) into the vault → `VaultFunded(source, amount)` |
+| `executeBurnEpoch` | `uint256 maxRecords` | anyone (keeper-automated, §13) | `now ≥ nextEpochAt["burn"]`; process up to `min(maxRecords, maxRecordsPerExecution=50)` ACT→AKT swaps FIFO (§7.3); `nextEpochAt["burn"] = now + epochDuration` → per-swap `SwapExecuted`/`SwapCanceled`, `EpochExecuted("burn", n)` |
+| `executeMintEpoch` | `uint256 maxRecords` | anyone | `now ≥ nextEpochAt["mint"]`; recompute CR + status first (§7.4); if status just recovered from ≥HaltCR to ≤Warning, only reschedule (mirror of breaker-reset behavior); else if Healthy/Warning process AKT→ACT swaps FIFO, **aborting the batch if CR trips mid-loop** (post-condition check per record, CacheContext parity via per-record try/effects-revert) → events as above, `MintStatusChanged` on change |
+| `updateStatus` | none | anyone | recompute CR + status without executing (mirrors per-EndBlock `mintStatusUpdate`); keeper-automated each epoch → `MintStatusChanged` on change |
+
+**REQ-EVM-039** Per-swap execution SHALL mirror the EndBlocker semantics (`x/bme/keeper/abci.go:35-213`):
+price both legs from Pyth (AKT/USD spot for staleness gating; **EMA price as the TWAP replacement**, Δ7);
+AKT→ACT: `minted = amount·price·(10000−mintSpreadBps)/10000`, burn AKT (`AKT.burnFrom(this)`), mint
+ACT to `to`, spread accounting to `remintCredit`; ACT→AKT: `minted = amount/price` (settleSpreadBps=0
+default), burn ACT, transfer AKT from vault to `to`; success → totals updated, `pendingBalance`
+decremented, `SwapExecuted`; **retriable failure** (stale price, transient) → `attempts++`, re-queue,
+cancel with refund at `maxPendingAttempts=3` (`SwapCanceled(reason=MaxAttempts)`); **fatal failure**
+(vault insolvent for the leg) → immediate cancel + refund of the escrowed coin.
+
+**REQ-EVM-040** Epoch scheduling SHALL be time-based (Δ6, D-20): `minEpochDuration` default **65 s**
+(mirror of `MinEpochBlocks=10` × 6.5 s). CR-based backoff mirrors `calculateCR` backoff:
+`epochDuration = minEpochDuration × (1 + backoffPercent/100)^steps`, `steps = (warnBps − crBps)/10`,
+capped at **93,600 s** (mirror of 14,400 blocks × 6.5 s). `executeBurnEpoch`/`executeMintEpoch` are
+permissionless; keeper automation (§13) is a liveness convenience, never an authorization gate.
+
+### 7.3 Collateral ratio and circuit breaker
+
+**REQ-EVM-041** CR SHALL be computed as (mirrors `calculateCR` `keeper.go:742-784`):
+
+```
+CR_bps = (AKT.balanceOf(vault) − pendingBalance[AKT]) × price_AKT_USD × 10000
+         ────────────────────────────────────────────────────────────────────
+                              ACT.totalSupply()
+```
+
+with a zero/stale price forcing `HaltOracle`. Status transitions (defaults carried over, D-20):
+`CR ≥ 9500` Healthy; `9000 ≤ CR < 9500` Warning (epoch backoff active); `CR < 9000` HaltCR (minting
+halted; ACT→AKT burns still allowed); oracle failure HaltOracle (everything halted). Every transition
+emits `MintStatusChanged(previous, new, crBps)`.
+
+**REQ-EVM-042** Vault AKT SHALL be reachable only via swap execution, the §6.8 escrow fallback (which
+reads but never spends vault funds; fallback pays from the escrow account's own AKT), and
+governance `fundVault`. No withdraw function exists. `ACT.totalSupply()` is the true CR denominator
+because ACT mint/burn is exclusively BME/EscrowVault-gated (REQ-EVM-018).
+
+### 7.4 Events, errors, invariants
+
+Events: `SwapQueued`, `SwapExecuted(id, burner, minter, burnedDenom, burnedAmount, priceWadBurn,
+mintedDenom, mintedAmount, priceWadMint, spread, remintCreditIssued, remintCreditAccrued)`,
+`SwapCanceled(id, reason)`, `MintStatusChanged(previous, new, crBps)` (mirrors
+`EventMintStatusChange`), `VaultFunded(source, amount)` (mirrors `EventVaultFunded`),
+`EpochExecuted(kind, processed, remaining, nextEpochAt)`.
+
+Custom errors: `UnsupportedPair()`, `BelowMinMint()`, `MintingHalted(uint8 status)`,
+`OracleHalted()`, `EpochNotDue()`, `StalePrice()`, `NothingPending()`, `Unauthorized()`.
+
+Invariants: I-BME-1 `AKT.balanceOf(this) ≥ pendingBalance[AKT]` and
+`ACT.balanceOf(this) == pendingBalance[ACT]`; I-BME-2 status==HaltOracle iff last price read failed
+freshness/positivity; I-BME-3 mint execution never occurs with `CR_bps < haltThreshold` at record
+post-condition; I-BME-4 Σ minted ACT (net of burns) == `ACT.totalSupply()` attributable to BME +
+escrow-migration mints per [05](./05-token-migration.md); I-BME-5 queue FIFO per direction.
+
+---
+
+## 8. `ProviderRegistry` and `AuditRegistry`
+
+### 8.1 `ProviderRegistry`
+
+Purpose: port of `x/provider` (registry of compute providers: host URI, self-declared attributes,
+contact info) EXTENDED per D-10 with on-chain **JWT signing keys** (replacing the x/cert x509
+registry, which is not ported) and per Q-08 with **registration collateral** (partial replacement for
+staking-era Sybil resistance).
+
+Storage (namespace `akash.storage.ProviderRegistry`):
+
+| Field | Type | Notes |
+|---|---|---|
+| `providers` | `mapping(address owner => Provider)` | one provider per address (mirrors single-map `x/provider` store); the `owner` address is the cold owner authority (per D-10.a / 07) |
+| `signingKeys` | `mapping(address owner => SigningKey[])` | bounded ≤ `maxSigningKeys` (default 3, parity with 03); rotating operator hot keys for JWT signing (per D-10.a / 07) |
+| `tlsSpkiHashes` | `mapping(address owner => bytes32[])` | provider TLS SPKI hash anchors, bounded ≤ 8 (per D-10.a / 07) |
+| `collateral` | `mapping(address owner => Collateral { uint256 amount; uint64 unlockAt; })` | AKT |
+
+```solidity
+struct Provider {              // mirrors provider/v1beta4.Provider
+  ProviderState state;         // 1=Active, 2=Deregistering, 3=Deregistered
+  string  hostURI;             // provider gateway URI
+  Attribute[] attributes;      // self-declared; ≤ maxProviderAttributes (default 24, A-18)
+  string  email; string website; // Info{EMail, Website}
+  uint64  registeredAt;
+}
+struct SigningKey {            // D-10; no Cosmos equivalent (x/cert replaced)
+  bytes32 keyId;               // JWK kid
+  uint8   algorithm;           // 1=ES256K (secp256k1; matches current `akash auth jwt` keyring signing), 2=Ed25519
+  bytes   publicKey;           // 33/32 bytes
+  uint8   status;              // 1=Active, 2=Revoked
+  uint64  addedAt; uint64 revokedAt;
+}
+```
+
+| Function | Access | Behavior |
+|---|---|---|
+| `registerProvider(hostURI, attributes, email, website)` | anyone, once per address | pulls `providerMinCollateral` AKT (config; **initial value 0 until Q-08 ratified**; mechanism normative, number open); stores Provider(Active) → `ProviderCreated` (mirrors `MsgCreateProvider`) |
+| `updateProvider(hostURI, attributes, email, website)` | provider | mirrors `MsgUpdateProvider`; NO active-lease check (parity: check removed in v0.32.0 for gas and not reintroduced) → `ProviderUpdated` |
+| `addSigningKey(keyId, algorithm, publicKey)` / `revokeSigningKey(keyId)` | provider | bounded; revocation immediate → `ProviderSigningKeyAdded/Revoked` |
+| `beginDeregister()` | provider | requires **no active or reclaiming leases** (query via `Marketplace` provider-lease counter); state → Deregistering; `unlockAt = now + collateralCooldown` (default 604800 s = 7 d) → `ProviderDeregistering` |
+| `finalizeDeregister()` | provider | `now ≥ unlockAt`; refunds collateral; deletes provider + keys → `ProviderDeregistered` |
+| `slashCollateral(owner, amount, recipient)` | `AkashTimelock` only | governance slashing per Q-08 conditions → `ProviderCollateralSlashed` |
+
+**REQ-EVM-043** `Marketplace` SHALL maintain `activeLeaseCount[provider]`
+(increment on `LeaseCreated`, decrement on lease terminal states) so `beginDeregister` can enforce the
+no-active-leases rule in O(1). This implements the behavior `MsgDeleteProvider` was supposed to have
+(on the current chain it reverts `NOTIMPLEMENTED`, `x/provider/handler/server.go:74-88`) and is an
+intentional delta (Δ8).
+
+**REQ-EVM-044** JWT trust chain (normative interface for [07](./07-offchain-and-clients.md)): provider
+gateways sign JWTs with a registered Active `SigningKey`; verifiers (tenants, Console) resolve keys by
+`(providerAddress, keyId)` from this registry (directly or via indexer with on-chain fallback) and
+MUST reject tokens signed by Revoked keys, honoring revocation within ≤ 60 s of the revoking
+transaction's sequencer confirmation. mTLS remains transport-level between tenant and provider with
+keys anchored here (D-10).
+
+Custom errors: `ProviderExists()`, `ProviderNotFound()`, `ProviderNotActive()`, `ActiveLeases()`,
+`CooldownActive()`, `TooManyKeys()`, `KeyNotFound()`, `CollateralInsufficient()`, `Unauthorized()`.
+Invariants: I-PR-1 a provider with `activeLeaseCount > 0` cannot leave Active; I-PR-2 collateral
+refunds only at Deregistered; I-PR-3 key arrays bounded.
+
+### 8.2 `AuditRegistry`
+
+Purpose: port of `x/audit`. Auditors attest provider attribute sets; `Marketplace` matching treats
+audited attributes first-class (REQ-EVM-025).
+
+Storage: `mapping(bytes32 => Attribute[]) auditedAttributes` keyed by
+`keccak256(abi.encode(provider, auditor))` (mirrors the `(owner, auditor)` composite store key), plus
+`mapping(address provider => address[]) auditorsOf` (bounded ≤ 32) for matching enumeration.
+
+| Function | Access | Behavior |
+|---|---|---|
+| `signProviderAttributes(provider, Attribute[] attrs)` | any auditor address | upsert full set for (provider, auditor) (mirrors `MsgSignProviderAttributes`) → `AuditorAttributesSigned(provider, auditor)` (mirrors `EventTrustedAuditorCreated`) |
+| `deleteProviderAttributes(provider, string[] keys)` | the auditor | delete listed keys, or entire record when `keys` empty (mirrors `MsgDeleteProviderAttributes`) → `AuditorAttributesDeleted` |
+| `getProviderAttributes(provider, auditor)` / `getAuditors(provider)` | view | used by `Marketplace` matching |
+
+**REQ-EVM-045** Audited attribute sets SHALL be bounded (≤ 64 attributes per (provider, auditor),
+REQ-EVM-021 string caps) and readable in a single view call for matching. There is no on-chain auditor
+allowlist (parity: any address may sign; trust is expressed by orders naming auditors in
+`signedByAllOf/AnyOf`).
+
+Custom errors: `NotAuditor()`, `NoAttributes()`, `BoundsExceeded()`. Invariant: I-AR-1
+`auditorsOf[p]` contains exactly the auditors with a non-empty attribute set for `p`.
+
+---
+
+## 9. Oracle integration (Pyth, D-13)
+
+On the current chain, Pyth prices reach consensus through a CosmWasm contract pushing
+`MsgAddPriceEntry` into `x/oracle`, which aggregates TWAP+median with staleness/deviation health
+(single authorized source on mainnet). On EVM this entire pipeline collapses (D-22) to direct reads of
+the **Pyth pull oracle** deployed on the target chain (a production Pyth deployment is a REQ-EVM-071
+host-chain criterion; Base and Arbitrum One carry one as of 2026-08; availability on Robinhood Chain
+is verified at kickoff per Q-42).
+
+**REQ-EVM-046** A thin internal library `PythAdapter` (not a deployed contract) SHALL wrap
+`IPyth` for all consumers (`BurnMintEscrow`, `EscrowVault` fallback): read via
+`getPriceNoOlderThan(feedId, maxStaleness)` with `maxStaleness = 30 s` (mirrors oracle param
+`MaxPriceStalenessPeriod=30s`); reject non-positive prices; reject when
+`conf × 10000 / price > maxConfBps` with `maxConfBps = 150` (mirrors `MaxPriceDeviationBps=150`);
+normalize `expo` to WAD. Parameters live in `AkashConfig` (§10.1).
+
+**REQ-EVM-047** Price freshness is the caller's responsibility (pull model): every transaction that
+needs a fresh price (swap request, epoch execution, fallback settlement) SHALL support fee-forwarded
+`IPyth.updatePriceFeeds(updateData)` in the same transaction (Hermes-sourced update blobs supplied by
+the caller/keeper; `msg.value` covers `getUpdateFee`). Keeper jobs (§13) bundle price updates with
+epoch executions. Consumers MUST NOT assume a pusher keeps the feed warm.
+
+**REQ-EVM-048** BME swap/CR pricing SHALL use Pyth's EMA price (`getEmaPriceNoOlderThan`) as the
+replacement for the current chain's 1 h TWAP; escrow AKT-fallback uses the spot price (mirrors direct
+`GetAggregatedPrice` use). Both apply REQ-EVM-046 gating. The AKT/USD feed id is configuration:
+`[TO-VERIFY: Pyth AKT/USD feed id and its availability on the candidate host chains at kickoff]`.
+
+**REQ-EVM-049** Fallback feed policy: if Pyth AKT/USD is stale > `oracleGraceWindow` (default 3600 s),
+BME enters `HaltOracle` (automatic via REQ-EVM-041) and stays there. There is NO secondary oracle at
+launch (parity: the current chain is single-source, `oparams.Sources` = one contract,
+`upgrades/software/v2.1.0/upgrade.go:66`). `AkashConfig` reserves a `fallbackFeed` slot (address +
+feed id, default unset) so governance can wire a second pull oracle (e.g. Chainlink, if an AKT feed
+exists) without an upgrade; when set, consumers read it only while Pyth is stale, and cross-check
+divergence ≤ `maxConfBps`. Wiring a fallback is a governance action, not a launch deliverable.
+
+---
+
+## 10. `AkashConfig`, governance, and parameters
+
+### 10.1 Parameter inventory
+
+`AkashConfig` is the single parameter store (replaces per-module params) and the client-version
+registry (replaces the Akash Discovery service). All writes are `AkashTimelock`-only; every change
+emits `ParamUpdated(bytes32 key, bytes oldValue, bytes newValue)`.
+
+**REQ-EVM-050** `AkashConfig` SHALL hold at minimum the following typed parameters with these launch
+defaults (carried from module params; validation rules mirror the source params where noted):
+
+| Key | Default | Mirrors / notes |
+|---|---|---|
+| `deployment.minDeposits[denom]` | ACT 500000; STABLE 500000; AKT 500000 (top-up min) | `deployment/v1beta4/params.go:32-38` (`500000uakt, 500000uact`); per-denom validation, missing denom = deposit rejected |
+| `deployment.maxGroupsPerDeployment` | 8 | new explicit bound (Δ10, A-18) |
+| `market.bidMinDeposits[denom]` | AKT 500000; ACT 500000 | `market/v1beta5/params.go:16-58` |
+| `market.orderMaxBids` | 20 (validation cap 500) | same |
+| `market.minReclamationWindow` | 3600 s | 1 h (D-24) |
+| `market.maxReclamationWindow` | 2,592,000 s | 720 h (D-24) |
+| `escrow.maxDepositors` | 16 | DAO-config `escrow.max_depositors`, initial value 16 per 13; D-21 bounded array (new) |
+| `escrow.maxActivePayments` | 16 | new explicit bound |
+| `escrow.stableActParityBps` | 10000 | governed `stable_act_parity_bps` par rule (D-14.a; ratification Q-22, §6.6) |
+| `bme.circuitBreakerWarnBps` | 9500 | `bme/v1/params.go`; validation warn > halt, both ≤ 10000 |
+| `bme.circuitBreakerHaltBps` | 9000 | same |
+| `bme.mintSpreadBps` | 25 | validation ≤ 1000 |
+| `bme.settleSpreadBps` | 0 | validation ≤ 1000 |
+| `bme.minEpochDuration` | 65 s | `MinEpochBlocks=10` × 6.5 s (Δ6) |
+| `bme.epochBackoffPercent` | 10 | same |
+| `bme.maxEpochDuration` | 93,600 s | backoff cap (14,400 blocks × 6.5 s) |
+| `bme.maxRecordsPerExecution` | 50 | `MaxEndblockerRecords=50` |
+| `bme.minMint` | 10,000,000 (ACT base units) | `MinMint=10,000,000uact` |
+| `bme.maxPendingAttempts` | 3 | same |
+| `oracle.pyth` | chain-specific address | none |
+| `oracle.aktUsdFeedId` | `[TO-VERIFY]` | REQ-EVM-048 |
+| `oracle.maxStaleness` | 30 s | `MaxPriceStalenessPeriod=30s` |
+| `oracle.maxConfBps` | 150 | `MaxPriceDeviationBps=150` |
+| `oracle.graceWindow` | 3600 s | REQ-EVM-049 |
+| `oracle.fallbackFeed` | unset | REQ-EVM-049 |
+| `provider.minCollateral` | 0 (pending Q-08) | mechanism per §8.1 |
+| `provider.collateralCooldown` | 604,800 s | 7 d |
+| `provider.maxAttributes` / `provider.maxSigningKeys` | 24 / 3 | bounds (A-18, parity with 03) |
+| `tokens.settlementStable` | chain-specific address | settlement-stablecoin address, selected per Q-43 (§3.3); D-14 |
+| `gas.trustedPaymaster` | address (informational) | §13.2 |
+
+Parameters NOT carried, with disposition: staking/slashing/mint/distribution/crisis params (sovereign
+consensus ends; D-06, D-12; emissions replacement in §11); gov params (re-expressed as Governor
+settings, §10.3); `awasm.BlockedAddresses` (no CosmWasm, D-22); oracle multi-source aggregation
+params `MinPriceSources/TwapWindow/PriceRetention/PruneEpoch/...` (collapsed into §9); take params
+(module dead on current chain; providers keep 100%; preserved).
+
+### 10.2 Client version registry (Discovery replacement)
+
+The current chain serves `GET /akash/discovery/v1/info` (chain id, node version,
+`min_client_version`, per-API module version map) that `chain-sdk`/CLI use to negotiate API versions.
+On EVM there is no node-attached service to extend, so the registry moves on-chain:
+
+**REQ-EVM-051** `AkashConfig` SHALL expose `clientRegistry()` returning
+`{ string protocolVersion; string minClientVersion; ApiVersion[] apis; }` where
+`ApiVersion = { string api; string version; }` seeded with the migrated API map (deployment v1beta4 →
+`deployments/1`, market v1beta5 → `market/1`, escrow, provider, audit, bme, oracle equivalents; the
+authoritative table is [14](./14-appendix-protocol-mapping.md) §versions), plus an event
+`ClientVersionUpdated`. Clients hard-fail when their version < `minClientVersion` (same contract as
+today's discovery negotiation); the indexer republishes this registry over the Console API shape
+([07](./07-offchain-and-clients.md)).
+
+### 10.3 Governance wiring (D-11, D-15)
+
+**REQ-EVM-052** `AkashGovernor` SHALL be OZ Governor (v5.x: `GovernorSettings`,
+`GovernorCountingSimple`, `GovernorVotes`, `GovernorVotesQuorumFraction`,
+`GovernorTimelockControl`) over `AKT` votes (timestamp clock, REQ-EVM-013) with launch settings:
+voting delay 86,400 s (1 d), voting period 259,200 s (3 d; mirrors gov.VotingPeriod), proposal
+threshold 2,500 AKT-equivalent (2,500,000,000 base units; mirrors gov.MinDeposit 2,500 AKT), quorum
+10% of total supply. The quorum figure is NOT a mirror (Cosmos quorum was 20% of *bonded, mostly
+delegated* stake; EVM delegation rates differ); calibration is a new open question (Q-23) with 10%
+as the launch default (D-11.a).
+
+**REQ-EVM-053** `AkashTimelock` (OZ `TimelockController`) SHALL be the `owner`/upgrade authority/param
+authority for every contract in Table 2-1. Roles: `PROPOSER_ROLE` = `AkashGovernor` only;
+`EXECUTOR_ROLE` = open (`address(0)`); `CANCELLER_ROLE` = the security-council **Safe** (D-11).
+Delay classes: standard operations (params, config) `minDelay = 172,800 s` (48 h); contract upgrades
+and token-role changes SHALL be scheduled with ≥ 259,200 s (72 h) delay (enforced by convention +
+monitoring at launch, by a delay-enforcing timelock extension if the audit prefers; decision
+delegated to [08](./08-security-and-audits.md)).
+
+**REQ-EVM-054** The security-council Safe (composition, signer policy, and the guardian
+pause role of REQ-EVM-012) is specified in [08](./08-security-and-audits.md); this document fixes only
+its two powers: cancel queued timelock operations, and pause the REQ-EVM-012 entrypoints. It can
+neither propose, execute, nor upgrade.
+
+---
+
+## 11. `EmissionsMinter` and `MigrationClaims` (interfaces)
+
+### 11.1 `EmissionsMinter` (D-12)
+
+Sovereign inflation ends at halt H. The replacement schedule mints AKT to (a) the provider-incentives
+pool and (b) the community treasury. The curve itself is a modeling deliverable (Q-01,
+[11. SOW](./11-scope-of-work.md) WS-1); the mechanism is fixed:
+
+**REQ-EVM-055** `EmissionsMinter` SHALL implement: an epoch-based drip
+(`claimEmissions()` permissionless, computes elapsed epochs since last mint and mints per the stored
+schedule), a schedule representation `Segment[] { uint64 startTime; uint64 endTime; uint256
+ratePerSecond; uint16 providerPoolBps; }` mutable only by `AkashTimelock`, an immutable
+`HARD_CAP` (total post-migration emissions ceiling, set at deployment from the ratified model), and
+recipients (provider-incentives pool address, community treasury = timelock) held in `AkashConfig`.
+Invariant I-EM-1: cumulative minted ≤ `HARD_CAP` regardless of schedule contents. Events:
+`EmissionsMinted(epoch, providerPoolAmount, treasuryAmount)`, `ScheduleUpdated`.
+
+### 11.2 `MigrationClaims` (interface only; normative spec in [05](./05-token-migration.md))
+
+Consumed by this architecture as follows: it is the only AKT minter besides `EmissionsMinter`
+(REQ-EVM-014); it operates the S1 Merkle distribution, the Wind-down Reserve, weekly residual
+distributions, S2, and vesting re-creation (D-05, D-06). Interface surface this document depends on:
+
+```solidity
+interface IMigrationClaims {
+  function claim(uint256 index, address account, uint256 amount, bytes32[] calldata proof) external;      // S1 liquid
+  function claimResidual(uint256 distributionId, uint256 index, address account, uint256 amount, bytes32[] calldata proof) external;
+  function claimVesting(uint256 index, address account, VestingSchedule calldata s, bytes32[] calldata proof) external; // re-created vesting
+  function windDownReserveBalance() external view returns (uint256);
+  event Claimed(uint256 indexed index, address indexed account, uint256 amount);
+  event ResidualDistributionPublished(uint256 indexed id, bytes32 merkleRoot, uint256 total);
+}
+```
+
+**REQ-EVM-056** The BME vault seed (D-20) SHALL be executed as a `MigrationClaims`-originated transfer
+of the migrated `bme` module-account AKT from the Wind-down Reserve into `BurnMintEscrow` via
+`fundVault` at activation (one governance transaction bundle; exact amounts per
+[05](./05-token-migration.md) supply accounting).
+
+---
+
+## 12. Keeper automation
+
+Two recurring jobs replace EndBlocker behavior: (a) BME epoch execution + status refresh (§7), (b)
+escrow settlement sweeps over soon-to-exhaust accounts (§6.5). Both are permissionless on-chain; the
+keeper is a liveness backstop, not an authority.
+
+**REQ-EVM-057** Primary keeper: **Chainlink Automation** (time-based + custom-logic upkeeps).
+Justification vs Gelato (the credible alternative; coverage by at least one of the two is a
+REQ-EVM-071 host-chain criterion): Chainlink's keeper network has
+the longer production track record for exactly this shape of job (conditional epoch execution),
+decentralized execution across independent node operators rather than a single operator's
+infrastructure, and native `checkUpkeep/performUpkeep` fits `executeMintEpoch`/`executeBurnEpoch`
+gating with no adapter. Gelato SHALL be wired as the documented secondary (both target
+`AutomationCompatibleInterface`-shaped entrypoints; migration between vendors is a registry
+re-registration, not a code change). If the selected host chain carries only one of the two networks
+in production, that network is primary. `[TO-VERIFY: Chainlink Automation and Gelato service coverage
+on the selected host chain at kickoff]`. Liveness requirement: BME epochs execute within `minEpochDuration + 120 s` p95;
+escrow overdrawn detection lag ≤ 300 s p95 (test targets in
+[09](./09-testing-and-verification.md)).
+
+**REQ-EVM-058** Keeper jobs MUST be stateless and replayable: anyone (provider daemons, Overclock ops,
+community bots) can execute the same entrypoints; the contracts enforce idempotence (`EpochNotDue`,
+no-op settles). Keeper funding/ownership is an operations item (Q-07).
+
+---
+
+## 13. Transaction semantics and UX
+
+### 13.1 Nonces and ordering
+
+The current chain enables **unordered transactions** (`authkeeper.WithUnorderedTransactions(true)`,
+`app/types/app.go:279`); EVM EOAs are strictly nonce-ordered.
+
+**REQ-EVM-059** Client guidance
+(normative for [07](./07-offchain-and-clients.md)): provider daemons submitting concurrent
+transactions (bids, withdrawals, settles) SHALL use either a local nonce manager with gap recovery or
+an ERC-4337 smart account with 2D nonces (parallel keys per workflow); tenant flows default to smart
+accounts (§13.2). No protocol contract may assume cross-transaction ordering beyond its own state
+checks (Δ15).
+
+### 13.2 AKT-denominated gas (paymasters) and meta-tx posture
+
+Gas on the B1 host chain is ETH (true of Base and Arbitrum One; verified per candidate, incl.
+Robinhood Chain, under Q-42). Users holding only AKT (the
+current chain's UX) are served via account abstraction.
+ERC-4337 + EIP-7702 are production-normal as of 2026-08 (~200M cumulative smart wallets; MetaMask/
+Rabby/Trust/OKX support 7702 upgrades), and D-14 context applies: users MAY simply hold ETH; AKT-gas
+is a UX layer, not protocol.
+
+**REQ-EVM-060** The Vendor SHALL integrate an **ERC-20 paymaster** (Pimlico/Alchemy/Biconomy-class;
+selection at kickoff) accepting AKT (and the settlement stablecoin via an issuer paymaster, e.g.
+Circle Paymaster for USDC, where available, else a generic ERC-20 paymaster; A-08) so that every §14 flow is
+executable by an account holding only AKT: 7702-delegated EOAs or 4337 smart accounts submit
+UserOperations; the paymaster charges AKT at oracle rate + published margin. Contracts MUST remain
+plain-EOA compatible (no `msg.sender == tx.origin` assumptions; ERC-2771 trusted forwarders are NOT
+used; AA replaces meta-tx; the only sender abstraction is ERC-4337/7702).
+
+**REQ-EVM-061** Sponsorship parity: today Console sponsors deposits via authz+feegrant. On EVM,
+deposit sponsorship uses §6.4 allowances; **fee** sponsorship uses a sponsoring paymaster policy
+(Console-operated, per-user quotas). Operational ownership: Q-07.
+
+### 13.3 Reorg and finality posture (B1)
+
+The host chain is an Ethereum L2 with the standard confirmation ladder: `unsafe`
+(sequencer-confirmed) → `safe` (batch on L1) → `finalized` (L1 finality, ~13 min typical). Some
+candidates add sub-block preconfirmations below `unsafe` (e.g. Flashblocks on Base, ~200 ms). Reorg
+risk on L2 is sequencer equivocation/restart before batch posting (rare but non-zero); there is no
+PoW/PoS reorg lottery at the L2 tip.
+
+**REQ-EVM-062** Confirmation policy (normative for clients/indexer/daemon;
+[07](./07-offchain-and-clients.md)):
+
+| Tier | Latency | Operations that act on it |
+|---|---|---|
+| Preconfirmation (where the host chain offers it) | sub-second (e.g. Flashblocks on Base, ~200 ms) | UI optimistic display only (bid lists, order status) |
+| L2 unsafe (sequencer block) | one L2 block (sub-second to ~2 s across candidates) | All marketplace actions: provider bid engine reacts to `OrderCreated`; provider starts provisioning on `LeaseCreated` (exposure is bounded by the streaming rate to seconds of compute, mirroring today's instant-at-commit behavior); keeper epochs |
+| L2 safe (batched to L1) | minutes | Indexer marks records `safe`; provider treats lease **close** and large `PaymentWithdrawn` as settled for accounting |
+| L1 finalized | ~13 min | Exchange crediting, treasury operations, `MigrationClaims` root publications ([05](./05-token-migration.md)) |
+
+Where the host chain provides preconfirmations (e.g. Flashblocks on Base), the preconfirmation tier
+MAY be used as shown; on a host chain without them, that tier is unused and its surfaces act on L2
+unsafe inclusion plus a client-configured confirmation depth (default 0).
+The indexer (D-16) MUST track and expose per-record confirmation tier and re-emit corrected
+state on the (rare) unsafe-head reorg; the provider daemon MUST tolerate event replay (idempotent
+handlers).
+
+## 14. Gas and fee analysis (B1)
+
+Assumptions (state them with every re-quote; re-verify against the selected host chain at kickoff per
+A-07): ETH = $1,917; post-Fusaka blob capacity 14/21 keeps host-chain DA amortization < 15% of tx
+cost; representative L2 fee levels (example figures as of 2026-08) of **calm 0.01 gwei**, **typical
+0.05 gwei**, and **elevated 0.5 gwei** effective L2 gas price (all-in, execution + amortized DA).
+Cost = gas × price × $1,917/10⁹. Gas figures are design estimates ±40%, to be replaced by measured
+figures in [09](./09-testing-and-verification.md) M2 benchmarks.
+
+Table 14-1: representative L2 fee levels (example figures as of 2026-08):
+
+| # | Flow (tx) | Est. gas | Calm | Typical | Elevated |
+|---|---|---|---|---|---|
+| 1 | `createDeployment` (1 group: deployment+group+escrow account+order) | ~480k | $0.009 | $0.046 | $0.46 |
+| 2 | `createBid` (matching + collateral account) | ~350k | $0.007 | $0.034 | $0.34 |
+| 3 | `createLease` (payment create + close 5 losing bids; worst 19) | ~700k (worst ~2.1M) | $0.013 (0.040) | $0.067 (0.20) | $0.67 (2.01) |
+| 4 | `withdrawLease` (settle + payout) | ~180k | $0.003 | $0.017 | $0.17 |
+| 5 | `depositDeployment` (ACT top-up) | ~150k | $0.003 | $0.014 | $0.14 |
+| 6 | `closeDeployment` (1 group, active lease: cascade + refunds) | ~450k | $0.009 | $0.043 | $0.43 |
+| none | `requestSwap` (BME) / per-swap epoch execution (keeper-paid) | ~200k / ~120k | $0.004 / $0.002 | $0.019 / $0.012 | $0.19 / $0.12 |
+
+**REQ-EVM-063** Fee acceptance targets: at the *typical* scenario, the six flows above SHALL each cost
+≤ $0.10, and a provider's per-lease weekly operating overhead (1 withdraw + amortized keeper settles)
+SHALL be ≤ $0.05, comfortably inside the fee band the REQ-EVM-071 criteria require of the host chain
+(simple < $0.01, complex $0.01–0.05, verified across the current candidates as of 2026-08). If
+measured costs on the selected host chain exceed 3× these targets at Gate 2, the Q-06 revisit trigger
+for B2 fires. Paymaster-served UserOperations add a bundler+paymaster overhead of ~42k gas +
+margin; include in Console cost modeling.
+
+**REQ-EVM-064** Protocol-side recurring cost (keeper upkeeps: BME epochs ~1,330/day at 65 s cadence
+when active, status refreshes, settlement sweeps) SHALL be modeled and budgeted in
+[11](./11-scope-of-work.md); design ceiling $500/month at typical fees.
+
+## 15. Variant B2: dedicated Arbitrum Orbit chain (specified, non-default)
+
+B2 exists so the program can pivot without a redesign if B1 economics or policy fail (trigger: Q-06).
+Everything in §2–§12 deploys unchanged; this section lists only the deltas.
+
+**Chain shape.** An Arbitrum Orbit chain settling to Arbitrum One (L3). Settling to Ethereum L1
+(L2) is costlier and buys nothing for this workload. Nitro stack, permissioned validator set at
+launch, BoLD when Orbit-supported. Under the Arbitrum Expansion Program (AEP), operating an Orbit
+chain owes **10% of protocol net revenue** (8% Arbitrum DAO / 2% developer guild; as of 2026-08,
+license terms re-verified at kickoff). "Net revenue" under AEP is fee revenue net of settlement/DA
+costs: with AKT as the gas token, the levy is effectively a 10% tax on the chain's AKT fee take,
+payable per AEP terms; model it against B1's zero platform tax, and note the flagship-scale
+precedent (Robinhood Chain, Jul 2026) demonstrates enterprise Orbit operation is viable, not free.
+
+**REQ-EVM-065** B2 SHALL use **AKT as the native gas token** (Orbit supports custom gas tokens;
+FROM-TRAINING, re-verify; OP Stack's equivalent is deprecated, which is why OP Stack is rejected for
+B2, D-02). Consequences: §13.2 gas abstraction becomes unnecessary (delete paymaster dependency);
+`AKT` deploys as the chain's native-token representation rather than a plain ERC-20 (the ERC-20
+contract of §3.1 still exists on the parent chain as the bridged/canonical form); EIP-2612/Votes
+behavior on a native-token wrapper needs an explicit wrapped-AKT (`WAKT`) for Governor voting.
+`[TO-VERIFY: Orbit custom-gas-token support for 6-decimal tokens (decimal-scaling behavior) as of
+kickoff]`.
+
+**REQ-EVM-066** Data availability: launch as **AnyTrust** (DAC, ≥ 7 members incl. Overclock + RaaS +
+2 independent operators) rather than a full rollup; Akash's event volume is modest but settlement
+sweeps are chatty, and AnyTrust cuts DA cost ~10–100×; the trust delta (DAC honesty for data
+withholding) is acceptable for a marketplace whose funds-exit paths are on the same chain. A
+governance-approved migration path AnyTrust → rollup MUST be documented.
+
+**REQ-EVM-067** Operations: B2 SHALL be run through a RaaS operator (Conduit/Caldera-class; both run
+production Orbit/OP chains as of 2026-08) under an SLA covering sequencer uptime ≥ 99.9%, batch
+posting lag ≤ 15 min p95, DAC quorum monitoring, and Nitro upgrade trains. The Vendor MUST still
+staff, and the SOW MUST price, the residual owner-side burden the RaaS cannot absorb: Nitro/BoLD
+upgrade review and sign-off, chain fee-parameter tuning (AKT-denominated gas schedule vs AKT/USD
+volatility, a pricing loop B1 simply doesn't have), canonical-bridge and DAC monitoring, key
+custody for the chain-owner role (behind `AkashTimelock` on the parent chain), and an incident
+runbook incl. sequencer-outage user comms. Order of magnitude: ~0.5–1 FTE + $10–25k/month RaaS+DA.
+This standing burden re-creates the consensus-operations load that migration driver #2 eliminates,
+and is the core reason B2 is not a default path (D-02).
+
+**REQ-EVM-068** Token plumbing: on B2 the canonical `AKT` ERC-20 (§3.1) SHALL be deployed on the
+**parent chain** (Arbitrum One) and registered as the Orbit chain's native gas token; `MigrationClaims`
+executes on the parent chain (claims mint parent-chain AKT; claimants bridge in via the canonical
+bridge, which the claim UI wraps as one flow). On the Orbit chain, native AKT is the gas/value token;
+a canonical `WAKT` wrapper provides the ERC-20 interface required by `EscrowVault`, `BurnMintEscrow`
+(vault balances), and `AkashGovernor` voting. All §3–§12 references to "AKT (ERC-20)" resolve to
+`WAKT` on B2. ACT is unchanged (chain-local restricted ERC-20).
+
+**REQ-EVM-069** Bridging/withdrawal UX (new user-facing surface B1 does not have): deposits
+parent→Orbit are minutes; trustless withdrawals inherit the fraud-proof challenge window
+(~7 days Orbit default) plus Arbitrum One's own exit path when exiting to L1; the Vendor SHALL
+integrate at least one fast-exit liquidity provider for AKT and document the two-hop exit honestly in
+client UX ([07](./07-offchain-and-clients.md)). Exchange integrations MUST be scoped: venues list
+assets on Arbitrum One or L1, so exchange flows remain parent-chain AKT and are unaffected by the
+Orbit chain itself, but Console/wallet flows now include a bridge step.
+
+**What changes vs B1 (summary).**
+
+| Area | B1 (host chain) | B2 (Orbit) |
+|---|---|---|
+| Gas token | ETH (+AKT via paymaster) | AKT native (REQ-EVM-065) |
+| Platform tax | none | AEP 10% of net revenue |
+| Fees | shared-chain market rates (§14) | self-set (near-zero marginal); floor = DA + AEP |
+| Bridging UX | none needed (assets live on the host chain) | canonical bridge appears: AKT/settlement-stablecoin deposit-withdrawal flows in Console/wallets (REQ-EVM-069); exchanges keep listing parent-chain AKT; the settlement stablecoin is bridged unless its issuer supports native issuance on the Orbit chain `[TO-VERIFY: native-issuance support for Orbit chains (e.g. Circle CCTP for USDC)]` |
+| Fee mechanics | ETH gas at market rates; paymaster margin for AKT UX | AKT gas at owner-set schedule; chain owner must actively re-tune the AKT gas schedule against AKT/USD volatility so fees track a stable fiat target, an operational pricing loop with no B1 equivalent |
+| Governance surface | Governor + timelock over contracts only | same, PLUS parent-chain chain-owner role (Nitro upgrades, gas schedule, DAC membership) held by `AkashTimelock` on Arbitrum One |
+| Oracle | Pyth on the host chain | Pyth contract must be deployed/served on the Orbit chain `[TO-VERIFY: Pyth Orbit-chain support]` |
+| Keepers | Chainlink/Gelato registries live | self-run keeper bots at launch (vendor networks arrive later, if ever) |
+| Reorg posture | §13.3 | same tiers; `safe` = batch on Arbitrum One, plus Arbitrum One's own posting to L1 (two-hop finality) |
+| Throughput/isolation | shared blockspace | dedicated blockspace, no noisy neighbors |
+| Ops burden | none (use the chain) | REQ-EVM-067 standing burden |
+
+**Revisit trigger.** Q-06 (owner: Vendor + Overclock, needed by G1) defines the threshold that
+reopens D-02 in favor of B2. Proposed starting definition for that work: (a) measured B1 costs
+exceed 3× the REQ-EVM-063 targets sustained over 30 days, or (b) the host chain introduces app-level
+fee extraction/permissioning affecting the suite, or (c) Akash transaction volume is throttled by
+host-chain sequencer policy. Absent a trigger, B2 artifacts are maintained as deployment scripts + this section
+only; no standing testnet.
+
+## 16. Deltas vs the current chain (intentional, exhaustive)
+
+**REQ-EVM-070** The following are the ONLY intended behavioral differences from the current chain
+(everything else is a parity bug; this is the test oracle for [09](./09-testing-and-verification.md)):
+
+| Δ | Difference | Justification |
+|---|---|---|
+| Δ1 | dseq is a per-tenant counter, not block-height-derived | no block-height identity on EVM; Q-12 confirms no tooling depends on dseq==height |
+| Δ2 | Escrow/bid/lease rates per **second** (WAD), not per block | blocks are not a stable time unit (D-21/D-21.a); conversion ×2/13 (= ÷6.5 exactly) at S1 |
+| Δ3 | Timestamps replace block heights in all state (`createdAt`, `settledAt`, epochs) | same basis change |
+| Δ4 | Escrow emits a full event set (current x/escrow emits none) | events are the indexer's system of record (D-23, REQ-EVM-009) |
+| Δ5 | authz `DepositAuthorization` → vault-native delegated-deposit allowances with restore-on-refund | no authz module on EVM (D-21) |
+| Δ6 | BME epochs time-based, executed by permissionless calls + keeper automation, not EndBlocker | no EndBlocker (D-20) |
+| Δ7 | x/oracle multi-source TWAP/median aggregation → direct Pyth pull (EMA for BME, spot for fallback) with staleness/conf gates | D-13/D-22; current mainnet was single-source anyway |
+| Δ8 | Provider deregistration implemented (no-active-leases + cooldown) where `MsgDeleteProvider` was `NOTIMPLEMENTED`; optional collateral (Q-08) | close a known gap; Sybil resistance post-staking |
+| Δ9 | x/cert x509 registry dropped; JWT signing keys in `ProviderRegistry` | D-10 |
+| Δ10 | Explicit size bounds (groups ≤8, resource units ≤4, attrs ≤24, depositors ≤16, bids ≤20 enforced structurally; A-18/Q-38) | EVM gas-bounded loops need hard caps; Cosmos bounded implicitly by gas |
+| Δ11 | Settlement stablecoin as first-class escrow denom with governed `stable_act_parity_bps` par drain rule (default 10000) | D-14/D-14.a; par-rule ratification Q-22 |
+| Δ12 | Single-key storage with state field (no state-in-key 3-probe lookups) | EVM mappings; behavior-neutral |
+| Δ13 | BME executed/canceled ledger and oracle price history not stored on-chain (events only) | D-23 working-state-only |
+| Δ14 | ACT bank `SendEnabled=false` → transfer-restricted ERC-20 with protocol allowlist | D-19 |
+| Δ15 | Unordered txs → EVM nonces (2D via ERC-4337) | platform constraint (§13.1) |
+| Δ16 | Discovery service → on-chain client-version registry in `AkashConfig` | REQ-EVM-051 |
+| Δ17 | Cosmos gov (deposit/quorum-of-bonded) → OZ Governor over ERC20Votes with timelock; quorum basis changes to fraction-of-supply | D-11/D-11.a; calibration Q-23 |
+| Δ18 | Known current-chain defects NOT ported: crisis invariants unwired, `ContractDebugMode=true`, min-gas-price disagreement, ACT `Display: uact` metadata, gov-hook nil-deref ordering hazard | defects, not features (research pack §9) |
+
+## Cross-references
+
+- [01. Current architecture](./01-current-architecture.md): source semantics for every mirror cited here.
+- [02. Target selection](./02-target-selection.md): D-01/D-02 rationale and Gate 0.
+- [03. Solana architecture](./03-solana-architecture.md): sibling design; shared decisions D-19..D-24.
+- [05. Token migration](./05-token-migration.md): `MigrationClaims` normative spec, S1/S2, Wind-down Reserve, BME vault seed.
+- [06. State & data migration](./06-state-and-data-migration.md): rate conversion (Δ2) and export tooling.
+- [07. Off-chain & clients](./07-offchain-and-clients.md): indexer, JWT verification, paymaster/client guidance (REQ-EVM-044/059/060/062).
+- [08. Security & audits](./08-security-and-audits.md): timelock/Safe key management, upgrade-to-immutability path.
+- [09. Testing](./09-testing-and-verification.md): parity suite driven by §16 and per-contract invariants.
+- [13. Open questions](./13-open-questions-and-assumptions.md): Q-06/Q-07/Q-08/Q-12/Q-16/Q-42 + new Q-22/Q-23.
+- [14. Protocol mapping](./14-appendix-protocol-mapping.md): exhaustive Msg/query/event/param → function/contract tables; matching truth tables.
+
+## Feeds into
+
+- [05](./05-token-migration.md)/[06](./06-state-and-data-migration.md): mint gating, vault seed, S1 conversion constants.
+- [07](./07-offchain-and-clients.md): ABIs, events, confirmation tiers, client registry.
+- [08](./08-security-and-audits.md): roles, upgrade authority, pause surface defined here.
+- [09](./09-testing-and-verification.md): REQ-EVM-* and invariants I-* are its acceptance basis.
+- [11](./11-scope-of-work.md): workstream decomposition of §3–§12; keeper/paymaster ops budgets.
+- [14](./14-appendix-protocol-mapping.md): EVM column source of truth.
+
+
+
+
+
+

--- a/spec/aep-79/doc/05-token-migration.md
+++ b/spec/aep-79/doc/05-token-migration.md
@@ -1,0 +1,651 @@
+# 05. Token Migration: AKT/ACT Supply Accounting, Claims, Exchanges, Emissions
+
+| | |
+|---|---|
+| **Document** | 05. Token migration |
+| **Doc ID** | AKASH-MIG-05 |
+| **Version** | 0.9 (draft for review) |
+| **Date** | 2026-08-10 |
+| **Owner** | Overclock Labs |
+| **Audience** | Vendor engineering; exchange/custodian integration teams; community reviewers |
+| **Status** | Normative where marked (MUST/SHALL); informative otherwise |
+
+## Purpose
+
+- Specify, to execution depth, how every micro-unit of AKT (`uakt`) and ACT (`uact`) on the Cosmos
+  chain (`akashnet-2`) is accounted for, snapshotted, and represented on the target chain under the
+  dual-snapshot mechanism (D-05).
+- Define the claims system (Merkle distribution, Cosmos-key verification, vesting re-creation,
+  multisig support) the Vendor MUST build for either target path (D-01).
+- Define the Wind-down Reserve, weekly residual distributions (C→H), S2 final distribution, exchange
+  coordination, emissions replacement mechanism (D-12), and unclaimed-funds policy.
+
+## In scope
+
+- Supply enumeration at S1: every value category on the old chain, its export source, and its
+  target-chain disposition; the conservation invariant and the reconciliation artifact.
+- ACT-specific handling: non-transferable representation, BME vault seeding, in-flight swap-queue
+  cancellation.
+- Claims design: tree format, sign-doc, on-chain verification (Solana and EVM), wallets, multisig,
+  edge cases; vesting re-creation (D-06); IBC-out AKT (D-07); exchange playbook; emissions
+  replacement mechanism; treasury migration; unclaimed policy.
+
+## Out of scope
+
+- Non-token state (marketplace records, provider registry, archives): [06](./06-state-and-data-migration.md).
+- Target-chain protocol design (escrow, BME engine runtime behavior): [03](./03-solana-architecture.md),
+  [04](./04-ethereum-architecture.md).
+- Cutover scheduling and governance proposals: [10](./10-rollout-and-cutover.md); the program calendar and
+  communications plan are maintained client-side, outside this technical set.
+- The numeric emissions curve: modeled under WS-1 in [11](./11-scope-of-work.md) (Q-01).
+
+---
+
+## 1. Migration model and conservation invariant
+
+Terminology (fixed in [13](./13-open-questions-and-assumptions.md), D-05): **C** = cutover, the
+governance-scheduled height at which the sunset upgrade activates on `akashnet-2`. **S1** = the supply
+snapshot taken from the state export at height C. **H** = C+90d, the final halt height. **S2** = the
+residual snapshot taken from the final export at H. **Wind-down Reserve** = the target-chain pool,
+held by the claims program/contract (`akash-claims` / `MigrationClaims`), that backs all value held by
+module accounts at S1 and pays it out as the old chain resolves it.
+
+A *module account* is a Cosmos address owned by chain code rather than a keypair (escrow pool, BME
+vault, community pool; see [01](./01-current-architecture.md)). Module-held funds cannot be
+attributed to one end user at S1; they are attributed as the old chain resolves them (weekly residual
+distributions C→H) or at S2 from the final state.
+
+```mermaid
+flowchart LR
+    L["akashnet-2 @ S1: liquid balances<br/>uakt + uact + staking + rewards + vesting"] -->|"S1 root"| CT["Target: S1 Merkle claims<br/>(mint at claim)"]
+    M["akashnet-2 @ S1: module-held funds<br/>escrow, BME vault, community pool,<br/>gov deposits, IBC escrows, fee collector"] -->|"reserved 1:1"| WR["Target: Wind-down Reserve<br/>(program/contract-held)"]
+    WR -->|"weekly residual roots (C→H)"| CT
+    WR -->|"S2 final distribution"| CT
+    WR -->|"S2: community pool, surplus, unredeemed"| T["DAO treasury"]
+```
+
+**REQ-TOK-001** The S1 snapshot SHALL be derived from a full deterministic state export of
+`akashnet-2` at exactly height C, produced by the tooling specified in
+[06](./06-state-and-data-migration.md), and independently reproducible byte-for-byte by any party
+running the exporter against an archive node.
+
+**REQ-TOK-002** Every micro-unit of `uakt` and of `uact` in the S1 export's bank supply MUST be
+classified into exactly one row of the supply accounting table (§2). The classification MUST be
+exhaustive and disjoint: `Σ(row totals per denom) == bank TotalSupply(denom) @ S1`, with zero
+unexplained remainder.
+
+**REQ-TOK-003 (conservation, AKT)** Cumulative migration-minted AKT on the target chain MUST equal
+`TotalSupply(uakt) @ S1`, decomposed as `liquid@S1 + reserved@S1 == total`, where `liquid@S1` is the
+sum of all S1 Merkle-claimable entitlements and `reserved@S1` is the Wind-down Reserve. The Reserve
+MUST be fully allocated (to residual claims, the S2 distribution, or the treasury) by S2 + the
+publication of the S2 root. Old-chain inflation minted after C is NOT part of the conservation base
+and MUST NOT be honored on the target chain.
+
+**REQ-TOK-004 (conservation, ACT)** Cumulative migration-minted ACT MUST equal
+`TotalSupply(uact) @ S1` (measured after the pre-export BME queue cancellation, §3.3), decomposed the
+same way. ACT minted post-launch by the target BME engine (D-20) and AKT minted by the emissions
+program (D-12) are outside these budgets and governed by their own caps (§9).
+
+**REQ-TOK-005** The claims program/contract MUST enforce the migration mint budgets on-chain: a
+per-denom counter of migration-minted supply that can never exceed the S1 totals baked in at
+deployment. Emissions minting MUST use a separate authority and separate cap; no code path may mint
+migration AKT against the emissions budget or vice versa.
+
+**REQ-TOK-006 (reconciliation artifact)** The Vendor SHALL publish, alongside the S1 root, a
+machine-verifiable reconciliation artifact: (a) the raw export hash and height; (b) per-category
+totals per §2; (c) the full leaf dataset (address, amounts, vesting tuple); (d) the Merkle root and
+tree parameters; (e) an open-source generator that reproduces (b)–(d) from (a) deterministically.
+Acceptance (see [09](./09-testing-and-verification.md)) requires two independent regenerations, one by
+a non-Vendor party, matching bit-for-bit.
+
+---
+
+## 2. Supply accounting at S1: the disposition table
+
+S1 treatments: **Claim-S1** = in the S1 Merkle tree, individually claimable; **Reserve** = minted into
+the Wind-down Reserve, paid via residual roots or S2; **Vesting** = re-created vesting (§5);
+**Refund-pre-export** = unwound by the sunset upgrade before the export is taken; **Out-of-scope** =
+not AKT/ACT supply (handled separately).
+
+| # | Category | Export source (akashnet-2 state) | S1 treatment | Target representation |
+|---|---|---|---|---|
+| 1 | Liquid `uakt`, externally-owned accounts | `bank.balances[].coins["uakt"]` minus module/contract addresses | Claim-S1 | AKT minted to claimant at claim |
+| 2 | Liquid `uact`, externally-owned accounts (bank-send disabled but holdable: `SendEnabled[uact]=false`, `cmd/akash/cmd/genesis.go:121-130`) | `bank.balances[].coins["uact"]` minus module/contract addresses | Claim-S1 | ACT (non-transferable per D-19) minted to claimant at claim |
+| 3 | Bonded stake (delegations; physically in `bonded_tokens_pool`) | `staking.delegations[]` shares × validator `tokens/shares` from `staking.validators[]` | Claim-S1 (liquid, per D-06) | AKT, folded into claimant leaf |
+| 4 | Unbonding entries (in `not_bonded_tokens_pool`) | `staking.unbonding_delegations[].entries[].balance` | Claim-S1 (liquid, per D-06; residual unbonding periods NOT honored) | AKT, folded into claimant leaf |
+| 5 | Redelegations | `staking.redelegations[]` | No value row: funds remain bonded, counted in row 3 | none |
+| 6 | Unwithdrawn delegator rewards accrued ≤ C | `distribution` state; exporter runs the withdraw-all computation virtually per delegator at C | Claim-S1 (per D-06) | AKT, folded into claimant leaf |
+| 7 | Unwithdrawn validator commission ≤ C | `distribution.validator_accumulated_commissions` | Claim-S1 (to operator account) | AKT, folded into operator leaf |
+| 8 | Community pool | `distribution.fee_pool.community_pool` | Reserve | S2: DAO treasury (§10), minus validator wind-down budget (§6.5) and any pre-authorized DEX-liquidity carve-out (§8.4) |
+| 9 | Gov deposits on proposals active at C | `gov.deposits[]` | Reserve | Refunds honored via residual roots; deposits burned on-chain (veto) → treasury at S2 |
+| 10 | Vesting accounts: locked portion at S1 (Base/Delayed/Continuous, stock `x/auth/vesting`) | `auth.accounts[]` typed `*VestingAccount`: `original_vesting`, `start_time`, `end_time`, `delegated_vesting`, `delegated_free` | Vesting (§5); vested-but-unspent portion → Claim-S1 | Re-created vesting schedule holding AKT (and ACT if held) |
+| 11 | Escrow: deployment accounts, `uact` funds | `escrow.accounts[]` (`Scope=deployment`) `State.Funds["uact"]`, `Deposits[]` | Reserve | Refunds/settlements honored as ACT via residual roots / S2 |
+| 12 | Escrow: deployment accounts, `uakt` funds (top-ups via `MsgAccountDeposit`) | same, `State.Funds["uakt"]` | Reserve | Honored as AKT |
+| 13 | Escrow: bid accounts (provider collateral) | `escrow.accounts[]` (`Scope=bid`), both denoms | Reserve | Refunded to provider at bid close; honored via residual roots / S2 |
+| 14 | Escrow: payment accrued balances (settled-but-unwithdrawn + virtual accrual to C per REQ-TOK-008) | `escrow.payments[].State.Balance` (+ computed `Rate × (C − SettledAt)`) | Reserve | Provider earnings honored via residual roots / S2, in denom of payment |
+| 15 | Escrow module surplus: module bank balance − Σ(account funds + payment balances); includes the 427,414,453 uakt moved distribution→escrow by the v2.1.0 upgrade (`upgrades/software/v2.1.0/upgrade.go:88-108`) and accumulated decimal-truncation dust | `bank.balances[escrow module addr]` minus escrow ledger totals | Reserve | S2: DAO treasury. See REQ-TOK-009 |
+| 16 | BME vault collateral (`uakt` in `bme` module account backing ACT) | `bank.balances[bme module addr]["uakt"]` after queue cancellation (§3.3) | Reserve (earmarked) | Seeds the target BME vault (§3.2) |
+| 17 | BME in-flight swap queue (`ledgerPendingBalances`, both directions, escrowed in module account) | `bme.ledger.pending_records[]` | Refund-pre-export (§3.3); collapses into rows 1–2 | none |
+| 18 | IBC transfer escrow, per channel (`uakt` backing vouchers on counterparty chains) | bank balance of each ICS-20 escrow address (derived per port/channel from `ibc.transfer` state); cross-check `transfer.total_escrowed` `[TO-VERIFY: live channel list and per-channel balances]` | Reserve (earmarked per channel) | Foundation redemption process for voucher holders (§7); unredeemed → treasury |
+| 19 | Fee collector | `bank.balances[fee_collector]` | Reserve | S2: folded into validator wind-down budget (§6.5, Q-13) |
+| 20 | Mint module account (transient minting buffer) | `bank.balances[mint module addr]` (≈0) | Reserve | S2: treasury (dust) |
+| 21 | CosmWasm contract accounts (pyth/pyth_pro/pyth_vaa/wormhole oracle-fee balances; the only contracts on chain, locked down per D-22) | `bank.balances[contract addrs]` from `wasm` export | Reserve | S2: treasury |
+| 22 | Any other module/orphan balance not enumerated above | catch-all diff | Reserve | S2: treasury; MUST be itemized in the reconciliation artifact, target zero |
+| 23 | Non-native denoms held on Akash (IBC vouchers, e.g. IBC USDC) | `bank.balances[].coins[ibc/*]` | Out-of-scope for AKT/ACT accounting | Cannot be minted on target. Policy: §7.4 |
+
+**REQ-TOK-007** Rows 1–2 SHALL exclude every module account (`app/mac.go:15-27`), every ICS-20 escrow
+address, and every CosmWasm contract address. The exclusion list MUST be emitted as part of the
+reconciliation artifact.
+
+**REQ-TOK-008 (virtual settlement)** The exporter SHALL NOT require an on-chain settle-all at C.
+Instead it MUST compute, per escrow payment, the virtual accrual `Rate × (C − SettledAt)` (clamped to
+available account funds, replicating `x/escrow/keeper/keeper.go` `accountSettle`/FIFO semantics
+exactly) so that row 14 reflects earned-but-unsettled value at C. Divergence between this off-chain
+computation and subsequent on-chain settlements during C→H MUST be zero by construction (same
+deterministic formula); [09](./09-testing-and-verification.md) requires a replay test proving it.
+
+**REQ-TOK-009 (module surplus precedent)** Row 15 exists because module bank balances and module
+ledger state can legitimately diverge: the v2.1.0 upgrade moved 427,414,453 uakt from the
+`distribution` module account to the `escrow` module account imperatively, without creating escrow
+ledger entries (community-pool spend precedent). The reconciliation MUST compute surplus = bank
+balance − ledger total per module account, allocate surpluses to the treasury at S2, and treat any
+negative surplus (ledger > bank) as a blocking defect that halts cutover (gate criterion in
+[10](./10-rollout-and-cutover.md)).
+
+**REQ-TOK-010** Post-C behavior of already-snapshotted liquid balances: coins in rows 1–2 remain
+spendable on the old chain for wind-down utility only (gas, escrow top-ups, BME burns per D-08/D-18)
+and carry **no further target-chain value**. The claim portal, wallet comms, and exchange notices
+MUST state this prominently: *value moves at S1; the old chain's liquid coins are already represented
+by your claim*.
+
+---
+
+## 3. ACT handling
+
+### 3.1 User-held ACT
+
+**REQ-TOK-011** User `uact` balances at S1 (row 2) SHALL be represented as ACT credits in the same
+S1 Merkle leaf as the address's AKT entitlement, minted at claim into the target's non-transferable
+ACT form (D-19: Token-2022 NonTransferable on Solana; transfer-restricted ERC-20 on EVM). A leaf MAY
+have `uakt == 0, uact > 0`; ACT-only claims MUST work (e.g. providers that only ever earned ACT).
+
+### 3.2 BME vault seeding and the collateral-ratio check
+
+The current BME engine (`x/bme`, [01](./01-current-architecture.md)) backs ACT with vault AKT at a
+collateral ratio `CR = (vault_uakt − pending_uakt) × (P_AKT/P_ACT) / TotalSupply(uact)` with
+warn/halt thresholds 9500/9000 bps (D-20).
+
+**REQ-TOK-012** The Wind-down Reserve slice from row 16 SHALL seed the target BME vault. Because
+`pending_uakt == 0` after queue cancellation (§3.3) and the ACT migration budget equals
+`TotalSupply(uact)@S1` (REQ-TOK-004), seeding the vault with exactly `vault_uakt@S1` yields, at
+unchanged oracle prices, a fully-diluted post-migration CR identical to the pre-migration CR.
+**Acceptance check (MUST, automated):** at S1 execution, assert
+`vault_seed × P_AKT / P_ACT / ACT_migration_budget ≥ CR_old@S1` using the same oracle price pair for
+both sides; abort cutover on failure. ACT that is never claimed only raises the effective CR, so the
+check is conservative.
+
+**REQ-TOK-013** The vault seed SHALL transfer from the Reserve to the BME program/contract vault
+account at S1 as an earmarked allocation, recorded in the reconciliation artifact. Old-chain BME
+burns during C→H pay out old-chain vault AKT (dead coins, not honored; see §6.3) and MUST NOT reduce
+the target vault seed.
+
+### 3.3 In-flight BME queue cancellation
+
+The BME module account escrows coins for queued swap requests at any moment (`ledgerPendingBalances`,
+`ledgerPending` records; `x/bme/keeper/key.go:12-26`).
+
+**REQ-TOK-014** The sunset upgrade handler at C SHALL, before any state relevant to the export is
+read: (a) iterate all `ledgerPending` records in both directions (uakt→uact and uact→uakt); (b)
+refund each record's `CoinsToBurn` from the module account to `Owner`; (c) write a
+`LedgerCanceledRecord` with a new cancellation reason (`BMCancelReasonMigration`) and emit
+`EventLedgerRecordCanceled`; (d) zero `ledgerPendingBalances`. The module account balance then equals
+vault collateral only. This mirrors the existing `cancelBurnMint` path (`x/bme/keeper/abci.go`) and
+MUST be exercised in the migration dry-runs ([09](./09-testing-and-verification.md)).
+
+**REQ-TOK-015** BME cumulative counters (`totalBurned`, `totalMinted`, `remintCredits`) SHALL be
+carried into the target BME engine's genesis state per [06](./06-state-and-data-migration.md) and
+[14](./14-appendix-protocol-mapping.md); they are bookkeeping, not coins, and do not appear in §2.
+
+---
+
+## 4. Claims design
+
+### 4.1 Merkle tree format
+
+**REQ-TOK-016** The S1 distribution SHALL be a binary Merkle tree with: leaf hash
+`H(0x00 ‖ leaf_bytes)`, internal node `H(0x01 ‖ sorted(L, R))` (sorted-pair, OpenZeppelin-compatible),
+`H = SHA-256` (native syscall on Solana; precompile 0x02 on EVM). Domain-separation bytes are
+mandatory (second-preimage hardening). Residual roots (§6) use the same format with a distinct leaf
+domain tag per root.
+
+**REQ-TOK-017** Leaf serialization (fixed-width, big-endian concatenation; no varints):
+
+```
+leaf_bytes = tag(1) ‖ addr(20) ‖ uakt(8) ‖ uact(8) ‖ vest_locked_uakt(8) ‖ vest_locked_uact(8)
+             ‖ vest_start(8) ‖ vest_end(8) ‖ vest_type(1)
+```
+
+where `tag` = 0x01 for S1 leaves; `addr` = the 20-byte bech32 payload of the `akash1` address;
+amounts are micro-units; `vest_type` ∈ {0 = none, 1 = continuous, 2 = delayed, 3 = base}; vesting
+fields zero when `vest_type = 0`. One leaf per address covers AKT, ACT, and vesting: exactly one
+claim transaction per address.
+
+**REQ-TOK-018** Per-address S1 entitlement composition: `uakt = rows 1+3+4+6(+7 for operators)` of
+§2; `uact = row 2`; the vesting tuple encodes the locked-at-S1 portion (§5), which is a *subset* of
+the leaf totals, not an addition.
+
+### 4.2 Claim flow: Cosmos key names a target address
+
+The claimant proves control of the `akash1` address by signing an offline sign-doc naming the
+destination target-chain address. No Cosmos transaction is broadcast; the old chain plays no part
+in claiming.
+
+**REQ-TOK-019** The sign-doc SHALL be an ADR-036 amino `StdSignDoc`
+(`account_number "0"`, `chain_id ""`, zero fee, empty memo, single `sign/MsgSignData` msg) whose
+`data` field is the base64 of the canonical claim payload:
+
+```json
+{"schema":"akash-mig-claim-v1","root":"<hex S1 or residual root>",
+ "target_chain":"solana|evm","target_chain_id":"<genesis-hash or EIP-155 id>",
+ "claims_address":"<claims program id | MigrationClaims address>",
+ "recipient":"<base58 pubkey | 0x address>"}
+```
+
+ADR-036 is the only arbitrary-signing format supported across Keplr, Leap, Cosmostation, and the
+Ledger Cosmos app; its fixed StdSignDoc envelope makes on-chain reconstruction constant-template
+string concatenation (constant segments + signer + data), never general JSON serialization.
+
+**REQ-TOK-020** On-chain verification MUST establish the full chain of custody: (1) reconstruct the
+exact sign-doc bytes from the claim arguments (constant template + supplied recipient);
+(2) `digest = SHA-256(sign_doc_bytes)`; (3) recover/verify the secp256k1 signature (64-byte `r‖s`,
+low-S enforced) against the digest; (4) derive `addr = RIPEMD-160(SHA-256(compressed_pubkey))`;
+(5) require `addr == leaf.addr` and a valid Merkle proof against the active root; (6) mint/credit
+strictly to the `recipient` named *inside the signed payload*, never to the transaction sender,
+so a stolen claim transaction cannot redirect funds.
+
+**REQ-TOK-021** Replay/domain separation: the signed payload binds root, target chain id, and claims
+address, so a signature for a testnet deployment, the non-selected target path, or a residual root MUST
+NOT verify against any other deployment or root. Each leaf is claimable exactly once per root
+(claim-bitmap or per-leaf receipt account); partial claims are NOT supported.
+
+### Solana specifics
+
+**REQ-TOK-022** Verification SHALL use the `secp256k1_recover` syscall on the SHA-256 digest, with a
+client-supplied recovery id (both values MAY be attempted). The Solana *secp256k1 native program* is
+unsuitable unmodified (it assumes keccak digests of eth-formatted messages), hence the syscall
+path. RIPEMD-160 has no syscall and SHALL be implemented in-program (pure Rust, one 20-byte digest
+per claim; budget ≤ 30k CU, benchmarked per [09](./09-testing-and-verification.md)). Claim receipts:
+per-leaf PDA (rent refunded at close after §11 sweep) or claim bitmap; Vendor selects on a measured
+rent/CU trade-off at design review.
+
+### Ethereum specifics
+
+**REQ-TOK-023** Verification SHALL use precompiles: SHA-256 (0x02) for the digest, `ecrecover` (0x01)
+for signature recovery, RIPEMD-160 (0x03) for address derivation. Cosmos signatures are 64-byte
+`r‖s` over SHA-256 (not keccak, and with no recovery id), so the contract MUST accept a claimant-
+supplied `v` and fall back to trying both `{27, 28}` ("recovery-id search"). Because `ecrecover`
+returns a keccak-derived Ethereum address rather than the public key, the claimant MUST supply the
+uncompressed 64-byte pubkey; the contract verifies (a)
+`ecrecover(digest, v, r, s) == address(uint160(uint256(keccak256(pubkey_uncompressed))))`, and (b)
+`ripemd160(sha256(compress(pubkey))) == leaf.addr`, compressing in-contract from the y-parity.
+
+### 4.3 Wallet and signer support
+
+**REQ-TOK-024** The claim portal (web) MUST support Keplr, Leap, and Cosmostation via
+`signArbitrary` (ADR-036), including their Ledger paths (the Ledger Cosmos app signs amino
+StdSignDocs; verify on hardware at kickoff, Ledger app version matrix in
+[07](./07-offchain-and-clients.md)). A CLI claimer MUST support air-gapped flows: emit sign-doc →
+sign offline (keyring or Ledger) → submit signature from a connected machine. The portal MUST render
+the recipient address exactly as signed and warn on clipboard mismatch (top phishing vector; see
+[12. Risk register](./12-risk-register.md) and [08](./08-security-and-audits.md)).
+
+### 4.4 Cosmos multisig accounts
+
+Cosmos multisigs are `LegacyAminoPubKey` threshold keys (k-of-n secp256k1 members); the address is
+derived from the amino-encoded composite pubkey (first 20 bytes of its SHA-256 `[TO-VERIFY: exact
+legacy-amino encoding bytes; produce test vectors from live akashnet-2 multisigs]`), so member keys
+are not recoverable from the address alone.
+
+**REQ-TOK-025** The claims program/contract SHALL support threshold claims: the claimant supplies
+`{threshold k, ordered member pubkey list}` plus ≥ k member signatures over the *identical* sign-doc
+(collected off-chain, e.g. via the portal's coordination page or file exchange). On-chain: (a)
+re-derive the multisig address from the supplied composite key and match `leaf.addr`; (b) verify each
+signature per §4.2 against its member key; (c) require ≥ k valid signatures from distinct members.
+The portal MUST provide a multisig coordination flow (export/import partial signatures) and the CLI
+MUST support it headlessly.
+
+### 4.5 Edge cases
+
+| Case | Handling |
+|---|---|
+| Module-owned addresses | Excluded from the tree (REQ-TOK-007); value flows via Reserve |
+| CosmWasm contract addresses | Excluded; balances → Reserve → treasury (row 21). The only contracts are the locked-down oracle set; no user-fund contracts exist (D-22) |
+| Addresses with only `uact` | Valid leaves; ACT-only claim (REQ-TOK-011) |
+| Accounts with no known pubkey that never signed (incl. any relics of the ICA feature added v0.18.0 / removed v0.20.0) | Leaves exist; claimable only if the owner can produce the key. Counted in unclaimed policy (§11). `[TO-VERIFY: count of balance-holding accounts with no on-chain pubkey]` |
+| Dust | Excluded below `DUST_MIN` per REQ-TOK-026 below |
+| Exchange omnibus/deposit addresses | Ordinary leaves; handled via the exchange playbook (§8), claimed programmatically by the venue |
+| Vesting accounts | §5; single leaf carries the tuple |
+| Same address claiming twice | Rejected (REQ-TOK-021) |
+
+**REQ-TOK-026** Leaves with `uakt + uact < DUST_MIN` (default 10,000 micro-units combined, i.e. 0.01
+tokens; value ratified with the S1 governance proposal) and no vesting tuple SHALL be excluded from
+the tree; their aggregate MUST be reported in the reconciliation artifact and allocated to the
+treasury at S2 (legal posture: Q-02).
+
+**REQ-TOK-027** The Vendor SHALL operate a public claims telemetry dashboard: % of S1 supply claimed,
+per-category residual balances, Reserve balance vs allocation, updated at least daily, the input to
+assumption A-04 monitoring and the unclaimed sweep (§11).
+
+---
+
+## 5. Vesting re-creation (D-06)
+
+Only stock `x/auth/vesting` types exist on akashnet-2 (created via `akash genesis add-account`,
+`cmd/akash/cmd/genaccounts.go:24-110`); the live inventory MUST be read from the export (Q-19).
+
+**REQ-TOK-028** For each vesting account, the exporter SHALL compute `locked@S1` per the SDK's own
+vesting math and split the leaf: `locked@S1` → re-created vesting; the remainder → liquid.
+Bonded/unbonding/reward amounts (rows 3/4/6) folded into the leaf get the same split:
+`delegated_vesting`/`delegated_free` from the export drive the attribution, so locked stake cannot
+escape the schedule by having been delegated at S1.
+
+**REQ-TOK-029** Re-created schedules MUST preserve the *remaining* schedule exactly (same end time,
+same release slope) per this normative mapping:
+
+| Cosmos type | Old semantics | `locked@S1` | Target schedule |
+|---|---|---|---|
+| ContinuousVestingAccount | Linear release `start_time → end_time` over `original_vesting` | `OV × (end − max(S1,start)) / (end − start)`, = `OV` if `S1 < start` | Linear release of `locked@S1` from `max(S1, start)` to `end`: identical slope `OV/(end−start)` by construction; a future `start_time` acts as a cliff, preserved |
+| DelayedVestingAccount | Everything locked until `end_time` | `OV` if `S1 < end`, else 0 | Cliff: 100% releasable at `end_time` |
+| BaseVestingAccount (bare) | As delayed: locked until `end_time` | same as delayed | Cliff at `end_time` |
+
+Accounts whose `end_time ≤ S1` have no tuple (fully vested → liquid). PeriodicVesting and
+PermanentLocked types do not exist on akashnet-2; if the export reveals any, cutover blocks until
+this table is extended by change control.
+
+### Solana specifics
+
+**REQ-TOK-030** The `akash-claims` program SHALL vest in place: the claim instruction mints the full
+entitlement, transfers `locked@S1` into a per-claimant vesting sub-account (PDA-owned token account
+carrying the schedule) and the remainder to the recipient. A permissionless `release` instruction
+transfers the vested tranche per on-chain Clock; the PDA closes (rent refunded to the claimant) when
+drained. Claimant pays rent (~one token account + schedule account); refundable at close.
+
+### Ethereum specifics
+
+**REQ-TOK-031** `MigrationClaims` SHALL deploy one EIP-1167 minimal-proxy clone per vesting claimant
+of an audited `VestingWallet`-derived implementation (OpenZeppelin), parameterized
+`start = max(S1, start_time)`, `duration = end_time − start` (delayed/base: `start = end_time`,
+`duration = 0`), beneficiary = recipient. Claimant pays claim gas including clone deployment
+(~50–80k gas marginal; cents on candidate host chains, e.g. Base, as of 2026-08); the protocol MAY sponsor via the paymaster
+service in [07](./07-offchain-and-clients.md) (Q-07). ACT vesting positions use the same clone with
+the restricted-token release path.
+
+---
+
+## 6. Wind-down Reserve and residual distributions
+
+### 6.1 Reserve instantiation
+
+**REQ-TOK-032** At S1 the claims program/contract SHALL mint the Reserve in full:
+`reserved@S1 = Σ(rows 8, 9, 11–16, 18–22)` in AKT, plus the ACT-denominated reserve
+(`Σ uact in rows 11, 13, 14`) as a mint *budget* (ACT mints lazily at payout, like claims). Earmarks
+(vault seed, per-channel IBC slices, community pool) are recorded on-chain as labeled sub-balances,
+so the telemetry dashboard (REQ-TOK-027) proves earmark discipline.
+
+### 6.2 Honored flows: the definition
+
+During C→H the old chain runs under the sunset message allow-list (D-18, Q-17). The Reserve honors
+**only flows out of module accounts to user accounts that are attributable to value locked before C**:
+
+1. Escrow payment withdrawals (provider earnings), in the denom received (`uact`, or `uakt` via the AKT-fallback path when BME is halted; D-21).
+2. Escrow account refunds to depositors at account/bid close, per FIFO depositor order.
+3. Gov deposit refunds for proposals that were active at C.
+
+**REQ-TOK-033 (FIFO attribution)** Escrow deposits are consumed FIFO and each `Depositor` record
+carries its deposit `Height` (`x/escrow` state). Honored amounts per account are capped at the
+principal of deposits with `Height < C`. Flows funded by post-C top-ups are old-chain-local and MUST
+NOT be honored; otherwise an address could re-spend its already-claimed S1 balance into escrow and
+mint duplicate target AKT via a self-lease (unbounded issuance attack). This cap is what makes
+REQ-TOK-003 an equality rather than an aspiration.
+
+**REQ-TOK-034 (not honored)** The following post-C flows MUST NOT create target-chain credits: BME
+burn payouts (§3.3 note: burners keep their S1 ACT claim, so nothing is forfeited); staking-reward
+withdrawals (rewards ≤ C are already in S1 leaves; post-C rewards are post-C inflation, excluded per
+REQ-TOK-003); any flow funded by post-C deposits (REQ-TOK-033). Provider tooling and Console MUST
+surface, per lease, the remaining reserve-backed escrow balance so providers can close leases
+(D-24 reclamation or ordinary close) before serving unpaid compute
+([07](./07-offchain-and-clients.md)).
+
+### 6.3 Weekly residual roots
+
+**REQ-TOK-035** Weekly (cadence and threshold parameters: Q-18), the Vendor's residual pipeline SHALL:
+(a) take the archive export at week-k height (tooling per [06](./06-state-and-data-migration.md));
+(b) deterministically diff escrow accounts/payments and gov deposits against the C export, replaying
+settlement math (REQ-TOK-008) and FIFO attribution (REQ-TOK-033); (c) emit per-address cumulative
+honored credits `{AKT, ACT}` from C to week k; (d) subtract amounts already covered by activated
+prior roots; (e) build residual root k (leaf tag distinct per REQ-TOK-016).
+
+**REQ-TOK-036** The pipeline MUST be deterministic and open-source: identical inputs (C export,
+week-k export) reproduce root k bit-for-bit. Each root ships with its full ledger and a recompute
+script, the same reproducibility bar as REQ-TOK-006.
+
+**REQ-TOK-037 (publication + dispute window)** Each residual root SHALL be published (ledger +
+script + root) at least **48 hours** before on-chain activation by the Migration Operator (the
+multisig defined in [08](./08-security-and-audits.md)). Any party reproducing a different root files
+a dispute; the operator MUST NOT activate a disputed root until resolved, and a corrected root
+supersedes (never mutates) a published one. Claims against residual roots use the identical §4 flow.
+
+**REQ-TOK-038 (minimum payout)** Addresses whose new credits in week k are below `MIN_PAYOUT`
+(default 1,000,000 micro-units = 1 token-equivalent; parameter, Q-18) SHALL be carried into
+subsequent roots rather than dropped; the S2 final root includes all carried remainders with no
+threshold. Nothing is ever forfeited by the threshold.
+
+### 6.4 S2 final distribution
+
+**REQ-TOK-039** At H, from the final export, the S2 root SHALL allocate everything remaining in the
+Reserve: (a) residual escrow balances attributed per the same refund/settlement logic (depositors
+and providers per final state; the halt supersedes on-chain force-closure); (b) unresolved gov
+deposits refunded (burned deposits → treasury); (c) community pool → DAO treasury (§10) minus (d);
+(d) the validator wind-down incentive budget (§6.5); (e) fee collector, mint dust, contract
+balances, module surpluses, dust aggregate (REQ-TOK-026) → treasury; (f) IBC redemption slices stay
+earmarked until the redemption window closes (§7.3), then sweep to treasury.
+
+**REQ-TOK-040** After S2 root activation and IBC-window close, the Reserve's unallocated balance MUST
+be exactly zero; the final reconciliation artifact proves `liquid@S1 + Σ(residual roots) + S2 root +
+treasury allocations == TotalSupply@S1` per denom. Publication of this artifact is a payment-gate
+deliverable ([11](./11-scope-of-work.md)).
+
+### 6.5 Validator wind-down incentive budget
+
+**REQ-TOK-041** The S2 distribution SHALL include a validator wind-down incentive line, funded from
+the community-pool slice of the Reserve (size and formula: Q-13, needed by G2), compensating
+akashnet-2 validators for C→H service, uptime-weighted per the final export's signing data
+(mechanics in [06](./06-state-and-data-migration.md) and [10](./10-rollout-and-cutover.md)). Post-C
+delegator yield is not otherwise honored (REQ-TOK-034); comms MUST state this before the migration
+governance vote, and whether the Q-13 budget extends to delegators is an input to that proposal.
+
+---
+
+## 7. IBC-out AKT (D-07)
+
+### 7.1 Quantification
+
+**REQ-TOK-042** The Vendor SHALL quantify stranded supply per channel: enumerate ICS-20 channels from
+the export, read each escrow address balance (row 18), and cross-check against counterparty-chain
+voucher supplies for the top venues (Osmosis, Cosmos Hub; full list Q-03)
+`[TO-VERIFY: live per-channel escrow balances and counterparty voucher distribution]`. Per-channel
+escrow balance equals the maximum redeemable amount for that channel; the redemption process is
+inherently fully funded by row 18 earmarks. `uact` cannot be IBC-escrowed (ICS-20 escrow uses bank
+sends, which enforce `SendEnabled[uact]=false`) `[TO-VERIFY: confirm zero uact vouchers exist on any
+counterparty]`.
+
+### 7.2 Pre-C voucher return (return-home window)
+
+**REQ-TOK-043** A pre-C return-home window of ≥ 12 weeks SHALL exist between migration-governance
+approval and C, during which voucher holders IBC AKT back to akashnet-2 so it is captured in their S1
+leaves. The IBC counterparty notices this depends on are normative in
+[10](./10-rollout-and-cutover.md) §7 (REQ-ROL-045); the audience-facing return-home communications
+campaign (wallet notices, frontend banners, direct outreach) is maintained in the client-side program
+& comms plan, outside this technical set. ICS-20 (in both directions) MUST
+remain in the sunset allow-list until H−7d so stragglers can return during the wind-down (Q-17;
+returning post-C makes the coins old-chain-liquid; such holders are made whole via §7.3, not via
+S1 leaves, so holder-facing notices MUST push returns *before* C).
+
+### 7.3 Post-S1 foundation redemption
+
+**REQ-TOK-044** For vouchers still outstanding at H, a foundation-operated redemption process SHALL
+run for a published window (default 12 months from H; length and KYC posture: Q-03; legal review
+Q-03/Q-10): the holder proves voucher ownership on the counterparty chain (signed message from the
+holding address plus a counterparty state proof or snapshot lookup at H) and receives target-chain
+AKT from the per-channel earmark. AKT returned to akashnet-2 during C→H (neither in S1 leaves nor
+still a voucher at H) is honored the same way, netting the channel's C→H escrow delta. Redemptions
+MUST be logged publicly against the earmark.
+
+**REQ-TOK-045** Unredeemed earmarks at window close sweep to the DAO treasury by governance action
+(§11 clocks do not apply; this window is its own). Flag: the redemption process handles user funds
+off-chain and is the program's most legally exposed surface (Q-03, Q-10; [12](./12-risk-register.md)).
+
+### 7.4 Non-native denoms (row 23)
+
+**REQ-TOK-046** IBC-voucher assets held on akashnet-2 (e.g. IBC USDC) cannot be represented by the
+claims system (the target cannot mint them). Comms MUST instruct holders to move them to their origin
+chains before H; ICS-20 outbound stays open until H−7d (REQ-TOK-043). Voucher balances stranded at H
+are recorded in the final export; disposition (case-by-case foundation assistance vs write-off) is a
+policy decision: new open question, owner Overclock + legal, needed by G3.
+
+---
+
+## 8. Exchange playbook
+
+### 8.1 Precedents (as of 2026-08)
+
+| Migration | Mechanics | Duration/tail |
+|---|---|---|
+| Helium HNT (2023) | Same-ticker chain swap: deposits/withdrawals paused ~1 day around snapshot; venues credited Solana HNT | ~1 day per venue |
+| Render RNDR→RENDER (2023–24) | New network Nov 2023; canonical ticker swap 2024-07-26; per-venue staggered windows ~4 weeks, deposits closed 1–2 weeks prior; self-custody upgrade contract open for years | ~2 years vote→completed swap |
+| Fetch/ASI (2024) | AGIX/OCEAN→FET at fixed rates; major CEXs auto-converted balances day-1; phase-2 ASI ticker never completed on major venues | Day-1 conversion; open-ended tail |
+| Noble (2026) | Cosmos SDK chain → own EVM L1; Cosmos chain to maintenance mode | Freshest Cosmos-exit precedent |
+
+Akash follows the Helium pattern (same ticker per A-09, one snapshot venues act on) with Render's
+long self-custody tail (2-year claim window).
+
+### 8.2 Coordination requirements
+
+**REQ-TOK-047** [RELOCATED] Exchange coordination timeline (venue notice lead times, integration-kit
+and sandbox dry-run schedule, per-venue swap windows): maintained in the client-side program & comms
+plan, outside this technical set. Venue list and per-venue technical requirements remain Q-04, needed
+by G1.
+
+The exchange-coordination milestones execution depends on remain normative in this set: formal venue
+notices no later than S1−30d including the point-of-no-return declaration
+([10](./10-rollout-and-cutover.md) §4.1, REQ-ROL-022); the exchange technical pack delivered ≥16
+weeks before C ([11](./11-scope-of-work.md) REQ-SOW-026; contents per REQ-ROL-046); venue
+deposit/withdrawal freeze at S1−24h and custodial swap execution from S1
+([10](./10-rollout-and-cutover.md) §4.1, REQ-ROL-030); and ≥2 venues completing sandbox integration
+before G3 ([09](./09-testing-and-verification.md) REQ-TST-041).
+
+**REQ-TOK-048** Venues MUST be instructed to disable old-chain AKT deposit crediting **permanently at
+S1**: old-chain coins deposited after S1 have no claim value (REQ-TOK-010), and crediting them would
+put the venue out of balance. The integration kit MUST include this as a checklist item with sign-off.
+
+**REQ-TOK-049** Exchange balances swap at S1 only; venues do not participate in residual roots (their
+customers' module-held funds, e.g. a provider's escrow earnings, flow to the customer's own
+address, not to venues). The kit MUST state this so venues do not attempt to model the Reserve.
+
+### 8.3 Market structure
+
+Ticker: AKT retained across venues (A-09); no rebrand, no rate conversion; 1 old AKT = 1 new AKT
+(6 decimals both sides, D-03/D-04). Chain identity: exchange alignment is also the defense against a
+value-bearing fork of the old chain (A-06; [12](./12-risk-register.md)).
+
+### 8.4 DEX liquidity
+
+**REQ-TOK-050** Day-one DEX liquidity SHALL be seeded on the target chain (Solana: Raydium and/or
+Orca AKT/settlement-stablecoin pool; EVM: an AKT/settlement-stablecoin pool on the leading DEX on the host chain, e.g. Aerodrome on Base), funded by a governance-pre-authorized carve-out from
+the community-pool slice of the Reserve, executable at S1 (amount, venue split, and LP management
+policy are an open question for the migration governance proposal; owner Overclock finance, needed
+by G2). Market-maker agreements for CEX order books SHOULD be renewed against the new chain before C
+(Q-04 workstream).
+
+---
+
+## 9. Emissions replacement (D-12)
+
+Sovereign inflation (stock Cosmos `x/mint`; live parameters are on-chain state only, read at
+kickoff per Q-19) ends economically at S1 (post-C inflation is dead, REQ-TOK-003) and literally at H.
+The replacement is `akash-emissions` (Solana) / `EmissionsMinter` (EVM). This section fixes the
+mechanism; the curve is the WS-1 modeling deliverable (Q-01) ratified by governance; the Vendor
+MUST NOT hard-code placeholder numbers.
+
+**REQ-TOK-051** The emissions minter SHALL enforce an immutable **hard cap** on cumulative emitted
+AKT, set at deployment from the ratified model (Q-01), independent of and additive to the migration
+budget (REQ-TOK-005). No authority, including governance, can raise it; lowering requires
+redeployment by governance.
+
+**REQ-TOK-052** The emission schedule (per-epoch amounts or rate function) SHALL live in on-chain
+config adjustable only by the DAO through the timelock (D-11), with bounds enforced in code: schedule
+changes cannot exceed the hard cap, cannot mint retroactively, and take effect no earlier than
+timelock expiry + one full epoch. A guardian role MAY pause emissions but can never mint or raise
+parameters ([08](./08-security-and-audits.md)).
+
+**REQ-TOK-053** Destinations are exactly two on-chain accounts, with a governance-adjustable split:
+(a) the provider-incentive pool (distribution mechanics per
+[03](./03-solana-architecture.md)/[04](./04-ethereum-architecture.md)); (b) the community treasury
+(§10). Minting is epoch-batched and permissionlessly crankable (Solana) / keeper-automated (EVM),
+consistent with D-20's execution model.
+
+**REQ-TOK-054** Launch state: the minter deploys with the ratified schedule if Q-01 closes before S1;
+otherwise it deploys **paused with a zero schedule** and activates by governance once ratified.
+Emissions never block cutover.
+
+---
+
+## 10. Treasury migration
+
+**REQ-TOK-055** The community-pool slice of the Reserve (row 8, net of §6.5 and §8.4 carve-outs)
+SHALL transfer at S2 to the DAO treasury: Solana, the Realms-governed treasury vault (Squads-held
+per D-11); EVM, the `AkashTimelock`-owned Safe. From S2 onward, spends follow target-chain
+governance only; the Cosmos community-pool spend mechanism (governance proposals; historically also
+imperative upgrade-handler moves, REQ-TOK-009) has no successor.
+
+**REQ-TOK-056** Strategic reserve: akashnet-2 has no foundation module and no hard-coded foundation
+address (`GenesisParams.StrategicReserveAccounts` exists but is unpopulated;
+`cmd/akash/cmd/genesis.go:202`); foundation/Overclock holdings are ordinary externally-owned (and
+vesting) accounts. These claim through the standard §4 flow, and MUST be enumerated and publicly
+labeled in the reconciliation artifact (address list: Overclock to supply at G1) so community
+reviewers can distinguish them from unclaimed retail supply in the telemetry (REQ-TOK-027).
+
+---
+
+## 11. Unclaimed policy
+
+**REQ-TOK-057** Claim windows: S1 leaves are claimable for **2 years from S1**; residual-root and S2
+leaves for **2 years from S2** (all residual roots share the S2 clock). The IBC redemption window
+(§7.3) is separate. Windows and expiry consequences MUST be stated in the claim portal, the exchange
+kit, and every distribution's published ledger.
+
+**REQ-TOK-058** At window expiry, unclaimed entitlements SHALL be swept to the DAO treasury **only
+by an explicit governance action** on the target chain, gated on the legal review of Q-02 (per-
+jurisdiction posture on expropriating unclaimed property; needed by G2). The claims program/contract
+MUST make the sweep impossible before the window ends (enforced on-chain, not procedurally) and MUST
+emit a final accounting event reconciling swept amounts against REQ-TOK-040's artifact. Governance
+MAY instead vote to extend windows; the code MUST support extension without redeployment.
+
+---
+
+## Cross-references
+
+- [01. Current architecture](./01-current-architecture.md): module accounts, escrow/BME/vesting mechanics cited throughout.
+- [03. Solana](./03-solana-architecture.md) / [04. Ethereum](./04-ethereum-architecture.md): `akash-claims`/`MigrationClaims` runtime context, BME/escrow ports, provider-incentive pool.
+- [06. State & data migration](./06-state-and-data-migration.md): export tooling, weekly archive cadence, sunset mechanics; [07. Off-chain & clients](./07-offchain-and-clients.md): claim portal/CLI, wallet matrix, paymaster, provider balance surfacing.
+- [08. Security & audits](./08-security-and-audits.md): Migration Operator multisig, guardian roles, claims threat model; [09. Testing](./09-testing-and-verification.md): reconciliation reproduction, settlement-replay proof, claim acceptance.
+- [10. Rollout & cutover](./10-rollout-and-cutover.md): governance proposals, runbook, gates consuming REQ-TOK-009/012/040.
+- [12. Risk register](./12-risk-register.md): claim phishing, exchange non-cooperation, unclaimed overhang, fork risk, IBC-redemption legal exposure.
+- [13. Open questions](./13-open-questions-and-assumptions.md): D-03..D-07, D-12, D-19..D-21; Q-01..Q-05, Q-10, Q-13, Q-18, Q-19; A-04, A-06, A-09.
+
+## Feeds into
+
+- [06](./06-state-and-data-migration.md): S1/S2 export requirements, honored-flow definitions, sunset-prep steps (REQ-TOK-008/014); [09](./09-testing-and-verification.md): acceptance tests for REQ-TOK-006/008/012/036/040.
+- [10](./10-rollout-and-cutover.md): runbook steps, gate criteria, exchange operational milestones (§8).
+- [11](./11-scope-of-work.md): WS-1 emissions modeling input (§9); reconciliation artifact as payment-gate deliverable.
+- [12](./12-risk-register.md): risk entries above; [14](./14-appendix-protocol-mapping.md): claims/emissions surfaces, BME state carry-over.

--- a/spec/aep-79/doc/06-state-and-data-migration.md
+++ b/spec/aep-79/doc/06-state-and-data-migration.md
@@ -1,0 +1,659 @@
+# 06. State & Data Migration
+
+| | |
+|---|---|
+| **Document** | 06. State & data migration |
+| **Doc ID** | AKASH-MIG-06 |
+| **Version** | 0.9 (draft for review) |
+| **Date** | 2026-08-10 |
+| **Owner** | Overclock Labs |
+| **Audience** | Vendor engineering |
+| **Status** | Normative where marked (MUST/SHALL); informative otherwise |
+
+## Purpose
+
+This document specifies the disposition of every piece of non-token state on `akashnet-2` (the Cosmos chain), the
+snapshot/export tooling that produces the migration artifacts, the weekly residual-distribution computation
+during the wind-down window, verification and sign-off, the sunset upgrade that restricts the old chain after S1,
+validator continuity through halt, archival, and decommission. Token *value* accounting is owned by
+[05. Token migration](./05-token-migration.md); this document produces the datasets doc 05 consumes.
+
+## In scope
+
+- Disposition (migrate / re-register / drop / wind down / archive) of every module's state.
+- The migration engine: exports at S1, weekly heights, and S2; artifact formats; determinism.
+- Weekly residual diff computation and classification rules (D-05, D-08).
+- Verification: dual implementations, property checks, public window, sign-off.
+- The sunset upgrade (D-18): message allow-list, fee floor, halt mechanics, validator continuity.
+- Archives and old-chain infrastructure decommission.
+
+## Out of scope
+
+- AKT/ACT supply equation, claim UX, exchange swaps, unclaimed policy: [05](./05-token-migration.md).
+- Target-chain designs consuming these artifacts: [03](./03-solana-architecture.md), [04](./04-ethereum-architecture.md).
+- Rehearsal pass criteria and test tooling detail: [09](./09-testing-and-verification.md).
+- Cutover runbook timing and operational notifications: [10](./10-rollout-and-cutover.md).
+
+Terminology: **S1** = supply snapshot at cutover **C**; **S2** = residual snapshot at halt **H** = C+90d;
+**Wind-down Reserve** = target-chain pool backing old-chain module-held funds (D-05). A **genesis export**
+serializes full application state to JSON at a height (`akash export` / `ExportAppStateAndValidators`,
+`app/export.go:30`). A **module account** is a protocol-owned keyless account (escrow vault, BME vault,
+governance deposits, etc.); the list is wired at `app/mac.go:15-27`.
+
+## 1. State disposition inventory
+
+### 1.1 The five treatments
+
+| Treatment | Meaning | Value carried? |
+|---|---|---|
+| **Migrated-as-value** | Converted into target-chain token credits (claims, vesting re-creation, Reserve seeding) per doc 05 | Yes |
+| **Migrated-as-registration** | The *actor* re-establishes the record on the target chain by signing a fresh transaction; no state is copied | No (identity re-established) |
+| **Wound down** | Runs to terminal state on the old chain during C→H under D-08; economic outcomes honored via residual distributions | Via residuals |
+| **Dropped** | No successor object on the target chain | No |
+| **Archived** | Preserved immutably per §7 | N/A |
+
+**REQ-STA-001** The Vendor SHALL produce a disposition matrix in which every KV store listed in
+`app/types/app.go:605-637` and every genesis section of the S1 export maps to exactly one of {migrated-as-value,
+migrated-as-registration, wound down, dropped}; completeness is checked mechanically against the export.
+
+**REQ-STA-002** Independently of treatment, ALL state SHALL be archived per §7: "dropped" never means deleted from the historical record.
+
+### 1.2 The supply-fixed-at-S1 principle and the reserved perimeter
+
+Two rules make every later section deterministic:
+
+1. **Supply fixed at S1.** Claim value derives exclusively from (a) state at the S1 height and (b) subsequent
+   flows of S1-reserved principal out of module accounts. `uakt`/`uact` minted after S1 (staking inflation,
+   BME-minted `uakt` from post-S1 burns) carries **no claim value**; this makes post-S1 bank sends harmless
+   (§5.4) and creates the validator-attrition problem solved in §6.
+2. **Reserved perimeter.** The accounts whose S1 balances are minted into the Wind-down Reserve rather than
+   individually claimed: the `escrow`, `bme`, and `gov` (proposal deposits) module accounts, every ICS-20
+   transfer escrow address (one derived account per IBC channel), `fee_collector`, and `distribution`
+   (community-pool portion per doc 05). `bonded_tokens_pool` / `not_bonded_tokens_pool` are **not** reserved:
+   they back the bonded/unbonding stake credited as liquid at S1 (D-06).
+
+**REQ-STA-003** No `uakt` or `uact` minted on the old chain after the S1 height SHALL appear in any claim set,
+residual distribution, or Reserve accounting line.
+
+**REQ-STA-004** The reserved perimeter SHALL be enumerated programmatically at S1 (module accounts from `x/auth`
+state + escrow addresses of all open IBC channels), published as the reserved-pool ledger (§2.4), and treated as
+a closed catch-all: any module-held balance not explicitly allocated by doc 05 defaults to treasury-at-S2.
+
+**REQ-STA-005** Post-S1 inflows *into* the perimeter (escrow top-ups via `MsgAccountDeposit`, new governance
+deposits, post-S1 BME burn escrows) are **claim-inert**: recorded for attribution (§3.3) but never credited,
+since those coins were already credited at S1. Cutover comms (doc 10) MUST state this for tenants topping up.
+
+### 1.3 Inventory: Akash modules
+
+Source structures are per [01](./01-current-architecture.md); genesis shapes below are the export sections.
+
+| Module (store) | Source structure (genesis) | Treatment | Verification method |
+|---|---|---|---|
+| `x/deployment` | `{Params{MinDeposits}, Deployments:[{Deployment, Groups}]}`; per-entity state incl. `pendingDenomMigrations` scratch map | **Wound down** (D-08): active deployments/groups run to close by H; params re-authored in target genesis/config, not copied | All entities terminal at H (S2 export shows zero `active`/`open`); `pendingDenomMigrations` empty (REQ-STA-008); archive checksum |
+| `x/market` | `{Params, Orders, Bids, Leases}` | **Wound down** (D-08): no new orders/bids/leases post-C; existing run to close/expiry; reclamation windows (D-24) keep operating | Zero non-terminal orders/bids/leases at H; count reconciliation vs event replay; archive checksum |
+| `x/escrow` | `{Accounts, Payments}`: accounts with multi-denom Dec `Funds` + FIFO `Deposits`, payments with per-block `Rate`, `Balance`, `Unsettled`, `Withdrawn` | **Wound down + migrated-as-value**: module balance at S1 → Wind-down Reserve; C→H flows honored via weekly residuals (§3); final virtual settlement at H (§3.4) | Conservation: Reserve = Σ residual credits + inert flows + residue (§4.2); state-vs-replay reconciliation each week |
+| `x/bme` | `{Params, State{TotalBurned, TotalMinted, RemintCredits}, Ledger{Records, PendingRecords}}` + module-account vault | **Hybrid**: vault balance → Reserve → seeds target BME vault (doc 05, D-20); params re-authored per D-20; pending ledger wound down (§3.2); counters dropped (target counters start at zero) | Vault balance vs reserved ledger line; pending records all executed/canceled/refunded by S2; archive |
+| `x/oracle` | `{Params, GenesisSourceID, GenesisLatestPricesIDs}` + price/TWAP history | **Dropped** (D-13/D-22): target reads Pyth pull feeds directly; price history is ephemeral market data | Archive checksum only; §5.4 keeps the feed *live* until H |
+| `x/epochs` | `{Epochs}` (scheduler cursors) | **Dropped**: target epochs are time-based (D-20); cursors meaningless off-chain | Archive checksum only |
+| `x/provider` | `{Providers}`: `Provider{Owner, HostURI, Attributes, Info}` | **Migrated-as-registration**: providers RE-REGISTER on the target chain from target-launch day (precedes C, D-08) | Re-registration coverage report from indexer (old↔new linkage, REQ-STA-007); archive |
+| `x/audit` | `{Providers: []AuditedProvider}`, auditor-signed attribute sets keyed `(owner, auditor)` | **Migrated-as-registration**: auditors RE-ATTEST on the target chain | Auditor re-attestation report; archive |
+| `x/cert` | `{Certificates}`: x509 PEM blobs keyed `(owner, serial)` | **Dropped** (D-10): replaced by JWT + on-chain signing keys ([07](./07-offchain-and-clients.md)) | Archive checksum; no target-side successor to verify |
+| `x/awasm` | `{Params{BlockedAddresses}}` | **Dropped** (D-22): the CosmWasm guardrail has no successor | Archive checksum |
+| `x/wasm` (wasmd) | Contract code + state: pyth, pyth_pro, pyth_vaa, wormhole (guardian sets, VAA archive) | **Dropped** (D-22): targets read Pyth directly; contracts archived incl. code blobs | Archive checksum; code-hash inventory |
+| `x/take` | Not wired; store deleted in v2.0.0 | **Absent**: nothing to migrate; listed for completeness | Assert absent from export |
+
+Why the registration rows cannot be ported trustlessly: provider and audit records are keyed by secp256k1 Cosmos
+accounts (bech32 `akash1…`); target identities use different key/address schemes (Solana Ed25519, EVM keccak
+addresses), so ownership of a target identity cannot be derived from old-chain state: it requires a fresh
+signature by the actor, which *is* a registration transaction. Audit records are additionally *attestations*
+("this auditor's key signed these attributes for this provider's key"); with both keys changing, a copied record
+attests nothing. Providers must also register new JWT signing keys (D-10) and post collateral (Q-08), neither of
+which exists in old-chain state; and `MsgDeleteProvider` was never implemented
+(`x/provider/handler/server.go:74-88`), so the registry holds abandoned records unfit for bulk import.
+
+**REQ-STA-006** The Vendor SHALL NOT build any mechanism that mints provider, audit, or certificate records on
+the target chain from old-chain state; providers re-register and auditors re-attest via target-chain transactions.
+
+**REQ-STA-007** The migration tooling SHALL support an OPTIONAL linkage attestation: a provider MAY sign its
+target-chain address with its old Cosmos key; the indexer ([07](./07-offchain-and-clients.md)) records the link
+so reputation/history carries across chains. Linkage is informational and SHALL NOT gate registration.
+
+**REQ-STA-008** The S1 pipeline SHALL assert that `x/deployment.pendingDenomMigrations` (drained by upgrade
+v2.1.0) is empty at S1; a non-empty map is a blocking discrepancy escalated per §4.5.
+
+### 1.4 Inventory: Cosmos SDK modules
+
+| Module | Source structure | Treatment | Verification method |
+|---|---|---|---|
+| `x/auth` | Accounts (base, module, vesting), numbers, sequences | **Dropped**, except vesting schedules → **migrated-as-value** (re-created per D-06/doc 05); numbers/sequences meaningless on target | Vesting inventory cross-check (§2.4); per-account schedule recomputation on sample n≥50 |
+| `x/bank` | Balances, supply, denom metadata, SendEnabled | Balances → **migrated-as-value** (S1 claim set: `uakt`; `uact` → ACT ledger seed); metadata/SendEnabled dropped (D-03/D-19 re-author) | Doc 05 conservation equation; dual-implementation root equality |
+| `x/staking` | Validators, delegations, unbonding, redelegations | **Migrated-as-value** as liquid credits (D-06); validator objects dropped (no consensus to port) | Σ(delegation tokens)+Σ(unbonding) vs bonded/not_bonded pool balances (documented rounding tolerance) |
+| `x/mint` | Inflation params/state (live values on-chain only; Q-19) | **Dropped**; replaced by emissions program (D-12) | Params captured in archive + Q-19 data pull |
+| `x/distribution` | Outstanding rewards, commission, fee pool, community pool | Accrued-to-S1 rewards/commission → **migrated-as-value** (doc 05); community pool → Reserve → treasury at S2; post-S1 accruals inert (REQ-STA-003) | Doc 05 reward computation vs module balance reconciliation |
+| `x/slashing` | Signing infos, missed-block bitmaps, params | **Dropped**; stays *active* C→H (§6); signing data feeds continuity payouts | §6 uptime dataset cross-check vs raw `LastCommit` |
+| `x/gov` | Proposals, deposits, votes, params | Deposits at S1 → reserved; refunds C→H → residual credits (§3.2); history dropped/archived | Deposit ledger reconciliation at S2 |
+| `x/authz` | Grants (incl. `DepositAuthorization`) | **Dropped**; delegated-deposit semantics re-implemented natively on target (D-21); grant-restore mapping honored in residuals (§3.3) | Residual granter-attribution audit (§3.3) |
+| `x/feegrant` | Fee allowances | **Dropped** (target fee mechanics differ); usable until H | Archive checksum |
+| `ibc` core | Clients, connections, channels | **Dropped**; kept operational until H for returns (§5.5) | Archive checksum |
+| `ibctransfer` | Per-channel escrow balances, denom traces | Escrows → **reserved** at S1 (per-channel ledger, D-07); returns C→H credited via residuals (§3.2); post-H → doc 05 redemption | Per-channel escrow reconciliation weekly; S2 remainder = redemption budget |
+| `x/evidence` | Equivocation evidence | **Dropped**/archived; submission stays allowed C→H (§6.5) | Archive checksum |
+| `x/upgrade` | Applied upgrade heights, pending plan | **Dropped**; the halt plan (§5.6) is the final entry | Archive checksum |
+| `x/params`, `x/consensus` | Chain-internal config | **Dropped** | Archive checksum |
+| `x/crisis` | ConstantFee param (invariants unregistered) | **Dropped** | Archive checksum |
+
+## 2. Snapshot & export pipeline (the migration engine)
+
+### 2.1 Architecture
+
+The migration engine is Go tooling (single repository, `akash-migrate`) layering deterministic transform stages
+on the chain's native genesis-export path; it links the node's own codec so decoding cannot drift from mainnet.
+
+```mermaid
+flowchart LR
+  A[Archive node A<br/>pruning=nothing] -->|halt at h, akash export| X1[Export JSON at h]
+  B[Archive node B<br/>independent operator] -->|halt at h, akash export| X2[Export JSON at h]
+  E[Block and event archive] --> T
+  E --> I2
+  X1 --> CMP{byte-equal +<br/>app-hash pin}
+  X2 --> CMP
+  CMP --> T[Transform: classify,<br/>attribute, round]
+  T --> ART[Artifacts + Merkle roots]
+  X1 --> I2[Independent implementation 2]
+  ART --> GATE{root equality gate}
+  I2 --> GATE
+  GATE -->|pass + sign-off| PUB[Signed manifest, published, anchored]
+```
+
+**REQ-STA-009** The primary migration engine SHALL be written in Go, import the exact `akashnet-2` release tag
+current at C, and consume state exclusively via the genesis-export path (`ExportAppStateAndValidators`,
+`app/export.go:30-68`), never via raw IAVL key scraping, with `forZeroHeight=false` (the zero-height path
+mutates distribution state, `app/export.go:151-157`, and MUST NOT be used).
+
+**REQ-STA-010** At least two archive nodes (`pruning=nothing`) run by independent operators (Vendor and Overclock
+minimum) SHALL produce each export, taken from a stopped filesystem-snapshot copy so the live node keeps syncing.
+
+### 2.2 Inputs
+
+| Input | Source | Notes |
+|---|---|---|
+| Archive node data dirs (≥2) | Vendor + Overclock operated | Full history of the `akashnet-2` v2 line; sized per [TO-VERIFY: current mainnet archive data-dir size] |
+| Export heights | Published schedule (§2.3) | Reached via `halt-height` app config on the export replica, then `akash export`; the `--height` flag on an unpruned node MAY be used instead [TO-VERIFY: `--height` export support in the SDK 0.53 fork] |
+| Halted-height app hash | Block header at h+1 (the header at h+1 commits the state root produced by executing block h) | Pin per REQ-STA-013 |
+| Block & event archive | CometBFT blockstore + tx index from the archive nodes | Feeds the replay engine (§3.1): bank transfer events, market/deployment lifecycle events, tx bodies |
+| Live-state parameters | Q-19 kickoff data pull | Mint params, vesting inventory; not derivable from source code |
+
+### 2.3 Export heights and schedule
+
+- S1 height `h_S1 = h_up − 1`, where `h_up` is the governance-scheduled sunset-upgrade height (§5): the last
+  block whose transactions are unrestricted. C is the timestamp of block `h_up`.
+- Weekly heights `h_k` (k = 1..12): the first block whose header time ≥ the published UTC timestamp `C + k·7d`
+  (deterministic given the chain; ≈ 93,000 blocks apart at the 6.5 s target block time, `util/network/network.go:8`).
+- S2 height `h_S2 = H`: the last committed block before the halt plan (§5.6).
+
+**REQ-STA-011** The full export schedule (S1 rule, twelve weekly timestamps, halt plan height) SHALL be published
+at least 14 days before C and referenced from the governance proposals scheduling the sunset upgrade and halt.
+
+**REQ-STA-012** For every scheduled height, the genesis exports from the independent archive nodes MUST be
+byte-identical; any divergence halts the pipeline and is escalated per §4.5.
+
+**REQ-STA-013** Every artifact manifest SHALL pin chain-id, export height h, block hash of h, app hash from
+header h+1, and binary version; the pinned app hash MUST match across both archive nodes before transforms run.
+
+### 2.4 Output artifacts (per run)
+
+| Artifact | Produced at | Schema (canonical CSV unless noted) | Consumer |
+|---|---|---|---|
+| `s1_claims.csv` + Merkle root | S1 | `row, address_bech32, address_hex, denom{uakt\|uact}, amount_micro, class{liquid\|bonded\|unbonding\|reward}` | Claims program/contract (doc 05) |
+| `reserved_pool_ledger.csv` | S1 (restated at S2) | `account, account_kind{module\|ibc_escrow}, denom, amount_micro, disposition_ref` | Wind-down Reserve seeding (doc 05) |
+| `act_ledger_seed.csv` | S1 | `uact` liquid holders + reserved `uact` positions | ACT mint seeding (D-19, doc 05) |
+| `vesting_inventory.csv` | S1 | `address, type{continuous\|delayed\|base}, original_vesting, start_time, end_time, locked_at_s1` | Vesting re-creation (doc 05) |
+| `ibc_escrow_by_channel.csv` | S1, weekly, S2 | `channel_id, counterparty_chain, escrow_address, denom, amount_micro` | D-07 redemption sizing (doc 05, Q-03) |
+| `residual_deltas_wk<k>.csv` + root | Weekly k=1..12 (12 weekly cycles + the S2 final distribution = 13 residual payouts total, matching [10 §8.2](./10-rollout-and-cutover.md)) | `address, denom{akt\|act}, delta_micro, class` (§3.5) | Weekly residual distribution (D-05) |
+| `s2_final_set.csv` + root | S2 | Same schema as weekly + final-settlement and refund classes | Final residual distribution (D-05) |
+| `validator_continuity.csv` | S2 | `valoper, signed_blocks, expected_blocks, uptime_pct, eligible, payout_weight` (§6) | Continuity payout at S2 |
+| `dust_ledger.csv` | Every run | Per-source truncation remainders (§2.5) | Conservation accounting |
+| `manifest.json` (signed) | Every run | Pins per REQ-STA-013 + SHA-256 of every artifact + tool container digest | Verification & archives |
+
+**REQ-STA-014** Every pipeline run SHALL emit the complete artifact set applicable to its event (S1, weekly, S2)
+plus the signed manifest; partial artifact sets MUST NOT be published.
+
+### 2.5 Determinism and rounding
+
+**REQ-STA-015** All artifacts SHALL be byte-stable: UTF-8, LF line endings, header row, rows sorted by (raw
+address bytes ascending, denom ascending), amounts as base-10 integer strings of micro-units, no floats anywhere
+in the pipeline, stable field order. Two runs over the same inputs MUST produce byte-identical artifacts.
+
+**REQ-STA-016** Conversion of fractional escrow quantities (`LegacyDec` Funds, Depositor balances, payment
+`Rate`/`Balance`; 18 decimal places) to integer micro-units SHALL use truncation toward zero, semantically
+identical to the escrow keeper's `TruncateInt` usage at deposit, settlement, and withdrawal
+(`x/escrow/keeper/keeper.go:1187-1209`), never rounding half-up. Per-source truncation remainders (< 1
+micro-unit per row) accumulate in `dust_ledger.csv` so Σ(truncated outputs) + Σ(dust) equals the source total
+exactly; dust goes to the community treasury allocation at S2, never to individual claims.
+
+Per-block→per-second rate conversion (D-21.a): wherever a transform or parity artifact expresses a per-block
+escrow/market `Rate` on the per-second basis consumed by the target designs, the conversion factor is the exact
+rational **×2/13 (= ÷6.5 exactly**; 6.5 s target block time, `util/network/network.go:8`**)**, fixed at S1 and
+maintained as a single shared constant with the parity harness ([09](./09-testing-and-verification.md)
+REQ-TST-012) and docs [03](./03-solana-architecture.md)/[04](./04-ethereum-architecture.md)/[14](./14-appendix-protocol-mapping.md).
+
+**REQ-STA-017** The pipeline SHALL run in a pinned container whose digest is recorded in the manifest; the
+repository at the tagged commit MUST reproduce that image, so third parties can re-derive artifacts from inputs.
+
+**REQ-STA-018** Merkle roots SHALL be computed over the canonical artifacts using the leaf and hash construction
+defined by doc 05 for the claims program/contract; this document constrains only determinism (sorted leaves, no
+duplicate addresses per set, one root per artifact recorded in the manifest).
+
+### Solana specifics
+
+Leaf hashing uses SHA-256 with the `akash-claims` program's leaf layout (doc 05 / [03](./03-solana-architecture.md));
+weekly residual roots are appended to its distribution list by the migration authority (D-11 multisig+timelock).
+
+### Ethereum specifics
+
+Leaves are `keccak256` over ABI-encoded `(index, claimant, denomId, amount)` with sorted-pair hashing
+(OpenZeppelin `MerkleProof`-compatible), per `MigrationClaims` in [04](./04-ethereum-architecture.md); weekly
+roots are added via a timelocked `addDistribution` call.
+
+### 2.6 Performance budget
+
+**REQ-STA-019** The pipeline SHALL meet: genesis export ≤ 2 h per node; transform + Merkle build +
+dual-implementation comparison ≤ 4 h; total compute from S1 height to publishable artifacts ≤ 6 h, with S1
+publication ≤ 24 h after C including human review steps (doc 10 runbook); weekly runs ≤ 24 h from export height
+to publication. Budgets MUST hold at 2× current mainnet state size, demonstrated during rehearsals (§9).
+
+## 3. Weekly residual diff computation
+
+### 3.1 Method: event-sourced replay with state reconciliation
+
+State snapshots alone cannot attribute intra-week flows (a lease that closes mid-week settles at its close
+height, not at the export height). The residual engine therefore replays, for each window `(h_{k−1}, h_k]`:
+
+1. **Bank transfer events** where a perimeter account (§1.2) is sender or recipient: authoritative amounts for
+   every escrow payout/refund/deposit, BME escrow/release, gov deposit/refund, and IBC escrow movement.
+2. **Protocol lifecycle events** for classification context: `EventLeaseClosed`/`EventBidClosed`/
+   `EventDeploymentClosed`/`EventGroupClosed` (x/escrow emits no events; closures surface via the market and
+   deployment hook cascade), BME `EventLedgerRecordExecuted`/`Canceled`, gov outcomes, ICS-20 packet events.
+3. **Escrow arithmetic replay**: starting from the week `k−1` export, apply the settlement function (accrual =
+   `Rate × (height − SettledAt)`, truncated; FIFO deduction over the Depositors list; overdrawn and `Unsettled`
+   semantics; AKT-fallback conversion) exactly as specified for `accountSettle`/`deductFromBalance`/
+   `settleFromAktFallback` in [01](./01-current-architecture.md), independently deriving each flow.
+
+**REQ-STA-020** Residual accounting SHALL cover exactly the reserved perimeter (§1.2): perimeter→user flows are
+candidate credits; non-perimeter flows are ignored; perimeter inflows are claim-inert attribution inputs (REQ-STA-005).
+
+**REQ-STA-021** The replayed terminal state at `h_k` MUST reconcile exactly (per account, per denom, after
+documented truncation) with the week-`k` genesis export; any mismatch is a hard failure that blocks publication
+of that week's distribution.
+
+### 3.2 Flow classification (normative)
+
+| # | Old-chain flow (C→H) | Classification | Residual credit |
+|---|---|---|---|
+| F1 | `MsgWithdrawLease` / payment close payout: escrow → provider (Δ in cumulative `PaymentState.Withdrawn`) | Provider earnings | Provider address, `act` (leases price in `uact`), subject to §3.3 attribution |
+| F2 | AKT-fallback settlement (BME halted at CR, oracle healthy): escrow → provider in `uakt` | Provider earnings (fallback) | Provider address, `akt`, subject to §3.3 |
+| F3 | Account close/overdrawn refund: escrow → each remaining depositor, FIFO order | Tenant refund | Per-depositor entry: credit iff entry `Height < h_up` (§3.3); denom as refunded |
+| F4 | Grant-sourced refund (Depositor.Source = grant): refund pays the **granter** and restores the grant's SpendLimits | Granter refund | Granter address (mirror of restore semantics), same entry-height rule |
+| F5 | BME pending record (queued at S1) executed | Swap completion | Owner, credited the minted side per the executed `LedgerRecord` amounts |
+| F6 | BME pending record (queued at S1) canceled: escrowed coin refunded | Swap refund | Owner, refunded denom |
+| F7 | BME record queued **after** S1 (only `MsgBurnACT` possible) | Claim-inert (REQ-STA-005) | None |
+| F8 | Gov proposal deposit refunded (proposal concluded C→H, deposit made pre-S1) | Deposit refund | Depositor, `akt` |
+| F9 | Gov deposit burned (veto) or deposit made post-S1 | Claim-inert / stays in Reserve | None |
+| F10 | ICS-20 voucher return: counterparty burn → transfer-escrow release → recipient | IBC return | Recipient address, `akt`, full credit (voucher balances were never S1-credited) |
+| F11 | Pre-S1 outbound ICS-20 packet times out post-S1: escrow refund → original sender | In-flight refund | Sender, `akt`, full credit (in-flight coins were not in the sender's S1 balance) |
+| F12 | Post-S1 escrow top-up (`MsgAccountDeposit`) | Perimeter inflow, claim-inert | None (recorded for §3.3) |
+
+**REQ-STA-022** The classification table F1–F12 is normative; the residual engine SHALL classify every perimeter
+bank-transfer event into exactly one class or fail the run with an "unclassified flow" error (no best-effort
+bucketing).
+
+**REQ-STA-023** IBC returns (F10) SHALL be credited to the on-chain recipient of the return transfer. Note the
+consequence: during C→H a voucher is effectively a bearer claim (a voucher bought on a DEX post-S1 and returned
+earns the credit). This is supply-conserving (bounded by the S1 escrow reservation) but is a policy exposure; the
+claim portal's screening posture applies to residual recipients identically (Q-03, Q-10).
+
+### 3.3 S1-principal FIFO attribution
+
+Escrow consumes deposits strictly FIFO (`deductFromBalance` walks the Depositors list in order) and each
+`Depositor` entry records its creation `Height`, so every payout/refund is *exactly* attributable by replay.
+
+**REQ-STA-024** Residual credits for classes F1–F4 SHALL be computed under FIFO attribution: a flow is credited
+only to the extent it drains depositor entries with `Height < h_up` (S1 principal); the portion draining post-S1
+entries is claim-inert. Cumulative credits per escrow account therefore never exceed that account's S1-reserved
+principal, which is what keeps the Wind-down Reserve sufficient by construction.
+
+**REQ-STA-025** Grant-sourced refunds (F4) SHALL credit the granter, mirroring the old chain's
+restore-on-refund behavior (`x/escrow/keeper/keeper.go:1050-1075`), so Console-style sponsored deposits are made
+whole to the sponsor, not the tenant.
+
+### 3.4 Final virtual settlement at H (feeds S2)
+
+Close messages are owner-/provider-gated, so some leases and escrow accounts will still be open at the halt.
+
+**REQ-STA-026** The S2 pipeline SHALL apply a *final virtual settlement* to every escrow account and payment
+still open at `h_S2`: compute accrued provider earnings as `Rate × (h_S2 − SettledAt)` (truncated, overdrawn
+semantics identical to `accountSettle`), classify the earned portion as F1/F2 and remaining depositor balances
+as F3/F4, all under §3.3 attribution; implemented by both implementations and checked in §4.2.
+
+**REQ-STA-027** After S2, the Reserve SHALL be fully allocated: Σ(weekly credits) + Σ(S2 credits) + IBC
+redemption budget (doc 05, D-07) + validator continuity payout (§6) + unallocated residue (claim-inert flows,
+dust, burned deposits) = S1 reserved total; the residue's disposition follows doc 05's unclaimed policy (Q-02).
+
+### 3.5 Output format and public recomputability
+
+**REQ-STA-028** Each weekly run SHALL output per-address, per-denom **net deltas** (`akt` and `act` credits) for
+the window, with a class breakdown column, as `residual_deltas_wk<k>.csv` (§2.4), plus that week's Merkle root;
+negative net positions floor at zero (never enforced against S1 claims).
+
+**REQ-STA-029** All inputs needed to recompute any weekly set (the week's genesis exports, the window's block
+and event archive, and the tool release) SHALL be published with it so any third party can reproduce the root.
+
+### 3.6 Cadence, thresholds, timing
+
+**REQ-STA-030** Weekly cadence: publication ≤ 24 h after the export height, public objection window ≥ 48 h
+(§4.3), distribution executed on the target chain ≤ 96 h after the export height. Worst-case lag from an
+old-chain settlement event to target-chain credit is then ≤ 11 days; the mean is ≈ 7 days, satisfying D-05's
+"~weekly" commitment.
+
+**REQ-STA-031** A minimum payout threshold (default 1 AKT-equivalent per address per week, final value per Q-18)
+SHALL apply; sub-threshold amounts carry forward to subsequent weeks and unconditionally flush into the S2 final
+set, so no address loses value to the threshold.
+
+## 4. Verification
+
+### 4.1 Dual independent implementations
+
+**REQ-STA-032** Two implementations of the entire artifact pipeline (S1 claim sets, weekly residuals incl.
+escrow replay and virtual settlement, S2) SHALL be built by different authors with no shared transform code; the
+second SHOULD be in a different language (reference: Go per REQ-STA-009; verifier: Rust or TypeScript). Shared
+components are limited to proto schema definitions (`pkg.akt.dev/go` generated types or their ports).
+
+**REQ-STA-033** Publication of any claim set or residual distribution is gated on byte-equality of the canonical
+artifacts AND equality of every Merkle root across both implementations; on mismatch the run aborts, the cause is
+diagnosed, and both implementations re-run; no "pick-the-majority" resolution exists.
+
+### 4.2 Property checks
+
+**REQ-STA-034** Both implementations SHALL evaluate, and the manifest SHALL record, at minimum: (a) conservation
+per doc 05's supply equation (liquid claims + stake/reward credits + vesting + reserved = total S1 supply, exact
+with dust ledger); (b) every amount ≥ 0, every address valid 20-byte bech32; (c) **no module account, IBC escrow
+address, or other perimeter address in any claim set** (list per REQ-STA-004); (d) no duplicate (address, denom)
+rows; (e) weekly: replay/state reconciliation (REQ-STA-021) and Reserve non-negativity; (f) S2: full-allocation
+identity (REQ-STA-027); (g) vesting: recomputed locked amounts match schedule arithmetic for every account.
+
+### 4.3 Public verification window
+
+**REQ-STA-035** The S1 and S2 artifact sets SHALL each have a public verification window of ≥ 7 days between
+publication and on-chain arming of the corresponding claims (root commitment / distribution activation); weekly
+residual sets, produced by the same audited tooling, get ≥ 48 h (§3.6). Published tooling (REQ-STA-017,
+REQ-STA-029) and a recomputation guide accompany every window; a staffed public objection channel operates
+throughout, and any objection reproducing a discrepancy suspends arming until resolved per §4.5.
+
+### 4.4 App-hash pinning
+
+**REQ-STA-036** Every published root SHALL be traceable to consensus via the manifest pins (REQ-STA-013): a
+verifier needs only a block header they trust (from any surviving copy of the chain, the archives, or their own
+node) plus the published inputs to validate the entire derivation.
+
+### 4.5 Sign-off procedure
+
+**REQ-STA-037** Each S1/weekly/S2 artifact set SHALL be attested before on-chain use by: the Vendor (engineering
+sign-off), Overclock Labs (client sign-off), and at least two independent `akashnet-2` community validators who
+ran the verifier implementation on their own archive data. Attestations are detached signatures over
+`manifest.json`, published alongside it; signer key policy per [08](./08-security-and-audits.md).
+
+**REQ-STA-038** Discrepancy escalation: any REQ-STA-012/021/033/034 failure or substantiated public objection
+freezes publication/arming, opens an incident per doc 08, and requires re-run plus re-attestation; for S1 the
+fallback is delaying claims-open, never shipping an unverified root (doc 10 carries the schedule contingency).
+
+## 5. Sunset upgrade specification (the final Cosmos upgrade)
+
+Per D-18, cutover C is enforced by one last software upgrade on `akashnet-2` (working name **`v3.0.0-sunset`**)
+that (a) installs a message allow-list, (b) raises the fee floor, and (c) caps block gas. It deliberately changes
+**no state layout**, so exports remain schema-stable across C→H (A-01).
+
+### 5.1 Implementation route
+
+**REQ-STA-039** The sunset upgrade SHALL be implemented as one additional upgrade in the existing
+self-registering plugin system (`upgrades/types/types.go` `RegisterUpgrade`, blank-imported via
+`upgrades/upgrades.go`, installed at `app/upgrades.go:34-56`), following ADR-001 conventions
+(`_docs/adr/adr-001-network-upgrades.md`): directory `upgrades/software/v3.0.0-sunset/` with `upgrade.go`/
+`init.go`, changelog entry, and the e2e upgrade suite run against a testnetified mainnet snapshot
+(`script/upgrades.sh`, §9). Urgent post-C fixes use `RegisterHeightPatch` (BeginBlocker, `app/app.go:446-454`).
+
+**REQ-STA-040** The sunset upgrade SHALL NOT add, delete, or re-key any KV store, and SHALL NOT run state
+migrations that alter genesis-export schemas; permitted writes are limited to parameter values (consensus MaxGas
+per REQ-STA-045), enforced by comparing pre/post store lists in the upgrade test.
+
+The filter is an ante-handler decorator (the ante chain is currently stock, `app/ante.go:46-58`) prepended to the
+fee decorators; it applies to every transaction from block `h_up` onward, in both CheckTx and DeliverTx.
+
+### 5.2 Message allow-list (post-S1, C→H)
+
+Default-deny. Type URLs follow the module versions served by the discovery service (deployment `v1beta4`, market
+`v1beta5`) [TO-VERIFY: exact type URL strings against `pkg.akt.dev/go` at the release tag current at C].
+
+| Module | Allowed messages | Rationale |
+|---|---|---|
+| escrow | `MsgAccountDeposit` | Top-ups keep running leases funded (D-08). Claim-inert (REQ-STA-005) |
+| market | `MsgCloseBid`, `MsgCloseLease`, `MsgWithdrawLease`, `MsgLeaseStartReclaim` | Wind-down verbs: settle, withdraw, close, reclaim (D-24) |
+| deployment | `MsgCloseDeployment`, `MsgCloseGroup`; `MsgPauseGroup` (SHOULD) | Close verbs per D-08; pause is strictly spend-reducing and creates no market state |
+| bme | `MsgBurnACT` only | Lets `uact` holders (e.g. escrow refunds) obtain `uakt` for gas; ACT→AKT stays allowed under CR-halt as today |
+| bank | `MsgSend`, `MsgMultiSend` | See §5.4 |
+| wasm | `MsgExecuteContract` **only** where contract = the Pyth price contract (`akash1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrqyagled`) | Oracle keep-alive, §5.4 |
+| oracle | `MsgAddPriceEntry` | Emitted by the Pyth contract; sole authorized source unchanged |
+| staking / slashing / distribution | All (delegate, undelegate, edit/create validator, unjail, withdraw rewards/commission, set withdraw address) | Consensus must keep operating C→H (§6); economically inert post-S1 (REQ-STA-003) |
+| gov | `MsgVote`, `MsgVoteWeighted`, `MsgDeposit`; `MsgSubmitProposal` restricted per REQ-STA-043 | Emergency governance only |
+| authz | `MsgExec` (recursively filtered), `MsgRevoke`; `MsgGrant` only for `/akash.escrow.v1.DepositAuthorization` | Sponsored top-ups keep working (D-21 seam); everything else revocation-only |
+| feegrant | `MsgGrantAllowance`, `MsgRevokeAllowance` | Fee sponsorship eases wind-down UX |
+| cert | `MsgRevokeCertificate` only | Security action for certs still used by running-lease mTLS; creation rejected (D-10); tenants whose certs expire C→H use the provider JWT auth path ([07](./07-offchain-and-clients.md)) |
+| ibc | Client messages (`MsgUpdateClient`, misbehaviour, upgrade), packet lifecycle (`MsgRecvPacket`, `MsgAcknowledgement`, `MsgTimeout`, `MsgTimeoutOnClose`) | Required for inbound returns and in-flight packet resolution (§5.5) |
+| evidence | `MsgSubmitEvidence` | Consensus security through H |
+| upgrade (via gov) | `MsgSoftwareUpgrade`, `MsgCancelUpgrade` | Halt scheduling and emergency response |
+
+**Rejected** (anything not allow-listed; notably): `MsgCreateDeployment`, `MsgUpdateDeployment`, `MsgStartGroup`,
+`MsgCreateBid`, `MsgCreateLease`, `MsgCreateProvider`, `MsgUpdateProvider`, `MsgCreateCertificate`, audit
+`MsgSignProviderAttributes`/`MsgDeleteProviderAttributes`, `MsgMintACT`, `MsgBurnMint`, `MsgFundVault`, ICS-20
+`MsgTransfer` (outbound), IBC channel/connection handshakes, wasm store/instantiate/migrate/admin messages,
+vesting-account creation, `MsgVerifyInvariant`.
+
+**REQ-STA-041** The allow-list above is normative and default-deny: the ante decorator SHALL reject any
+transaction containing a message whose type URL is not explicitly allowed, before fee deduction, with a
+deterministic error code and an emitted rejection event carrying the offending type URL.
+
+**REQ-STA-042** The filter SHALL apply recursively to wrapped messages (`authz.MsgExec` inner messages and every
+message nested in `gov.MsgSubmitProposal`) with a bounded unwrap depth (≥ 3); a transaction is rejected if *any*
+nested message fails the filter.
+
+**REQ-STA-043** `MsgSubmitProposal` SHALL be accepted only when every nested message is one of
+`MsgSoftwareUpgrade`, `MsgCancelUpgrade`, or a module `MsgUpdateParams`: emergency parameter and upgrade
+governance only; community-pool spends and arbitrary executions are rejected. Expedited proposals SHOULD be used
+for emergencies [TO-VERIFY: expedited gov params live on mainnet].
+
+### 5.3 Fee floor and block-gas cap
+
+Minimum gas price on Cosmos is node-local configuration, not consensus; it cannot be relied on for a
+network-wide floor. Note also that post-S1 old-AKT tends toward zero market price, so *no* fee level is a strong
+economic barrier; the floor is a rate-limiter, and the real spam bound is the allow-list plus block gas.
+
+**REQ-STA-044** The sunset upgrade SHALL enforce a consensus-level global minimum gas price in the ante chain,
+compiled in as a constant: provisional **0.5 uakt/gas** (20× the community floor of 0.025 uakt; final value per
+Q-17), alongside updated recommended node config; changes to the constant ship via height patch (REQ-STA-039).
+
+**REQ-STA-045** The upgrade handler SHALL set consensus `block.max_gas` to a reduced cap, provisional
+**30,000,000** [TO-VERIFY: consensus params currently live on akashnet-2; the SDK default is unlimited],
+bounding worst-case spam throughput on a chain whose gas token has lost claim value.
+
+### 5.4 Rationale notes (normative context)
+
+- **Bank sends stay enabled.** (a) Post-S1 transfers are claim-inert (REQ-STA-003): claims were fixed at S1, so
+  moving old-AKT cannot move claim value; the exfiltration surface is *leaving the chain*, which is blocked.
+  (b) Wallets, exchange consolidation sweeps, and own-account gas top-ups require plain sends; blocking them
+  breaks wind-down UX for zero benefit. (c) Module accounts cannot receive external sends anyway (`app/app.go:85`).
+- **Oracle keep-alive.** The wind-down path *needs* live AKT/USD prices until H: BME CR computation (a zero price
+  forces `halt_oracle`, which blocks even ACT→AKT refunds), the escrow AKT-fallback settlement, and `MsgBurnACT`
+  execution all consume the oracle. Hence the pinned `MsgExecuteContract` + `MsgAddPriceEntry` allowance, and:
+
+**REQ-STA-046** Overclock SHALL keep the Pyth price-pusher (Hermes feeder) operating against the old chain until
+H, with §6-style monitoring; a stale oracle during C→H is an incident (doc 12 risk), not an acceptable
+degradation.
+
+### 5.5 IBC policy: outbound blocked, inbound feeds redemption
+
+Outbound ICS-20 (`MsgTransfer`) is rejected from `h_up` to prevent post-snapshot exfiltration of claim-inert AKT
+to DEX venues where it could be sold to buyers unaware that claims are fixed at S1. Inbound remains fully
+operational: each returning voucher releases coins from the (reserved) transfer escrow to the recipient, credited
+as class F10 (§3.2), the on-chain half of the D-07 redemption design. Returns during C→H are thus honored
+*automatically* via weekly residuals; only post-H stragglers need the foundation redemption process (doc 05).
+
+**REQ-STA-047** The filter SHALL reject ICS-20 `MsgTransfer` while allowing client-update and packet lifecycle
+messages, so inbound returns complete and outbound packets in flight at S1 resolve (ack or timeout-refund,
+credited as F11); relayer operation for the active channels is an Overclock ops obligation until H.
+
+### 5.6 Halt mechanics at H
+
+**REQ-STA-048** The halt SHALL be consensus-enforced via a governance-scheduled upgrade plan (working name
+`v3.1.0-halt`) at height `h_S2 + 1` for which **no binary is ever released**: `x/upgrade` halts every node at
+that height deterministically; the last committed block is `h_S2 = H`, the S2 export height. Belt-and-braces:
+recommended node config for the final week sets `halt-height = h_S2 + 1`, and operators are instructed not to
+enable Cosmovisor auto-download. Emergency deferral of H uses `MsgCancelUpgrade` + a new plan (REQ-STA-043).
+
+## 6. Validator continuity C→H
+
+### 6.1 Problem
+
+From `h_up`, block rewards are paid in old-AKT that is excluded from claims (REQ-STA-003): validating
+`akashnet-2` earns nothing real for 90 days while costs continue. Unmitigated, validators unbond and shut down,
+and the chain loses liveness (> 1/3 voting power offline) before H, stranding running leases, escrow refunds,
+and the residual pipeline itself.
+
+### 6.2 Wind-down incentive
+
+**REQ-STA-049** The S1 accounting SHALL reserve a **validator continuity budget** as an explicit Wind-down
+Reserve line item (`reserved_pool_ledger.csv`), sized by governance input per Q-13, paid in target-chain AKT at
+S2, not weekly, so the incentive binds operators to the full window.
+
+**REQ-STA-050** The S2 payout SHALL be pro-rata by measured participation: default formula
+`weight_i = signed_blocks_i × min(power_i, p95_power_cap)` over C→H, with eligibility requiring ≥ 90% of expected
+blocks signed while in the active set and active-set membership ≥ 80% of the window; the cap prevents the payout
+from simply mirroring stake concentration. Formula constants are Provisional pending Q-13 ratification.
+
+### 6.3 Measurement
+
+**REQ-STA-051** Uptime SHALL be computed from raw block data (`LastCommit` signatures in the archived blockstore)
+by both pipeline implementations, cross-checked against `x/slashing` signing-info counters (30,000-block window
+per mainnet params), and published as `validator_continuity.csv` (§2.4) with the S2 verification window.
+
+### 6.4 Minimum viable set and monitoring
+
+**REQ-STA-052** Wind-down monitoring (doc 10 runbook) SHALL alert on: active validators < 40; any consecutive
+24 h with > 20% of bonded power jailed or offline; or projected voting-power liveness < 45% within 7 days.
+Escalation: foundation delegations to healthy validators and/or activation of standby validators operated by
+Overclock; these actions are pre-authorized in the cutover runbook.
+
+### 6.5 Slashing stays active; the equivocation gap
+
+Slashing and jailing remain fully active C→H (downtime jailing; 5% double-sign slash), but post-S1 slashed
+old-AKT has no claim value: **the continuity payout is the only real economic stake** against equivocation.
+
+**REQ-STA-053** Any validator tombstoned or slashed for equivocation during C→H SHALL forfeit its entire
+continuity payout; downtime jailing does not forfeit but reduces `signed_blocks_i` naturally. This forfeiture is
+the migration-era replacement for slashing's economic deterrent and MUST be stated in the Q-13 program terms.
+
+## 7. Archives (D-18)
+
+### 7.1 Artifacts
+
+| Archive artifact | Contents | Format |
+|---|---|---|
+| Genesis exports | S1, all 12 weekly heights, S2 (H) | JSON, zstd-compressed |
+| Full node data directory | `application.db`, `blockstore.db`, `state.db`, `tx_index.db` from a `pruning=nothing` archive node at H; complete replayable history | tar + zstd |
+| Event archive | Per-block ABCI events and tx results extracted for indexer-independent analysis | JSONL + Parquet |
+| Indexer database dump | Full history DB (deployments, leases, settlements), the system of record for history per D-23 | `pg_dump` custom format |
+| Static explorer build | Browsable read-only explorer over the archived data | Static site bundle |
+| Migration artifact set | Every §2.4 artifact, manifest, signatures, tool releases (source + container digests) | As produced |
+| Wasm contract inventory | Code blobs + state for pyth/pyth_pro/pyth_vaa/wormhole | tar + zstd |
+
+**REQ-STA-054** The Vendor SHALL produce the complete artifact table above within 14 days of H, with the
+archive-node data directory captured immediately at halt.
+
+### 7.2 Integrity
+
+**REQ-STA-055** A single top-level archive manifest SHALL list SHA-256 checksums of every artifact, be signed by
+the REQ-STA-037 attestor set, and be published in the docs repository and on the claim portal.
+
+**REQ-STA-056** The archive manifest hash SHOULD additionally be anchored on the target chain (Solana: a
+memo/account written by the D-11 authority; EVM: an event emitted by `MigrationClaims`), making archive integrity
+verifiable from the chain that survives.
+
+**REQ-STA-057** A restore drill SHALL validate the archives before decommission: boot a node from the archived
+data directory, replay ≥ 1,000 blocks, and restore the indexer dump; results attached to the archive manifest.
+
+### 7.3 Hosting, retention, access
+
+**REQ-STA-058** Archives SHALL be published as (a) public BitTorrent with a foundation-run seed and (b) at least
+two independent cloud mirrors (provider and funding per Q-09), retention ≥ 5 years (Q-09 confirms), with
+download instructions preserved in the permanent docs.
+
+## 8. Old-chain infrastructure decommission (H → H+90d)
+
+**REQ-STA-059** The following checklist SHALL be executed in order between H and H+90d, each item with an owner
+and date recorded in the doc 10 runbook:
+
+| # | Item | Action |
+|---|---|---|
+| 1 | Public RPC/gRPC/REST endpoints (`rpc.akash.network` et al.) | Serve HTTP 410 + JSON pointer to archives/claim portal for 90 days, then remove |
+| 2 | `snapshots.akash.network` | Stop publication; keep the final H snapshot listed, marked terminal |
+| 3 | `akash-network/net` repo `mainnet/meta.json` | Mark network halted: final height H, halt timestamp, archive manifest URL |
+| 4 | Cosmos chain-registry entry | PR marking `akashnet-2` as killed, pointing to migration docs |
+| 5 | Seed/persistent-peer nodes | Shut down after item 3 lands |
+| 6 | Monitoring/alerting for old-chain infra | Retire dashboards; export final metrics to the archive |
+| 7 | DNS | Repoint chain hostnames to a static sunset page (archives, claim portal, docs) |
+| 8 | Docs | Banner every old-chain page; wallet/exchange partners notified to delist the chain (not the token) |
+| 9 | Release channels (Homebrew tap, install.sh, container registry) | Mark old-chain binaries archived; do not delete |
+
+**REQ-STA-060** Permanent survivors (never decommissioned): the archives (§7), the claim portal (for the full
+claim windows per D-05: 2 years from S1, residuals 2 years from S2), and the migration documentation set.
+
+## 9. Migration rehearsal requirements
+
+The repo ships fork-from-mainnet tooling: `akash in-place-testnet` (testnetify) rewrites a mainnet snapshot into
+a locally controlled chain, wiping validator/unbonding stores, injecting test validators, overriding gov periods
+(`cmd/akash/cmd/testnetify/`, `app/testnet.go`), and the upgrade test harness (`script/upgrades.sh`) already
+downloads a snapshot, testnetifies it, and runs tagged e2e upgrade suites. The rehearsals build on this tooling.
+
+**REQ-STA-061** The Vendor SHALL run **three full dry-runs (R1, R2, R3)** on forked mainnet state before the
+production S1, each covering: sunset upgrade execution via the plugin system → S1 export + artifact build +
+dual-implementation gate → a time-compressed wind-down (≥ 2 weekly residual cycles exercising classes F1–F12,
+including forced overdrawn accounts, AKT-fallback under a simulated BME halt, grant-sourced refunds, and IBC
+returns) → halt plan → S2 including the final virtual settlement → archive production and restore drill.
+
+**REQ-STA-062** R3 is the dress rehearsal: production tool versions frozen (the container digests that will be
+used at C), the full attestor set signing, and a public verification window on the rehearsal artifacts; pass
+criteria (zero root mismatches, zero unclassified flows, budgets per REQ-STA-019 met) are defined and measured
+per [09. Testing & verification](./09-testing-and-verification.md).
+
+**REQ-STA-063** No production S1 SHALL occur until R3 has passed with zero discrepancies; a failed rehearsal
+restarts the R-count clock for the failed stages (doc 10 gate dependency).
+
+R4 (the final dress rehearsal at S1−14d, defined in [10. Rollout & cutover](./10-rollout-and-cutover.md)
+§4.1) re-runs the frozen R3 configuration on fresh mainnet-fork state; its pass criteria are R3's.
+
+## Cross-references
+
+- [05. Token migration](./05-token-migration.md): supply equation, claim mechanics, Reserve seeding, D-07 redemption, unclaimed policy.
+- [01. Current architecture](./01-current-architecture.md): module state shapes and escrow mechanics cited throughout.
+- [03. Solana architecture](./03-solana-architecture.md) / [04. Ethereum architecture](./04-ethereum-architecture.md): claims program/contract consuming the roots.
+- [07. Off-chain & clients](./07-offchain-and-clients.md): indexer (history system of record), JWT auth replacing x/cert, linkage surfacing.
+- [08. Security & audits](./08-security-and-audits.md): attestor key policy, incident response.
+- [09. Testing & verification](./09-testing-and-verification.md): rehearsal pass criteria, upgrade test harness.
+- [10. Rollout & cutover](./10-rollout-and-cutover.md): runbook slots for every schedule in this doc; decommission ownership.
+- [13. Open questions](./13-open-questions-and-assumptions.md): Q-02, Q-03, Q-09, Q-10, Q-13, Q-17, Q-18, Q-19; A-01, A-02.
+
+## Feeds into
+
+- **05** consumes: S1 claim sets, ACT ledger seed, vesting inventory, reserved-pool ledger, IBC per-channel ledger, dust ledger.
+- **09** consumes: rehearsal scope (R1–R3), dual-implementation gate, property-check list as test oracles.
+- **10** consumes: sunset/halt governance sequencing, export schedule, verification windows, decommission checklist, continuity monitoring thresholds.
+- **11** consumes: migration-engine, verifier, sunset-upgrade, and archive workstreams as SOW deliverables.
+- **12** consumes: oracle keep-alive, validator attrition, equivocation-gap, and root-mismatch risks.
+- **14** consumes: the allow-list and disposition tables for the exhaustive mapping appendix.

--- a/spec/aep-79/doc/07-offchain-and-clients.md
+++ b/spec/aep-79/doc/07-offchain-and-clients.md
@@ -1,0 +1,651 @@
+# 07. Off-chain Services & Clients
+
+| | |
+|---|---|
+| **Document** | 07. Off-chain services & clients |
+| **Doc ID** | AKASH-MIG-07 |
+| **Version** | 0.9 (draft for review) |
+| **Date** | 2026-08-10 |
+| **Owner** | Overclock Labs |
+| **Audience** | Vendor engineering (off-chain / infrastructure workstream) |
+| **Status** | Normative where marked (MUST/SHALL); informative otherwise |
+
+## Purpose
+
+Specify how every off-chain component of the Akash ecosystem (the provider daemon, Console, indexers, SDKs,
+CLI, wallets, explorers, RPC infrastructure, and provider/tenant authentication) is adapted to the target
+chain selected at Gate 0. On-chain program/contract designs live in [03](./03-solana-architecture.md) /
+[04](./04-ethereum-architecture.md); this document defines the client contracts against them.
+
+## In scope
+
+- Blast-radius inventory of all off-chain consumers of `akashnet-2` and their replacements.
+- The `pkg/chain` adapter for provider-services, including the Solana signer sidecar (D-17).
+- Provider/tenant authentication redesign (D-10) and manifest-flow invariants (D-09).
+- Indexer requirements and architecture (D-16); Console/API compatibility (A-11).
+- SDKs, CLI command mapping, version negotiation, wallets, explorers, RPC, fee UX, claim tooling.
+
+## Out of scope
+
+- Program/contract instruction-level design: [03](./03-solana-architecture.md), [04](./04-ethereum-architecture.md).
+- Token claim mechanics and Merkle tree formats: [05](./05-token-migration.md).
+- Archive production and old-chain data export: [06](./06-state-and-data-migration.md).
+- Cutover scheduling and governance gates: [10](./10-rollout-and-cutover.md) (§9 here covers off-chain ordering only).
+
+---
+
+## 1. Component inventory & blast radius
+
+Everything below currently speaks to `akashnet-2` through one of four seams: the shared Go type/client contract
+(`pkg.akt.dev/go` v0.2.14, pinned in `go.mod`), CometBFT RPC/websocket events, grpc-gateway REST queries, or
+the x509/JWT provider-gateway trust root. All four seams change.
+
+| Component | What it is | What breaks | Replacement | Owner | Detail |
+|---|---|---|---|---|---|
+| provider-services | Go daemon (`akash-network/provider`) on the provider's Kubernetes cluster: bid engine, manifest server, lease operators | All chain I/O: tx submission, queries, CometBFT event subscriptions, x/cert lookups | `pkg/chain` adapter + per-target implementation (§2); JWT-only gateway auth (§3) | Vendor (adapter) + Overclock (release/ops) | §2, §3 |
+| Console web + Console API | Tenant web app + REST API (`akash-network/console` monorepo) incl. managed wallets, trials | Wallet layer (Keplr/Leap), tx building, fee grants, indexer backend | Target-chain wallet adapters, chain-sdk v2, sponsorship service (§6) | Overclock (Vendor supplies SDK/indexer) | §5, §6 |
+| Chain indexer | Console's chain scraper → Postgres (powers Console API + stats) | CometBFT block/event ingestion, bech32/txhash formats | New indexer per D-16 (§4); old DB imported read-only | Vendor build; ops per Q-07 | §4 |
+| `@akashnetwork/chain-sdk` (TS) | Tenant/tooling SDK; negotiates API version via discovery (`testutil/network/rpc.go:12`) | Everything (Cosmos tx/query/proto stack) | chain-sdk v2: Codama client (Solana) / viem (EVM) (§5.1) | Vendor | §5 |
+| `pkg.akt.dev/go` + `/cli` | Shared Go contract: proto types, denoms, sdkutil, entire CLI trees (`cmd/akash/cmd/root.go:69-87`) | Everything; the node repo itself consumes it | Go SDK v3 hosting `pkg/chain` types + generated bindings (§5.2) | Vendor | §5 |
+| `akash` CLI | User CLI (root `akash`, env prefix `AKASH`) | All `tx`/`query`/`keys`/`events` subtrees | `akash` CLI v3 (§5.3) with command-map parity | Vendor | §5.3 |
+| Wallets | Keplr, Leap (+ Ledger via them) | Chain unsupported post-halt | Phantom/Solflare/Backpack/Ledger or MetaMask/Coinbase Wallet/Rabby/Ledger (§6.1); Keplr/Leap retained for claims | Third party; integration Overclock | §6 |
+| Explorers | Mintscan et al. | Coverage ends at halt H | Solscan/SolanaFM or Basescan + Console public pages; static archive explorer | Third party / Overclock | §7.1 |
+| `akash-network/net` `meta.json` | Chain registry (RPC endpoints, versions, upgrade matrix) at `https://raw.githubusercontent.com/akash-network/net/master/mainnet/meta.json` | Schema is Cosmos-shaped | New schema: program/contract addresses, cluster, indexer + sponsorship URLs; on-chain `akash-config` is authoritative (§5.4) | Overclock | §5.4 |
+| snapshots.akash.network | Node snapshot host (`/<network>/latest`) | No sovereign nodes to bootstrap post-halt | Serve old-chain snapshots until H+90d (D-18); then archive per 06 | Overclock | [06](./06-state-and-data-migration.md) |
+| Pyth Hermes price-feeder | Off-chain pusher (`_run/node/price-feeder.sh`, `_docs/pyth-integration.md`) feeding the CosmWasm Pyth contract | Obsolete: targets read Pyth pull feeds natively (D-13, D-22) | None; settlement/BME cranks post Pyth updates in-tx (03/04) | none (retired) | [03](./03-solana-architecture.md) |
+| Rosetta API | Coinbase Rosetta/Mesh endpoint wired at `cmd/akash/cmd/root.go:79` | Cosmos-specific | Dropped. Exchanges use native target-chain integrations; no Akash-specific Mesh work | none (retired) | [05](./05-token-migration.md) §exchanges |
+| Discovery service | `GET /akash/discovery/v1/info` + gRPC `GetInfo`: chain_id, `min_client_version`, per-module API versions | Served by the node; node goes away | `akash-config` on-chain version registry + client-side enforcement (§5.4) | Vendor | §5.4 |
+
+**REQ-OFF-001** Every component in the table above MUST have a named owner and a written migration plan
+(issue-tracked) before Gate G2 as defined in [10](./10-rollout-and-cutover.md).
+
+**REQ-OFF-002** After cutover C, no supported client or service may require a Cosmos dependency (bech32
+parsing, CometBFT RPC, amino/proto registry) except: (a) the claim portal's old-chain proof flow (§8) and
+(b) read-only archive tooling per [06](./06-state-and-data-migration.md).
+
+**REQ-OFF-003** All off-chain components MUST treat the indexer as the only source of *historical* protocol
+state, and the chain as the only *authoritative* source of live state (D-23: terminal-state accounts are
+closed; events are the system of record for history).
+
+## 2. provider-services adaptation (D-17)
+
+provider-services is the deepest integration and the one whose failure stops the marketplace's supply side.
+Design goal: the daemon's Kubernetes orchestration, bid pricing, and manifest logic remain untouched; all
+chain awareness moves behind one Go interface.
+
+### 2.1 Integration surface today
+
+- **Reads:** grpc queries for orders/bids/leases/deployments/groups, escrow accounts/payments, provider +
+  audited attributes (`x/market`, `x/deployment`, `x/escrow`, `x/provider`, `x/audit`).
+- **Writes:** `MsgCreateBid` (with escrow collateral per `BidMinDeposits`), `MsgCloseBid`, `MsgWithdrawLease`
+  (settle + payout), `MsgLeaseStartReclaim` (D-24), `MsgCreateProvider`/`MsgUpdateProvider`,
+  `MsgAccountDeposit` (collateral top-up).
+- **Events:** CometBFT websocket subscription → typed events (`pkg.akt.dev/go/sdkutil/event.go`,
+  `EventTypeMessage = "akash.v1"`) → in-process pubsub bus (`pubsub/bus.go`), consumed by
+  `bidengine/{service,order}.go`.
+- **Auth:** x/cert server cert + client-cert validation, plus JWT (`_run/common-commands.mk:49-84` already
+  exercises `--auth-type` JWT and an auth server); see §3.
+
+### 2.2 The `pkg/chain` adapter interface
+
+**REQ-OFF-004** The Vendor SHALL extract a chain-neutral Go package `pkg/chain` in provider-services whose
+interface is the *only* path between the daemon and any chain; no target-chain SDK type may appear outside
+implementations of this interface.
+
+The normative shape (naming MAY vary; capabilities MUST NOT):
+
+```go
+type Client interface {
+    Query() QueryClient
+    Tx() TxClient
+    // StartEvents pumps normalized events into the daemon's pubsub bus
+    // (pubsub/bus.go contract) until ctx cancels; performs
+    // snapshot-then-stream reconciliation (REQ-OFF-010).
+    StartEvents(ctx context.Context, bus pubsub.Publisher) error
+    Health(ctx context.Context) (Health, error) // head slot/block, feed lag, signer status
+}
+
+type QueryClient interface {
+    // Authoritative single-entity reads (direct chain state).
+    Deployment(ctx, DeploymentID) (Deployment, error)   // incl. ADR-002 manifest Hash
+    Group(ctx, GroupID) (Group, error)
+    Order(ctx, OrderID) (Order, error)
+    Bid(ctx, BidID) (Bid, error)
+    Lease(ctx, LeaseID) (Lease, error)
+    EscrowAccount(ctx, EscrowAccountID) (EscrowAccount, error) // funds, depositors, settled-at
+    EscrowPayment(ctx, EscrowPaymentID) (EscrowPayment, error) // rate, accrued balance, withdrawn
+    Provider(ctx, Address) (Provider, error)
+    AuditedAttributes(ctx, Address) ([]AuditedAttributes, error)
+    // Set reads (MAY be indexer-served; used for startup reconciliation).
+    OpenOrders(ctx, OrderFilter) ([]Order, error)
+    OpenBids(ctx, provider Address) ([]Bid, error)
+    ActiveLeases(ctx, provider Address) ([]Lease, error)
+    MarketParams(ctx) (MarketParams, error) // incl. BidMinDeposits, reclamation bounds
+    Balance(ctx, Address, denom string) (Coin, error)
+}
+
+type TxClient interface { // every method idempotent under retry (REQ-OFF-017)
+    CreateBid(ctx, CreateBidRequest) (BidID, TxRef, error) // price, resources offer, collateral, reclamation window
+    CloseBid(ctx, BidID) (TxRef, error)
+    StartLeaseReclaim(ctx, LeaseID, Reason) (TxRef, error)
+    SettleAndWithdraw(ctx, []LeaseID) ([]TxRef, error)     // batched earnings withdrawal
+    DepositEscrow(ctx, EscrowAccountID, Coin) (TxRef, error)
+    RegisterProvider(ctx, ProviderRecord, collateral Coin) (TxRef, error)
+    UpdateProvider(ctx, ProviderRecord) (TxRef, error)
+}
+```
+
+**REQ-OFF-005** `QueryClient` single-entity reads MUST be served from chain state (not the indexer) whenever
+the result gates a funds-moving or bid decision; set reads MAY be indexer-served but MUST be verified against
+chain state before acting (fetch-before-bid).
+
+**REQ-OFF-006** Lease-creation (`MsgCreateLease` analogue) is tenant-side and is intentionally absent from
+`TxClient`; the daemon only observes `LeaseCreated`. Tenant write paths live in the SDKs (§5).
+
+**REQ-OFF-007** The adapter MUST expose escrow payment balances with enough fidelity for the daemon to
+reproduce today's withdrawal scheduling (accrued-but-unwithdrawn balance per lease, per-second rate per D-21),
+and `SettleAndWithdraw` MUST invoke the permissionless settle entrypoint before withdrawal.
+
+### 2.3 Event feed and the pubsub bus contract
+
+The in-process bus (`pubsub/bus.go`) gives the bid engine: asynchronous fan-out (a slow subscriber never
+blocks publishers or peers; per-subscriber buffering), per-subscriber FIFO ordering in publish order, and
+`Subscriber.Clone()` that inherits not-yet-emitted buffered events (relied on by `bidengine/{service,order}.go`
+when spawning per-order monitors). The chain adapter feeds this bus.
+
+**REQ-OFF-008** `StartEvents` MUST preserve the bus contract: events for a given entity ID are published in
+on-chain order, and publishing MUST NOT block on subscriber consumption.
+
+**REQ-OFF-009** Delivery is at-least-once; the adapter MUST de-duplicate before publishing, keyed by
+`(chain_id, tx_signature|log_id, event_index)`, across reconnects and process restarts within a configurable
+window (default 10 minutes).
+
+**REQ-OFF-010** On startup or stream gap, the adapter MUST reconcile: list open orders / own open bids / own
+active leases via `QueryClient`, synthesize the corresponding events into the bus, then attach the live stream
+from a cursor at or before the snapshot point (overlap de-duplicated per REQ-OFF-009).
+
+**REQ-OFF-011** Event mapping MUST cover at least the following (full protocol event inventory in
+[14](./14-appendix-protocol-mapping.md)):
+
+| pubsub bus event (daemon) | Cosmos source today | Solana source | EVM source |
+|---|---|---|---|
+| `OrderCreated` / `OrderClosed` | `akash.market.v1.EventOrderCreated/Closed` | `akash-market` CPI events `OrderCreated/Closed` | `Marketplace` logs `OrderCreated/Closed` |
+| `BidCreated` / `BidClosed` | `EventBidCreated/Closed` | `BidCreated/Closed` | `BidCreated/Closed` |
+| `LeaseCreated` / `LeaseClosed` | `EventLeaseCreated/Closed` | `LeaseCreated/Closed` | `LeaseCreated/Closed` |
+| `LeaseReclaimStarted` | `EventLeaseReclaimStarted` | `LeaseReclaimStarted` | `LeaseReclaimStarted` |
+| `DeploymentUpdated` (manifest hash) | `akash.deployment.v1.EventDeploymentUpdated` | `akash-deployment` `DeploymentUpdated` | `DeploymentRegistry` `DeploymentUpdated` |
+| `DeploymentClosed` | `EventDeploymentClosed` | `DeploymentClosed` | `DeploymentClosed` |
+| `GroupPaused/Started/Closed` | `EventGroupPaused/Started/Closed` | group events | group events |
+| `EscrowPaymentOverdrawn` | none today (x/escrow emits no events; surfaced via market hooks) | `akash-escrow` `PaymentOverdrawn` | `EscrowVault` `PaymentOverdrawn` |
+| `ProviderUpdated` | `akash.provider.v1beta4.EventProviderUpdated` | `akash-provider-registry` event | `ProviderRegistry` log |
+
+**REQ-OFF-012** The target programs/contracts MUST emit explicit escrow settlement/overdraw events (closing
+today's gap where escrow state changes are only observable via market hooks); the adapter maps them to
+`EscrowPaymentOverdrawn`/`EscrowAccountClosed` bus events.
+
+### 2.4 Solana specifics
+
+```mermaid
+flowchart LR
+  subgraph provider K8s cluster
+    D[provider-services daemon<br/>bid engine + operators] -- pkg/chain --> A[solana adapter]
+    A -- localhost gRPC --> S[signer sidecar<br/>Rust or TS]
+  end
+  A -- HTTPS getAccountInfo/getProgramAccounts --> RPC[(RPC provider x2)]
+  A -- websocket/webhook stream --> GY[Geyser plugin or<br/>Helius-class webhooks]
+  S -- signed tx, priority fee --> RPC
+  IDX[(indexer, §4)] -. set reads .-> A
+```
+
+**Read path.** Indexer-fed stream + webhook/Geyser events for reactivity; direct `getAccountInfo` /
+`getMultipleAccounts` (Borsh-decoded via generated layouts) for authoritative checks before any bid or
+withdrawal decision; `getProgramAccounts` with discriminator+owner memcmp filters for startup reconciliation
+when the indexer is down.
+
+**REQ-OFF-013** The Solana adapter MUST make bid decisions on state read at `confirmed` commitment or stronger
+and MUST record the observed slot; funds-withdrawal accounting MUST be confirmed at `finalized` (~12.8 s
+pre-Alpenglow as of 2026-08; re-verify under A-13) before being marked complete in daemon state.
+
+**Write path.** Two candidate implementations; decision at Gate G1 after the Q-15 prototype:
+
+1. **Pure Go:** tx assembly/signing via a Go Solana client (`gagliardetto/solana-go` is the de-facto library;
+   FROM-TRAINING; `[TO-VERIFY: solana-go maintenance status and current-RPC compatibility at kickoff]`),
+   including compute-budget instructions and priority fees.
+2. **Signer sidecar (default plan of record):** a co-located Rust or TypeScript service using first-party
+   SDKs, running in the daemon pod, speaking gRPC on localhost/UDS.
+
+**REQ-OFF-014** If the sidecar is used, its API SHALL be:
+
+```proto
+service AkashSigner {
+  rpc SignAndSend(SignAndSendRequest) returns (SignAndSendResponse);
+  rpc Simulate(SimulateRequest) returns (SimulateResponse);
+  rpc PublicKeys(Empty) returns (PublicKeysResponse);   // operator pubkeys available
+  rpc Health(Empty) returns (HealthResponse);           // RPC lag, blockhash freshness, key status
+}
+message SignAndSendRequest {
+  bytes  ix_batch = 1;            // serialized instruction list: (program_id, accounts, data)[]
+  string dedup_key = 2;           // caller-generated; result cached >=24h (REQ-OFF-017)
+  PriorityFeePolicy fee = 3;      // AUTO_PERCENTILE{percentile, default p75} | FIXED; max_lamports_per_cu cap mandatory
+  uint32 cu_limit = 4;            // 0 => simulate and set with 20% headroom
+  repeated string lookup_tables = 5;
+  Commitment wait_for = 6;        // PROCESSED | CONFIRMED | FINALIZED
+}
+message SignAndSendResponse { string signature = 1; uint64 slot = 2; Status status = 3; string error = 4; }
+// Status: CONFIRMED | FAILED | EXPIRED | DUPLICATE (dedup_key hit)
+```
+
+**REQ-OFF-015** Sidecar key custody: private keys MUST never leave the sidecar process; supported backends are
+an encrypted file keystore (default) and a remote-signer/HSM backend; the sidecar MUST enforce a program-ID
+allowlist (Akash programs + compute-budget + token programs only), MUST reject bare SOL/token transfer
+instructions above a configured per-24h budget, and MUST bind to localhost/UDS with an auth token shared with
+the daemon.
+
+**REQ-OFF-016** The sidecar MUST implement rebroadcast-until-expiry: re-send the *identically signed*
+transaction until the blockhash expires (150-block validity, ~60–90 s), then surface `EXPIRED` rather than
+silently re-signing with a fresh blockhash (the daemon decides to retry, engaging REQ-OFF-017).
+
+**Event feed.** Primary: managed webhook/stream service (Helius-class) filtered on Akash program IDs;
+secondary: self-run Agave node with a Geyser plugin (shared with the indexer, §4.2). Both normalize Anchor CPI
+events (03 mandates `emit_cpi!` so events survive log truncation) into §2.3 bus events.
+
+### 2.5 Ethereum specifics
+
+- **Bindings:** `abigen`-generated Go bindings from the audited ABIs ([04](./04-ethereum-architecture.md)),
+  versioned with the contracts and consumed by CI.
+- **Reads:** `eth_call` against `latest` for reactive checks; balance/withdrawal accounting at the `safe` tag.
+  Some candidate host chains offer sub-second effective confirmations (e.g. ~200 ms on Base via Flashblocks, as of 2026-08).
+- **Events:** `eth_subscribe` logs over websocket with an `eth_getLogs` polling fallback; the adapter emits bus
+  events only after a configurable confirmation depth (default 4 blocks) and MUST handle reorg rollback by
+  re-checking receipts before funds actions (bus events are never retracted; daemon actions stay idempotent).
+- **Write path:** a single-sender goroutine per operator key with a nonce manager and stuck-tx gas
+  replacement; parallel throughput via multiple registered operator keys (§3.4), not nonce gymnastics.
+
+### 2.6 Retry, idempotency, ordering
+
+Today the chain runs with **unordered transactions enabled** (`authkeeper.WithUnorderedTransactions(true)`,
+`app/types/app.go:279`): the daemon can fire parallel txs without sequence contention, using timeout-based
+replay protection. Target equivalents:
+
+| Property | Cosmos today | Solana | EVM |
+|---|---|---|---|
+| Replay protection | account sequence, or unordered+timeout | (message, recent_blockhash) signature uniqueness | strict per-account nonce |
+| Parallel submission | native (unordered) | native | needs nonce manager or multiple keys |
+| Safe rebroadcast | same tx bytes | same signed tx until blockhash expiry | same nonce, replace-by-fee |
+| Duplicate-effect guard | sequence | state-level: PDA per entity | state-level: revert on exists |
+
+**REQ-OFF-017** Every `TxClient` method MUST have at-most-once *effect* semantics under arbitrary retries and
+process crashes, achieved by (a) a client-generated `dedup_key` cached by the sidecar/sender, (b) state-level
+idempotency (e.g. `CreateBid` derives the bid PDA / storage key from `(order_id, provider)` so a duplicate
+lands on "already exists", which the adapter MUST map to success-with-existing-ID) and (c) a durable local
+intent journal replayed on startup: journal entry written before first broadcast, resolved by checking chain
+state, never by assuming.
+
+**REQ-OFF-018** The bid engine's end-to-end reaction budget (order event on chain to bid transaction
+broadcast) MUST be ≤ 2 s p95 on Solana and ≤ 5 s p95 on the host chain under nominal load (verified in
+[09](./09-testing-and-verification.md) load tests). The indexer MUST NOT be in this critical path.
+
+### 2.7 Provider hot-key management
+
+**REQ-OFF-019** provider-services MUST support: (a) encrypted file keystore (default; parity with the current
+Cosmos keyring file backend), (b) a remote-signer/HSM option via the sidecar backend (REQ-OFF-015), and
+(c) split identity: the provider's on-chain owner authority (cold key, used for registration/collateral/key
+rotation) MUST be distinct from operational hot keys used for bids/withdrawals, per §3.4.
+
+**REQ-OFF-020** Operational accounts MUST work with a bounded float: earnings withdrawals pay to a configured
+payout address (cold), and documentation MUST instruct providers to fund hot keys only with gas/rent working
+capital from a treasury account (recommended auto-top-up with a cap, alerting below N days of runway).
+
+## 3. Provider & tenant authentication (D-10)
+
+### 3.1 Today
+
+Two mechanisms coexist. x/cert is NOT ported (D-10); the JWT direction is completed and generalized.
+
+- **On-chain x509 (x/cert) + mTLS.** Tenants and providers publish self-signed certs on chain
+  (`MsgCreateCertificate`; detail in [01](./01-current-architecture.md)); the provider gateway presents its
+  chain-registered server cert and validates tenant client certs against chain state
+  (`x/cert/utils/key_pair_manager.go` `Generate(notBefore, notAfter, domains)`; `x/cert/utils/utils.go`
+  `LoadAndQueryCertificateForAccount`). The chain is the trust root; there is no CA.
+- **Off-chain JWT.** `akash auth jwt --exp --nbf --access --scope` (`cmd/akash/cmd/auth.go:34-152`) mints
+  ES256K tokens signed by the tenant's keyring key via `pkg.akt.dev/go/util/jwt`. Claims: `iss` = tenant
+  address, `version: "v1"`, `leases.access ∈ full|scoped|granular`, `leases.scope` from the fixed set
+  `send-manifest, get-manifest, logs, shell, events, status, restart, hostname-migrate, ip-migrate,
+  attestation`, plus per-deployment `permissions[{provider, access, scope, dseq/gseq/oseq, services}]` for
+  granular access. Verification is provider-side only (no on-chain JWT state). A wallet-signed variant already
+  exists (`SigningMethodES256KADR36`, `pkg.akt.dev/go/util/jwt/es256kadr36.go`), a precedent for the target design.
+
+### 3.2 Provider gateway identity (server side)
+
+**REQ-OFF-021** The provider gateway MUST serve TLS with one of: (a) an ordinary web-PKI certificate for the
+hostname in the provider's registered `host_uri` (e.g. ACME/Let's Encrypt), or (b) a self-signed certificate
+whose SPKI SHA-256 hash is registered in the provider's on-chain provider-registry record.
+
+**REQ-OFF-022** Clients (Console, SDKs, CLI) MUST verify provider gateways as follows: fetch the provider
+record from chain/indexer; if `tls_spki_hashes` is non-empty, require a pinned match; else require standard
+web-PKI validation of `host_uri`'s hostname. Trust-on-first-use is prohibited.
+
+**REQ-OFF-023** The provider-registry record ([03](./03-solana-architecture.md)/[04](./04-ethereum-architecture.md))
+MUST support at least 2 concurrently valid `tls_spki_hashes` entries so certificate rotation is hitless
+(add new, roll gateway, remove old).
+
+### 3.3 Tenant credentials (client side): wallet-signed JWT
+
+Tenant mTLS client certificates are replaced by bearer JWTs presented to the provider gateway over TLS. The
+claims schema carries over from v1 with `version: "v2"` and target-native issuer formats.
+
+**REQ-OFF-024** Providers MUST accept JWTs with: registered claims `iss` (tenant address in target-native
+format), `iat`, `nbf`, `exp`; and Akash claims `version`, `leases.access`, `leases.scope`,
+`leases.permissions` semantically identical to the current `pkg.akt.dev/go/util/jwt` schema (scope names
+unchanged). CLI/SDK flag surface MUST mirror today's `--exp/--nbf/--access/--scope`.
+
+**REQ-OFF-025** Signature algorithms: Solana uses EdDSA (Ed25519) where `iss` is the base58 public key
+(address = key, no chain lookup needed). EVM uses EIP-191 `personal_sign` recovery (compact secp256k1 with
+recovery id; header `alg: "ES256K-R"`), with ERC-1271 contract-signature verification supported for smart
+accounts (EIP-4337/EIP-7702). Providers MUST reject `alg: none` and any alg not in this set.
+
+**REQ-OFF-026** Two issuance modes MUST be supported: (a) **offline-signed token**, in which the CLI/SDK signs the JWT
+directly with a local key (headless automation; parity with `akash auth jwt`); (b) **interactive challenge**, in which
+the provider gateway (or Console acting for it) issues a SIWS/SIWE-style human-readable challenge (domain,
+address, nonce, expiry); the wallet signs it; the verifier accepts the signed challenge as a short-lived
+session credential with the same scope fields. Mode (b) exists because browser wallets render raw JWS signing
+inputs as opaque bytes.
+
+**REQ-OFF-027** Providers MUST enforce `exp`/`nbf` with ≤ 30 s clock-skew tolerance, MUST bound token lifetime
+(accept `exp - iat ≤ 24 h`; default issuance remains 15 m), and MUST scope-check every gateway route against
+`leases.access/scope/permissions` exactly as the current JWT middleware does.
+
+**REQ-OFF-028** Authorization derives from on-chain lease state: a token proves key possession; the gateway
+MUST additionally verify that `iss` owns the deployment/lease being accessed (live chain read or indexer +
+chain confirm), as today.
+
+### 3.4 Provider operator keys: registration and rotation
+
+**REQ-OFF-029** The provider-registry record MUST hold a set of registered operator signing keys (pubkey,
+purpose, added-at, revoked-at), authorized to submit bids, withdrawals, and reclamation for that provider;
+adding/revoking keys requires the owner authority. At least 2 concurrent active keys MUST be supported
+(rotation without downtime); revocation MUST take effect at the next instruction/call that validates the key set.
+
+**REQ-OFF-030** Gateway responses that clients rely on for provider authenticity (e.g. attestation endpoints)
+MUST be signed by a registered operator key, and clients MUST verify against the registry.
+
+### 3.5 Manifest flow invariance (D-09, A-10)
+
+The SDL and manifest never lived on chain; only the manifest hash does (`Deployment.Hash`). Flow (tenant
+sends manifest to provider gateway (`send-manifest`), provider hashes and compares with the on-chain
+deployment hash) is unchanged.
+
+**REQ-OFF-031** Manifest hashing MUST remain byte-identical to ADR-002: version = SHA-256 of the sorted-JSON
+manifest serialization (`_docs/adr/adr-002-manifest-v2beta2.md:16`, reference implementation in
+`pkg.akt.dev/go` manifest v2beta2). The target chain's deployment record stores the same 32-byte value, and
+cross-implementation test vectors (Go, TS, Rust/Solidity where hashes are checked on-chain) MUST pass
+identical digests in [09](./09-testing-and-verification.md).
+
+**REQ-OFF-032** SDL parsing MUST continue to use the existing SDL libraries (`pkg.akt.dev/go/sdl` v0.2.2 line
+and the TS equivalent) with no schema change (D-09); any serialization change is a breaking protocol change
+requiring client sign-off.
+
+## 4. Indexing (D-16)
+
+### 4.1 Requirements (target-neutral)
+
+**REQ-OFF-033** Completeness: the indexer MUST capture 100% of protocol events emitted by Akash
+programs/contracts from deployment slot/block zero, with at-least-once ingestion and idempotent upserts keyed
+by `(chain_id, tx_signature|log_id, event_index)`; a full re-index from origin MUST be reproducible and MUST
+converge to the same database state (checksummed in CI).
+
+**REQ-OFF-034** Correctness: the indexer MUST NOT surface non-canonical data. Solana: ingest at `confirmed`,
+mark rows final at `finalized`/rooted, tolerate skipped slots (slot numbers are non-contiguous) and webhook
+gaps (backfill via `getSignaturesForAddress`); EVM: track block-hash parent links and roll back on reorg
+before re-emitting.
+
+**REQ-OFF-035** Freshness: event-on-chain to queryable-in-API MUST be ≤ 2 s p95 (Solana) / ≤ 4 s p95 (EVM host chain).
+This budget serves Console UX and provider set-reads; the bid engine does not depend on it (REQ-OFF-018).
+
+**REQ-OFF-036** The indexer MUST expose (a) the Console API REST shapes (§4.4) and (b) a streaming endpoint
+(websocket/SSE) of normalized protocol events for adapter/Console consumption.
+
+### 4.2 Solana specifics
+
+Two interchangeable ingestion frontends, both normatively supported: (a) a Geyser plugin on a self-run Agave
+node (account updates + tx notifications filtered to Akash program IDs); (b) a managed webhook/stream provider
+(Helius-class). Pipeline: ingestion → Anchor event/account decoder (from IDL) → Postgres. Run (b) primary and
+(a) as sovereignty fallback, or inverse per Q-07 operational ownership.
+
+### 4.3 Ethereum specifics
+
+Ponder-class self-hosted indexer over the contract ABIs. **Note:** the Ponder team joined Monad in 2026-02
+(roadmap-capture risk, as of 2026-08); the Vendor MUST evaluate Subsquid and Envio as alternates at kickoff
+and pick per maintenance status. The Graph is acceptable only for public composability, not as the Console
+backend (self-hosted requirement, Q-07).
+
+### 4.4 Schema & API compatibility (A-11)
+
+**REQ-OFF-037** The new indexer MUST serve the existing Console API response shapes (endpoints, field names,
+pagination) for all marketplace resources, with exactly two sanctioned deltas: address format and tx-hash
+format. Chain-specific endpoints without a successor concept (validators, staking, Cosmos gov,
+blocks-by-height) are frozen on the archive API and excluded from the new API.
+
+**REQ-OFF-038** Format versioning strategy: the API is namespaced `/v1` (frozen, old-chain archive, bech32
+`akash1…` + uppercase-hex tx hashes) and `/v2` (target-native: base58 addresses + base58 signatures on Solana;
+EIP-55 `0x…` + `0x` tx hashes on EVM). Every `/v2` record carries a `chain_id` discriminator. Clients MUST NOT
+be required to parse both formats within one namespace.
+
+### 4.5 Historical continuity across the migration
+
+**REQ-OFF-039** The old-chain indexer database (exported per [06](./06-state-and-data-migration.md)) MUST be
+imported read-only so Console renders continuous history: a tenant or provider sees `akashnet-2`
+deployments/leases (badged as archived) alongside target-chain activity. Old records retain old identifiers;
+no address rewriting.
+
+**REQ-OFF-040** Cross-chain identity join: because S1 claims publicly bind old→new addresses on chain
+([05](./05-token-migration.md)), the indexer MAY offer an opt-in mapping so "my history" spans both chains for
+claimed addresses; the join table MUST be rebuildable from on-chain claim events only.
+
+## 5. SDKs & CLI
+
+### 5.1 TypeScript: `@akashnetwork/chain-sdk` v2
+
+**REQ-OFF-041** chain-sdk v2 (same package, breaking major) MUST provide: for Solana, a Codama-generated client
+from the Anchor IDLs on `@solana/kit`; for EVM, `viem` with generated typed ABIs. The high-level API (create/close
+deployment from SDL, list bids, create lease, send manifest, JWT issuance per §3.3) MUST be preserved so
+Console's migration is primarily dependency injection. Historical list operations route to the indexer `/v2`
+API (REQ-OFF-003); SDL handling is unchanged.
+
+### 5.2 Go SDK
+
+**REQ-OFF-042** A successor Go module to `pkg.akt.dev/go` MUST host: the chain-neutral protocol types and IDs,
+the `pkg/chain` adapter interfaces (§2.2, shared verbatim with provider-services), the Solana implementation
+(generated Borsh account/event codecs from the IDL; instruction builders; `[TO-VERIFY: anchor-go generator
+maturity at kickoff]`), the EVM implementation (abigen), the JWT package (§3.3 algorithms), and the SDL
+package unchanged.
+
+### 5.3 `akash` CLI v3 command mapping
+
+Today's `query`/`tx`/`keys`/`events` trees live in `pkg.akt.dev/go/cli` v0.2.4 (`cmd/akash/cmd/root.go:69-87`).
+CLI v3 keeps verbs and UX (dseq/gseq/oseq flags, SDL input) per D-09.
+
+| # | Today (akashnet-2) | CLI v3 | Notes |
+|---|---|---|---|
+| 1 | `akash keys add <name>` | `akash keys add <name>` | target-chain keystore; Ledger supported |
+| 2 | `akash tx deployment create <sdl>` | `akash deployment create <sdl>` | builds create + escrow deposit; SDL unchanged |
+| 3 | `akash tx deployment update <sdl>` | `akash deployment update <sdl> --dseq N` | re-hashes manifest per ADR-002 |
+| 4 | `akash tx deployment close --dseq N` | `akash deployment close --dseq N` | |
+| 5 | `akash tx escrow account deposit` (`MsgAccountDeposit`) | `akash escrow deposit --dseq N --amount X` | AKT or ACT; `--from-allowance` for delegated deposits (D-21) |
+| 6 | `akash query deployment list --owner A` | `akash deployment list [--owner A]` | indexer-served (D-23: closed entities off-chain) |
+| 7 | `akash query market order list --state open` | `akash market order list` | live from chain; historical from indexer |
+| 8 | `akash query market bid list --provider P` | `akash market bid list --provider P` | |
+| 9 | `akash query market lease list --provider P` | `akash market lease list --provider P` | |
+| 10 | `akash tx market lease create --dseq --gseq --oseq --provider` | `akash market lease create` (same flags) | sequence UX preserved (D-09, Q-12) |
+| 11 | `akash tx market lease close` | `akash market lease close` | |
+| 12 | `akash tx market lease withdraw` | `akash market lease withdraw` | invokes permissionless settle first (D-21) |
+| 13 | `akash tx cert generate/publish client` | **removed** | replaced by JWT (§3, D-10) |
+| 14 | `akash auth jwt --exp --nbf --access --scope` | `akash auth jwt` (same flags) | EdDSA (Solana) / ES256K-R (EVM) |
+| 15 | `akash tx provider create provider.yaml` | `akash provider register provider.yaml --collateral X` | plus `akash provider migrate` wizard (§8) |
+| 16 | `akash events` | `akash events tail [--filter ...]` | indexer stream, not CometBFT websocket |
+| 17 | `akash status` | `akash net status` | reads `akash-config` + RPC health |
+
+**REQ-OFF-043** CLI v3 MUST implement the table above; removed commands MUST exit non-zero with a migration
+message naming the replacement, not fail with "unknown command", for one major release.
+
+### 5.4 Version negotiation: discovery-service replacement
+
+Today clients negotiate against the node's Discovery service (`GET /akash/discovery/v1/info`, gRPC
+`akash.discovery.v1.Discovery/GetInfo`, CometBFT RPC method `"akash"`): `chain_id`, `node_version`,
+**`min_client_version`**, per-module API version maps; chain-sdk hard-depends on it (`testutil/network/rpc.go:12,26`).
+
+**REQ-OFF-044** The `akash-config` program/contract MUST publish: schema version, program IDs/contract
+addresses, protocol API version, `min_client_version`, and feature flags; mutable only via governance (D-11).
+
+**REQ-OFF-045** All first-party clients (chain-sdk, Go SDK, CLI, provider-services) MUST read `akash-config`
+at startup and refuse to operate (hard fail with upgrade instructions) when their own version is below
+`min_client_version`, preserving today's forced-upgrade lever client-side, since no node exists to reject old
+clients.
+
+**REQ-OFF-046** Off-chain mutable metadata (RPC endpoints, indexer URL, sponsorship URL, claim-portal URL)
+MUST be published as a versioned JSON schema in `akash-network/net` (successor to `mainnet/meta.json`);
+`akash-config` prevails on conflicts for on-chain facts.
+
+## 6. Console & fee UX
+
+### 6.1 Wallet support matrix (launch targets; re-verify per [13](./13-open-questions-and-assumptions.md) §4)
+
+| Wallet | Path | Tx signing | Message signing (JWT/SIWx, §3.3) | Ledger | Tier |
+|---|---|---|---|---|---|
+| Phantom | Solana | yes | `signMessage` | passthrough | 1 |
+| Solflare | Solana | yes | yes | passthrough | 1 |
+| Backpack | Solana | yes | yes | `[TO-VERIFY: Backpack Ledger passthrough status]` | 2 |
+| Ledger (native app) | Solana | yes; program txs may require blind signing | via host wallet | none | 1 |
+| MetaMask | EVM | yes | `personal_sign`/EIP-712 | passthrough | 1 |
+| Coinbase Wallet | EVM | yes | yes (ERC-1271 for smart wallet) | no | 1 |
+| Rabby | EVM | yes | yes | passthrough | 2 |
+| Keplr / Leap | old chain only | wind-down ops until H | ADR-36 (claim proofs, §8) | yes | claims only |
+
+**REQ-OFF-047** Console MUST integrate wallets via the standard discovery layers (Wallet Standard on Solana;
+EIP-6963 on EVM) rather than per-wallet adapters, with Tier-1 wallets explicitly QA'd each release.
+
+### 6.2 Managed-wallet users (Q-14)
+
+**REQ-OFF-048** Console's managed/custodial wallet balances (keys operated by Overclock) SHALL be migrated
+custodially at S1 exactly like an exchange swap ([05](./05-token-migration.md)): Overclock claims in bulk from
+its custodial addresses and credits users on new-chain custodial wallets, with no user action and an audit
+trail reconciling per-user balances pre/post swap. Mechanics and comms are Q-14 (owner: Console team, needed
+by G2).
+
+### 6.3 Fee sponsorship service (Q-07) and trials
+
+Today Console sponsors trial/UX costs via `feegrant` (tx fees) and authz deposit grants (escrow deposits,
+`x/escrow/keeper/keeper.go:190-280`). Targets:
+
+- **Solana:** a fee-payer relayer (Octane-style; FROM-TRAINING): Console API co-signs transactions as
+  `fee_payer` when policy passes. The Solana base fee is 5,000 lamports/signature (≈ $0.00075 as of 2026-08), so cost is
+  dominated by abuse control, not fees.
+- **EVM:** an ERC-4337 verifying paymaster (plus EIP-7702 delegation for EOAs) with the same policy service;
+  generic ERC-20 and issuer stablecoin paymasters (e.g. Circle Paymaster for USDC) are production-normal as of 2026-08.
+
+**REQ-OFF-049** The sponsorship service MUST enforce: instruction/call allowlist (Akash programs/contracts
+only, no bare transfers), per-address and per-IP rate limits, per-address daily spend caps, global budget
+circuit breaker, and denylist hooks; every sponsored tx MUST be attributable in logs for ≥ 90 days.
+
+**REQ-OFF-050** Escrow deposit sponsorship MUST use the on-chain delegated-deposit allowance (D-21) so refunds
+restore the sponsor's allowance (preserving today's grant-restore-on-refund semantics that Console trial
+economics depend on).
+
+**REQ-OFF-051** The existing trial flow (no-crypto start, sponsored deployment, upgrade to self-funded) MUST
+be preserved end-to-end on the target chain using the above primitives; settlement-stablecoin payment
+paths (D-14) MUST be first-class in Console pricing and top-up UX.
+
+## 7. Explorers & public infrastructure
+
+### 7.1 Explorer strategy
+
+**REQ-OFF-052** Generic chain explorers suffice for transactions/balances: Solscan/SolanaFM (Solana) or
+the host chain's canonical explorer (e.g. Basescan on Base or Arbiscan on Arbitrum One); all programs MUST
+publish IDLs on-chain and all contracts MUST be source-verified so explorer
+decoding works. Domain objects (deployments/orders/leases/providers) are served by public, unauthenticated
+Console pages backed by the indexer; the "marketplace explorer" is a Console surface, not a separate product.
+Mintscan coverage ends at halt H; the static archive explorer is specified in
+[06](./06-state-and-data-migration.md) (D-18).
+
+### 7.2 RPC strategy
+
+**REQ-OFF-053** Production services (Console, indexer, sponsorship, claim portal) MUST run against ≥ 2
+independent commercial RPC providers with client-side failover and per-provider health metrics;
+provider-services documentation MUST ship the same dual-endpoint guidance. Solana SHOULD additionally run one
+self-operated Agave node with the Geyser plugin (indexer sovereignty, §4.2); EVM equivalently MAY run a
+host-chain full node. Vendor selection and SLAs are a kickoff task (volatile facts,
+[13](./13-open-questions-and-assumptions.md) §4); operational ownership is Q-07.
+
+### 7.3 Status page & public API limits
+
+**REQ-OFF-054** A public status page MUST cover: RPC providers (per-provider), indexer ingest lag, Console
+API, sponsorship relayer, claim portal, and (until H) old-chain wind-down services.
+
+**REQ-OFF-055** Public indexer/Console API endpoints MUST publish documented rate limits (anonymous + keyed
+tiers) and return standard rate-limit headers; limits MUST at least match today's Console API tiers.
+
+## 8. Claim portal & migration UX tooling
+
+Claim mechanics (Merkle trees, S1/S2, residuals) are in [05](./05-token-migration.md); this covers the tooling.
+
+**REQ-OFF-056** A web claim portal MUST support: prove old-chain ownership by ADR-36 offline signature via
+Keplr/Leap (Ledger included) over a challenge that binds the target-chain recipient address; submit the Merkle
+claim on the target chain (sponsored via §6.3 so claimants need no gas); show claim status/history per
+address, including weekly residual distributions during C→H (D-05).
+
+**REQ-OFF-057** A headless CLI claim path (`akash claim`) MUST exist for providers, exchanges, and scripted
+treasuries: reads the old key from a Cosmos keyring, signs the same challenge format as the portal, submits
+via RPC; supports multisig owners `[TO-VERIFY: ADR-36 multisig signing support in current Keplr/CLI tooling]`.
+
+**REQ-OFF-058** Provider re-registration wizard: `akash provider migrate` MUST, in one command: read the
+operator's provider record and audited attributes from the [06] archive (or live old chain pre-halt), prefill
+the target `ProviderRecord` (attributes, `host_uri`, contact info), prompt for collateral (Q-08) and operator
+keys (§3.4), register on the target chain, and print the §3.2 TLS anchoring choices. It MUST be idempotent
+(safe re-run resumes). Audit attestations do NOT carry over automatically: auditors re-sign on the target
+chain; the wizard MUST emit a re-audit request artifact.
+
+## 9. Off-chain cutover choreography
+
+Authoritative schedule and gates in [10](./10-rollout-and-cutover.md); off-chain ordering constraints:
+
+| Stage | Off-chain actions |
+|---|---|
+| Pre-launch | Indexer + RPC contracts live against testnet, then mainnet programs at launch L; claim portal and sponsorship staged; chain-sdk v2 / CLI v3 / Go SDK released |
+| L → C (launch → cutover) | provider-services GA (adapter + JWT auth); providers re-register (§8 wizard) and serve the new chain; Console dual-stack: both chains visible, new chain becomes the default deploy target, old-chain deploys behind an end-of-life warning |
+| C (=S1) | Old chain enters sunset (D-18): Console switches old chain to read-only + wind-down actions (close/withdraw/deposit top-up only); claims open; old-chain indexer keeps ingesting |
+| C → H | Dual-stack steady state: wind-down dashboard (old leases, residual distributions); weekly residual claims surfaced in portal |
+| H (=S2) | Old-chain reads flip to the imported archive (§4.5); old RPC/indexer/snapshots decommission per D-18 at H+90d |
+
+**REQ-OFF-059** Deploy order MUST be: indexer + RPC infra → programs/contracts (mainnet launch L) →
+provider-services GA and provider re-registration → Console target-chain default. No stage may go live before
+its predecessor passes the [09](./09-testing-and-verification.md) acceptance gate.
+
+**REQ-OFF-060** During L→H, provider-services MUST support one daemon instance per chain running concurrently
+against the same Kubernetes cluster with disjoint cluster resource naming (namespaces/ingress derived from
+lease IDs MUST NOT collide across chains; verified in 09 dual-stack tests).
+
+**REQ-OFF-061** Console MUST render old-chain data read-only from C onward, with wind-down actions (close,
+withdraw, top-up) as the only old-chain writes, matching the sunset msg allow-list (D-18, Q-17).
+
+**REQ-OFF-062** All first-party clients released for the migration MUST carry both-chain configuration until
+H, selected via the `akash-config`/net-registry metadata (§5.4), so a single release serves the full wind-down
+window.
+
+---
+
+## Cross-references
+
+- [01. Current architecture](./01-current-architecture.md): module/state detail behind §1–§3.
+- [03. Solana architecture](./03-solana-architecture.md) / [04. Ethereum architecture](./04-ethereum-architecture.md): programs/contracts, event emission, `akash-config`.
+- [05. Token migration](./05-token-migration.md): claims consumed by §8; exchange/custodial swaps (§6.2).
+- [06. State & data migration](./06-state-and-data-migration.md): archives imported in §4.5; provider record source for §8.
+- [10. Rollout & cutover](./10-rollout-and-cutover.md): gates and calendar for §9.
+- [13. Open questions](./13-open-questions-and-assumptions.md): Q-07, Q-12, Q-14, Q-15, Q-16, Q-18; volatile-fact list.
+- [14. Appendix: protocol mapping](./14-appendix-protocol-mapping.md), the full event/msg/query mapping backing §2.3 and §5.3.
+
+## Feeds into
+
+- [08. Security & audits](./08-security-and-audits.md): sidecar custody (REQ-OFF-015), JWT verification (§3), sponsorship abuse controls (REQ-OFF-049).
+- [09. Testing & verification](./09-testing-and-verification.md): every REQ-OFF acceptance test; latency budgets (REQ-OFF-018/035), hash vectors (REQ-OFF-031), dual-stack tests (REQ-OFF-060).
+- [10. Rollout & cutover](./10-rollout-and-cutover.md): §9 stage ordering constraints.
+- [11. Scope of work](./11-scope-of-work.md): off-chain workstream deliverables (adapter, sidecar, indexer, SDKs, CLI, portal).

--- a/spec/aep-79/doc/08-security-and-audits.md
+++ b/spec/aep-79/doc/08-security-and-audits.md
@@ -1,0 +1,530 @@
+| | |
+|---|---|
+| **Document** | 08. Security & Audits |
+| **Doc ID** | AKASH-MIG-08 |
+| **Version** | 0.9 (draft for review) |
+| **Date** | 2026-08-10 |
+| **Owner** | Overclock Labs |
+| **Audience** | Vendor engineering + security leads, audit firms, Akash core team |
+| **Status** | Normative where marked (MUST/SHALL); informative otherwise |
+
+## Purpose
+
+Defines the security program for the migration: how the threat model changes when Akash leaves its sovereign
+Cosmos SDK chain (see [01. Current architecture](./01-current-architecture.md)) for Solana or an EVM chain, the
+component threat models the Vendor MUST design and test against, key management and the upgrade-authority
+lifecycle (D-15), the audit plan and its coupling to program gates, the protocol invariant set, operational
+security (monitoring, incident response, bug bounty, verifiable builds), and the bridge stance.
+
+## In scope
+
+- Security posture delta analysis: Cosmos sovereign chain → Solana / EVM deployment.
+- Threat models for every protocol component and its security-relevant off-chain periphery.
+- Key management, multisig/timelock policy, guardian pause powers, authority sunset roadmap.
+- Audit tranches, firm selection criteria, gate coupling; bug bounty; monitoring; incident response.
+- Protocol invariants (consumed as executable properties by [09. Testing](./09-testing-and-verification.md)).
+
+## Out of scope
+
+- Test implementation detail (fuzz harnesses, testnets, acceptance criteria): [09](./09-testing-and-verification.md).
+- Cutover runbooks and gate definitions G0–G5: [10. Rollout & cutover](./10-rollout-and-cutover.md).
+- Claims mechanism design and supply accounting: [05. Token migration](./05-token-migration.md).
+- Target architecture internals (accounts, instructions, contracts): [03](./03-solana-architecture.md) / [04](./04-ethereum-architecture.md).
+
+---
+
+## 1. Security posture delta
+
+The migration does not merely relocate risk; it changes its shape. Three categories: surfaces that disappear,
+surfaces that appear, and surfaces that transform.
+
+### 1.1 What disappears
+
+| Surface (today) | Detail on current chain | Post-migration |
+|---|---|---|
+| Sovereign validator set + slashing | ~100-validator CometBFT set bonded in AKT; 5% double-sign slash, downtime jailing (`cmd/akash/cmd/genesis.go:219-299`) | Gone. Consensus security is inherited from the L1 (§1.2). Validator-key compromise, cartel, and chain-halt-by-validators classes vanish, as does the cost of operating/monitoring a validator set |
+| IBC surface | ICS-20 transfer, v1 + v2 (Eureka) routers; `ibctransfer` module account holds Minter+Burner | Gone at halt H (D-05: no persistent bridge). Removes voucher-inflation bugs, counterparty-chain risk, relayer censorship. Stranded-voucher handling per D-07 |
+| CosmWasm + awasm filter | wasmd hosting only the Pyth feed contracts, wrapped by a custom msg filter allowing exactly one message type; hardcoded `ContractDebugMode=true` defect (`app/app.go:158-163`) | Gone (D-22). No general-purpose contract runtime to confine; the outstanding debug-mode defect is retired rather than ported |
+| Single-source CosmWasm oracle | One authorized pusher: the Pyth contract address is the sole `Sources` entry with `MinPriceSources=1`; Wormhole guardian-set updates bypass Akash governance entirely (`_docs/governance-updates.md:44-57`) | Replaced by direct Pyth pull-oracle reads in protocol programs/contracts (D-13). **This is a net security improvement**: it removes the single authorized pusher, the four-contract CosmWasm verification chain, and a guardian-update path outside Akash governance, in exchange for a direct, monitorable dependency on Pyth with in-protocol staleness/confidence gating |
+
+### 1.2 What appears
+
+| New surface | Why it matters |
+|---|---|
+| **Program/contract upgrade authority: the new root of trust** | Today a malicious upgrade requires a public governance proposal plus 2/3 of validators voluntarily running the binary. Post-migration, whoever controls the upgrade authority can replace the code that custodies all protocol funds with one (multisig) signature. Every control in §4 exists to constrain this |
+| **Claims distributor honeypot** | At S1 the `akash-claims` / `MigrationClaims` system (including the Wind-down Reserve) controls effectively the entire migrated AKT supply (all unclaimed liquid balances plus all module-held funds) for an exposure window of up to 2 years (D-05). It is the single largest honeypot in the program and receives the strictest treatment in this document (§2.1, §4.5, §5.1) |
+| Crank/keeper liveness dependency | Escrow settlement, BME epochs, and residual distributions execute via permissionless cranks (Solana) or keeper automation (EVM) instead of consensus-embedded End/BeginBlockers (D-20/D-21). Liveness failure delays settlement and overdrawn detection (economic exposure), though lazy accounting means no funds are lost by inaction |
+| Fee-payer / relayer abuse surface | Gasless-UX sponsorship (fee payer on Solana, paymaster/relayer on EVM) introduces a hot-key service that attackers can drain or abuse (§2.7) |
+| L1 inheritance | Solana: consensus outages/degradation and the Alpenglow consensus transition landing inside the migration window (A-13); plan an instability buffer. Ethereum path: L1 consensus plus **the host chain's centralized sequencer** (Stage 1 fault proofs; no major L2 at Stage 2 as of 2026-08; candidate-chain policy also shifts, e.g. Base announced Superchain exit 2026-02); sequencer censorship/downtime and forced-inclusion latency become part of the protocol's availability story |
+| Public ordering adversaries (MEV) | Analyzed and largely defused by protocol design in §3 |
+
+### 1.3 What transforms: losing the chain-halt recovery lever
+
+Escrow and BME defects mean **direct fund loss, exactly as today**. What changes is recoverability. On the
+sovereign chain, Akash has repeatedly used coordinated upgrades as a state-repair tool: the v1.1.0 upgrade
+repaired overdrawn escrow accounts, and v2.1.0 imperatively moved 427,414,453 uakt from the distribution module
+account into escrow (`upgrades/software/v2.1.0/upgrade.go:88-108`). On Solana or the host chain there is no halt lever and
+no consensus-blessed state rewrite: recovery is limited to what the deployed code and its authorities permit, on
+a chain that keeps running while you respond. Three requirement families follow:
+
+**REQ-SEC-001** Every program/contract that holds or moves user funds MUST implement a guardian pause per §4.3 (intake freeze that never blocks withdrawals or refunds).
+
+**REQ-SEC-002** The Vendor MUST document and rehearse (on testnet, before mainnet launch) an upgrade-based recovery runbook per fund-holding program/contract (the migration-era replacement for "upgrade the chain to fix state"), including state-reconstruction sources (indexer + archives per [06](./06-state-and-data-migration.md)) and expected time-to-mitigation.
+
+**REQ-SEC-003** The invariant monitors of §7.1 MUST be deployed and alert-tested before any real-value deployment (testnet dress rehearsal included).
+
+**REQ-SEC-004** Critical-path instructions/functions MUST carry on-chain conservation assertions where cost permits (at minimum I-3 and I-4 of §6), so violations abort atomically rather than requiring after-the-fact recovery.
+
+Note the inherited gap being closed here: the current chain registers **no invariants at all** (the crisis module
+is not wired into the app), so the target's §6/§7 posture is strictly stronger than status quo.
+
+---
+
+## 2. Component threat models
+
+Format: STRIDE-informed tables (S spoofing, T tampering, R repudiation, I info disclosure, D denial of service,
+E elevation of privilege). Mitigation cells reference the requirement that mandates them.
+
+### 2.1 Claims distributor (`akash-claims` / `MigrationClaims`)
+
+Context: Merkle-distribution claims per D-05; claimants prove ownership of a snapshot Cosmos address and
+designate a target-chain recipient. Roots: S1 root, weekly interim residual roots (C→H), S2 root.
+
+| Threat | Class | Vector | Mitigation |
+|---|---|---|---|
+| Double-claim | T | Replay same leaf; claim across two roots containing overlapping balances | REQ-SEC-007; residual roots MUST contain only incremental amounts ([05](./05-token-migration.md)) |
+| Forged Cosmos ownership proof | S | secp256k1 signature malleability (high-S acceptance); verifying the wrong digest (raw bytes vs the documented ADR-36-style sign-doc); accepting a signature over attacker-chosen bytes | REQ-SEC-008 |
+| Address confusion | S | Verifier trusts a caller-supplied Cosmos address instead of deriving it from the verified pubkey | REQ-SEC-008 (derivation mandatory) |
+| Multisig threshold bypass | E | Cosmos multisig accounts have a distinct threshold pubkey type; a verifier that accepts any single participant key steals every multisig-held balance | REQ-SEC-009 |
+| Cross-domain replay | T | Claim message replayed on the other target chain, a testnet, or a later distribution | REQ-SEC-010 |
+| Root substitution | T/E | Compromised authority replaces a registered root with an attacker root, the single fastest full-drain path | REQ-SEC-005, REQ-SEC-006 |
+| Honeypot drain via code defect | E | Any arithmetic/validation bug in the one program holding ~the entire supply | REQ-SEC-011/012; audit tranche T1 (§5.1); I-3 on-chain |
+
+**REQ-SEC-005** Each Merkle root MUST be immutable once registered: no instruction/function to modify or delete a registered root may exist. New roots (weekly residuals, S2) are append-only, and root registration MUST be permanently disabled (irreversible flag) once the S2 root and the D-07 redemption reserve root are set.
+
+**REQ-SEC-006** Before activation, every root MUST be independently recomputed from the published snapshot data by ≥3 parties (Vendor, Overclock, ≥1 independent auditor/community verifier) whose signed attestations are published; the registration transaction MUST reference the attestation set.
+
+**REQ-SEC-007** The claims program/contract MUST enforce one-leaf-one-claim via a per-leaf on-chain receipt (claim bitmap or receipt PDA / storage slot) checked before payout.
+
+**REQ-SEC-008** Cosmos ownership verification MUST verify secp256k1 over the exact, byte-specified claim digest (documented in [05](./05-token-migration.md)), MUST reject high-S signatures, and MUST derive the snapshot address from the verified pubkey (`bech32(ripemd160(sha256(pubkey)))`) rather than accepting a claimed address.
+
+**REQ-SEC-009** Multisig snapshot accounts MUST be verified at their recorded threshold: k distinct valid participant signatures over the same digest, against the pubkey set committed in the leaf.
+
+**REQ-SEC-010** The signed claim payload MUST bind leaf reference, distribution/root identifier, target-chain identifier, claims program/contract address, and recipient address, making it non-replayable across roots, deployments, and chains.
+
+**REQ-SEC-011** Claims payouts MUST flow mint-on-claim from a program-controlled mint authority (Solana, per D-03) or from a dedicated distributor balance segregated from all other protocol funds (EVM), never from a shared vault.
+
+**REQ-SEC-012** The claims system MUST enforce a governance-set velocity breaker: if claimed value in a rolling 24 h window exceeds a configured fraction of remaining unclaimed supply, claim processing auto-pauses (full-stop tier, §4.3) pending review. Threshold set at G2; anomaly detection also in §7.1.
+
+### 2.2 Escrow (`akash-escrow` / `EscrowVault`)
+
+Context: per D-21 (lazy per-second streaming, permissionless settle, multi-depositor FIFO refunds, overdrawn
+semantics, AKT-fallback settlement when BME is halted).
+
+| Threat | Class | Vector | Mitigation |
+|---|---|---|---|
+| Value creation | T | Arithmetic/rounding defect lets withdrawn+refunded exceed deposited | I-1/I-2 (§6); REQ-SEC-004; fuzz suites in 09 |
+| Rounding-direction abuse | T | Many small settles/withdraws harvesting favorable rounding | REQ-SEC-013 |
+| Depositor-vector griefing | D | Attacker stuffs the depositor list (dust deposits) so refund loops exceed compute/gas limits; account becomes uncloseable | REQ-SEC-014 |
+| Settle front-running | D | Permissionless settle lands just before a tenant top-up, forcing overdrawn→close of a healthy lease | Accepted residual (semantics preserved by D-21); low-balance client alerts (REQ-SEC-071); minimum-deposit params keep runway |
+| Overdrawn oscillation | T | Deposit/withdraw cycling across the overdrawn boundary to double-accrue or skip accrual around the settled-at freeze | REQ-SEC-015; boundary property tests (09) |
+| Delegated-deposit (allowance) abuse | E | The D-21 delegated-deposit allowance spent on unintended accounts, or restore-on-refund crediting the wrong granter | REQ-SEC-016 |
+
+**REQ-SEC-013** All escrow rounding MUST truncate in the protocol's favor (against the payee/refundee), mirroring current `TruncateInt` behavior; no code path may round up an outflow, and dust remainders accrue to the escrow account.
+
+**REQ-SEC-014** The per-account depositor list MUST be bounded (parameter, default ≤16), and every refund loop MUST fit within one transaction's compute/gas budget at the bound, verified by test.
+
+**REQ-SEC-015** Overdrawn state transitions MUST preserve the current-chain freeze semantics (accrual timestamp frozen while overdrawn; settle-before-deposit ordering) and MUST be covered by a state-machine property suite in [09](./09-testing-and-verification.md).
+
+**REQ-SEC-016** Delegated-deposit allowances MUST record (granter, grantee, scope, remaining limit) on chain; spends decrement atomically with the deposit; refunds restore only the originating granter's allowance, never a balance transfer to the grantee.
+
+### 2.3 BME (`akash-bme` / `BurnMintEscrow`)
+
+Context: per D-20 (queued epoch-batched AKT↔ACT swaps, collateral ratio CR = vault AKT value / ACT supply, warn
+9500 bps / halt 9000 bps, mint spread, permissionless crank / keeper execution).
+
+| Threat | Class | Vector | Mitigation |
+|---|---|---|---|
+| Oracle staleness/manipulation | T | Stale or manipulated AKT/USD price inflates CR (mints unbacked ACT) or misprices refunds | REQ-SEC-017; Pyth confidence + staleness gating per 03/04; monitoring §7.1 |
+| Queue jamming | D | Flood of dust swap requests starves the batch executor | REQ-SEC-018 (MinMint ≥ 10 ACT carried over; per-epoch record cap; per-account pending cap) |
+| Spread / epoch-timing arbitrage | T | Locking a request-time price and executing later; racing epoch boundaries around price moves | REQ-SEC-019 (execution-time pricing, single price per batch); mint spread (25 bps default) exceeds typical intra-epoch noise |
+| Vault drain | E | Any outflow path other than refund execution | REQ-SEC-020 |
+| Halt-state abuse | T | Flapping the breaker via price manipulation to time mints; exploiting the CR-halt refund path | REQ-SEC-017/021; analysis below |
+| Crank griefing | D | Executor submits failing batches to burn retries | Carry `MaxPendingAttempts=3` cancel semantics; crank tips flat (REQ-SEC-047) |
+
+**Exit-valve analysis (normative context).** ACT→AKT burns remaining allowed under CR-halt (but not under
+oracle-halt) is intentional, carried over from the current chain: it lets ACT holders exit to AKT even when the
+vault is undercollateralized, preventing a trapped-asset scenario. The consequence is a controlled-run dynamic:
+early redeemers exit at full oracle value while CR degrades for late redeemers. Three properties keep this
+controlled rather than catastrophic: (a) batch caps (`MaxEndblockerRecords=50`-equivalent per execution) and
+epoch backoff rate-limit redemption throughput; (b) refunds always price off a healthy (non-stale) oracle read,
+since oracle-halt blocks them; (c) governance can recapitalize via the fund-vault path. The Vendor MUST preserve
+all three and MUST NOT "fix" the exit valve by blocking refunds under CR-halt.
+
+**REQ-SEC-017** CR computation and every swap execution MUST enforce the oracle staleness and confidence bounds defined in [03](./03-solana-architecture.md)/[04](./04-ethereum-architecture.md); a stale/unhealthy read MUST resolve to oracle-halt (no mints, no refunds), never to a default price.
+
+**REQ-SEC-018** Queue intake MUST enforce a minimum swap size (default 10 ACT-equivalent), a per-epoch execution record cap, and a per-account pending-request cap, all governance parameters.
+
+**REQ-SEC-019** All records in one epoch batch MUST execute at a single execution-time aggregated price; request-time prices MUST NOT be honored, and queue position within a batch MUST NOT affect the price received.
+
+**REQ-SEC-020** The vault MUST have exactly one outflow path (refund/settlement execution). Funding is one-way (governance fund instruction, mirroring `MsgFundVault`); no administrative withdrawal capability may exist, including for the upgrade authority short of a code upgrade.
+
+**REQ-SEC-021** Mint batches MUST re-check CR as a post-condition and abort mid-batch if CR crosses the halt threshold during execution (carrying current EndBlocker behavior); I-4 (§6) is asserted on-chain.
+
+### 2.4 Marketplace (`akash-market`, `akash-deployment` / `Marketplace`, `DeploymentRegistry`)
+
+| Threat | Class | Vector | Mitigation |
+|---|---|---|---|
+| Bid-slot griefing | D | Junk bids exhaust the per-order bid cap (today `OrderMaxBids=20`) at zero net cost since collateral is refunded on loss; real providers cannot bid | REQ-SEC-022; collateral sizing + forfeiture per Q-08 |
+| Fake providers (Sybil) | S | Costless provider registration floods matching with phantom supply | Registration collateral (Q-08); audited-attribute weighting; REQ-SEC-023 |
+| Attribute spoofing | S | Provider self-declares false attributes (region, GPU class) to win leases | Audit registry provenance (REQ-SEC-023); Console default-filters to audited attributes ([07](./07-offchain-and-clients.md)) |
+| Reclamation abuse | D | Provider abuses the D-24 reclamation window to strand tenants, or bypasses it to yank leases | Port window bounds 1h–720h exactly; deadline checks as today (`x/market/handler/server.go:138-192`) |
+| Lease-award manipulation | T | Ordering attacks on bid/lease creation | Defused by design: tenant explicitly selects the winning bid (§3) |
+
+**REQ-SEC-022** Bid slots MUST NOT be exhaustible at zero economic cost: the design MUST include bid-collateral forfeiture conditions and/or a non-refundable bid fee (parameters from Q-08), and the per-order bid cap MUST remain governance-tunable.
+
+**REQ-SEC-023** The audit registry port MUST preserve auditor-signed attribute provenance (attribute → auditor identity) so clients can distinguish self-declared from audited attributes; matching that consumes audited attributes MUST verify the auditor chain on-chain or via the authoritative read path (REQ-SEC-034).
+
+### 2.5 Provider registry: key rotation (`akash-provider-registry` / `ProviderRegistry`)
+
+Per D-10, provider JWT signing keys are anchored on-chain; rotation is the attack surface: an attacker holding a
+provider's owner key rotates the signing key and impersonates the provider to tenants (manifest theft, workload
+interception).
+
+**REQ-SEC-024** Signing-key rotation MUST be owner-signed, MUST emit an indexed event, and MUST record the previous key and rotation timestamp on-chain (rotation history queryable).
+
+**REQ-SEC-025** Tenant-side verification (Console, SDKs, provider daemon peers) MUST resolve provider signing keys via the authoritative read path (REQ-SEC-034) at connection time (never from cache older than 5 minutes) and MUST surface unexpected-rotation warnings.
+
+**REQ-SEC-026** The provider daemon MUST alert its operator on any rotation event affecting its own provider record (detects hostile rotation via a compromised owner key).
+
+### 2.6 Governance & upgrade authority (Realms + Squads v4 / OZ Governor + Timelock + Safe)
+
+| Threat | Class | Vector | Mitigation |
+|---|---|---|---|
+| Proposal spam | D | Cheap proposals bury real ones / voter fatigue | REQ-SEC-027 |
+| Timelock bypass | E | A privileged function callable outside the timelock; direct-execution role retained by an EOA | REQ-SEC-028 |
+| Malicious proposal rushed at low quorum | E | Parameter/upgrade proposal passed quietly | Timelock delay = public reaction window (§4.2); security-council cancel (REQ-SEC-029) |
+| Multisig signer compromise | S/E | Phished/coerced signers reach threshold | §4.1 quorum/geo/HSM requirements (REQ-SEC-048..052) |
+| Governance-stack supply chain | T | Upstream Realms (low-velocity maintenance) / Squads / OZ code changes | REQ-SEC-030; Q-11 Realms gap analysis |
+
+**REQ-SEC-027** Proposal creation MUST carry an economic threshold (token deposit or minimum voting power) sized at G1 such that spam is uneconomical; parameters governance-tunable.
+
+**REQ-SEC-028** Every privileged operation (upgrade, parameter change, root registration, treasury movement, authority transfer) MUST route through the timelock; the only exemptions are guardian pause (intake-only, §4.3) and timelock-operation cancellation.
+
+**REQ-SEC-029** A security council (the launch multisig) MUST hold cancel power over queued timelock operations during the upgradeable phase; cancel power sunsets with the §4.5 roadmap.
+
+**REQ-SEC-030** The Vendor MUST pin exact versions of governance-stack dependencies (Realms/SPL Governance, Squads v4, OZ Governor/Timelock/Safe), monitor upstream changes (including scheduled upstream program upgrades such as Pyth's DAO-managed upgrades), and re-verify before adopting any update.
+
+### 2.7 Fee-payer / relayer (gasless UX)
+
+| Threat | Class | Vector | Mitigation |
+|---|---|---|---|
+| Fee-float drain | D | Spam of valid-but-pointless sponsored transactions | REQ-SEC-031/032 |
+| Instruction smuggling | E | Sponsored tx includes instructions moving relayer assets or invoking foreign programs | REQ-SEC-031/033 |
+| Quota-identity Sybil | D | Fresh addresses evade per-account quotas | Global rate cap + per-IP/per-session app-layer limits (REQ-SEC-032) |
+
+**REQ-SEC-031** The relayer MUST sponsor only transactions matching an allow-list of (program/contract address, instruction/function selector) patterns for the Akash protocol suite, verified by simulation before signing; anything else is rejected.
+
+**REQ-SEC-032** The relayer MUST enforce per-address and global sponsorship quotas (rate + value), with alerts on quota saturation (§7.1).
+
+**REQ-SEC-033** Fee-payer/paymaster keys MUST hold only a working fee float (auto-refilled from a cold treasury with a capped daily amount) and MUST NOT hold or control any other asset or authority.
+
+### 2.8 Indexer & Console read path
+
+Per D-16/D-23 the indexer is the system of record for history, which makes it a spoofing target: a poisoned
+indexer can show a tenant a healthy lease that is closed, or an inflated escrow balance, inducing harmful signed
+transactions.
+
+**REQ-SEC-034** Any Console/client flow that results in a money-moving signature (deposit, withdraw, claim, swap, lease create/close) MUST reconcile the displayed state against an authoritative on-chain read (RPC `getAccountInfo` / `eth_call`) immediately before presenting the signing prompt; indexer data alone MUST NOT drive such prompts.
+
+**REQ-SEC-035** An indexer-integrity monitor MUST continuously sample indexer state against chain state (random entity sample + chain-head lag), alerting on divergence (§7.1).
+
+### 2.9 Solana specifics: program vulnerability classes
+
+| Threat | Class | Vector | Mitigation |
+|---|---|---|---|
+| Missing owner/signer checks; duplicate mutable accounts | S/E | Account substitution with look-alike accounts; same account passed twice mutable, corrupting balance math | REQ-SEC-036 |
+| Type confusion | T | Account data reinterpreted across types (missing discriminator) | REQ-SEC-036 |
+| PDA seed collision | T | Ambiguous seed concatenation ("ab"+"c" vs "a"+"bc") or scope overlap (escrow deployment vs bid scopes) yields the same PDA | REQ-SEC-037 |
+| CPI privilege escalation | E | Program invokes an attacker-supplied program id, or leaks PDA signer seeds to arbitrary CPI | REQ-SEC-038 |
+| Account resurrection | T | Closed account revived via lamport top-up or re-init within one transaction | REQ-SEC-039 |
+| ALT poisoning | S | Malicious address-lookup-table entries resolve a client-built transaction to attacker accounts | REQ-SEC-040 |
+
+**REQ-SEC-036** Every instruction MUST validate, for every account: owner program, signer/writable expectations, type discriminator, and duplicate-account distinctness (Anchor constraint set, or equivalent explicit checks in Pinocchio paths). All crates build with `overflow-checks=true` and checked casts.
+
+**REQ-SEC-037** PDA seed schemas MUST be canonical, documented in [03](./03-solana-architecture.md), collision-free across programs and scopes, and use fixed-width or length-prefixed components (no raw string concatenation).
+
+**REQ-SEC-038** All CPI target program ids MUST be pinned to known ids (token program, protocol sibling programs, Pyth); no instruction may CPI into a caller-supplied program id, and PDA signer seeds MUST only sign CPIs constructed by the owning program.
+
+**REQ-SEC-039** Account closure MUST be resurrection-safe: drain lamports, zero data, write a CLOSED discriminator (or reassign to the system program); creation paths MUST reject accounts bearing the CLOSED marker within the same transaction.
+
+**REQ-SEC-040** Canonical address lookup tables MUST be published, frozen (no append authority after finalization), and pinned by address in first-party clients; client SDKs MUST verify ALT contents against expected protocol addresses at build time.
+
+### 2.10 Ethereum/host-chain specifics: contract vulnerability classes
+
+| Threat | Class | Vector | Mitigation |
+|---|---|---|---|
+| Reentrancy on settle/withdraw/refund | E | External token calls mid-state-update; note ACT's restricted-transfer hooks are protocol code and still reenter | REQ-SEC-041 |
+| Approval races | T | ERC-20 `approve` front-run on deposit flows | REQ-SEC-042 |
+| UUPS storage collision | T | Upgrade shifts storage layout, corrupting escrow accounting | REQ-SEC-043 |
+| Uninitialized proxy / implementation takeover | E | Initializer front-run; attacker initializes a bare implementation contract | REQ-SEC-044 |
+| Keeper MEV | T | Automation bots sandwich fallback-price settlement around oracle updates | §3 (REQ-SEC-046); flat keeper compensation (REQ-SEC-047) |
+| Sequencer trust | D | Host-chain sequencer downtime/censorship delays settles, claims, breaker updates | Forced-inclusion via L1 documented in runbooks (REQ-SEC-002); monitoring §7.1 |
+
+**REQ-SEC-041** All fund-moving external calls MUST follow checks-effects-interactions and carry reentrancy guards; cross-contract protocol calls (EscrowVault↔BurnMintEscrow↔ACT) MUST be modeled as reentrant in tests.
+
+**REQ-SEC-042** Protocol deposit flows MUST use EIP-2612 permit or exact-allowance patterns; no flow may require a standing unlimited approval to a protocol contract.
+
+**REQ-SEC-043** Upgradeable contracts MUST use namespaced storage (ERC-7201) with storage-layout compatibility checks (OZ upgrades tooling or equivalent) enforced in CI for every upgrade.
+
+**REQ-SEC-044** Implementation contracts MUST call `_disableInitializers()` in constructors, and deployment scripts MUST atomically deploy+initialize proxies (deterministic deployment, no initialization window).
+
+---
+
+## 3. MEV and transaction-ordering analysis
+
+The current chain is **low-MEV by design**, and this property MUST be preserved. There is no time-priority
+auction anywhere in the protocol: an order does not go to the first or best bid by arrival; the tenant
+explicitly selects a bid via lease creation (`MsgCreateLease{BidID}`), all bids at or below the order price are
+equally eligible, and closing a lease merely relists the order. There are no liquidation bounties, no AMM pools,
+no first-come mint windows; the chain runs no-op proposal handlers and a default mempool. Akash has never
+depended on ordering fairness, and the target design must not start.
+
+**REQ-SEC-045** No target-chain mechanism may award an economic outcome (lease award, bid acceptance, claim priority, swap price) based on transaction-ordering priority; tenant-selects-bid semantics per D-09 are the normative pattern.
+
+Residual ordering surfaces and their treatment:
+
+| Surface | Extraction | Bound |
+|---|---|---|
+| Settle-timing (AKT-fallback path prices ACT debt in AKT at settle time) | Caller times settlement around price moves | Aggregated/TWAP price with staleness + deviation caps per 03/04; extraction bounded to intra-window noise (REQ-SEC-046) |
+| BME queue position | Jump the queue before an epoch executes | Defused: single execution-time batch price (REQ-SEC-019) |
+| Crank/keeper tip races | Bots race permissionless settle/epoch cranks for tips | Benign (identical state outcome); flat tips (REQ-SEC-047) |
+| Host-chain sequencer ordering (EVM) | Sequencer-level frontrunning of settles | Same price-bounding as above; private submission SHOULD be available for operational transactions |
+
+**REQ-SEC-046** Every price-consuming settlement path MUST use an aggregated price with explicit staleness and deviation bounds (parameters in 03/04) such that the maximum ordering-derived value transfer per settlement is bounded and quantified in the design review.
+
+**REQ-SEC-047** Crank/keeper incentives MUST be flat per-execution fees or tips, never proportional to value moved, so racing cranks cannot become an extraction market.
+
+---
+
+## 4. Key management and authority lifecycle
+
+### 4.1 Launch configuration
+
+| | Solana | Ethereum/host chain |
+|---|---|---|
+| Upgrade authority | Squads v4 multisig (de-facto standard as of 2026-08) holding all program upgrade authorities, executing only timelocked proposals | Safe multisig as proposer on OZ `TimelockController`; timelock is `owner`/`UPGRADER_ROLE` of all UUPS proxies |
+| Token authorities | AKT/ACT mint authorities held by protocol PDAs (claims/emissions/BME programs) per D-03/D-19, never by the multisig directly | Mint roles granted only to `MigrationClaims`, `EmissionsMinter`, `BurnMintEscrow` per D-04/D-19 |
+| DAO layer | Realms (SPL Governance) token voting (Q-11 gap analysis pending) | `AkashGovernor` (OZ Governor) |
+| Guardian (pause) | Designated pause key set inside Squads (any 2-of-7 members may trigger intake pause) | `PAUSER_ROLE` held by a 2-of-7 sub-quorum of the Safe |
+
+**REQ-SEC-048** The launch upgrade authority MUST be a multisig with threshold ≥ 4-of-7 (example baseline; exact set fixed at G1 and published).
+
+**REQ-SEC-049** No single organization may control more than 2 of 7 signers (Overclock included), and signers MUST span ≥3 legal jurisdictions.
+
+**REQ-SEC-050** Every signer key MUST be hardware-backed (HSM or hardware wallet on a dedicated device), never hot, never reused across environments (testnet keys distinct).
+
+**REQ-SEC-051** Signer identities/roles MUST be published (at minimum organization + role), and each signer MUST complete a quarterly liveness attestation (signing a canary message); two consecutive misses trigger replacement.
+
+**REQ-SEC-052** Signer departure or suspected compromise MUST trigger a multisig membership change within 7 days; ≥2 simultaneously compromised/lost signers triggers the emergency re-key runbook (REQ-SEC-055).
+
+### 4.2 Timelock policy
+
+| Operation class | Delay | Approver |
+|---|---|---|
+| Routine parameter change (bounded ranges defined in 03/04) | 48 h | Multisig (Phase L) / DAO (Phase 1+) |
+| Program/contract upgrade | 7 d | Multisig + published diff/audit note |
+| Residual root registration (weekly, C→H) | 48 h | Multisig + 3-party attestation (REQ-SEC-006) |
+| Emergency security patch | 24 h minimum | Elevated threshold 6-of-7; public disclosure ≤72 h after execution |
+| Guardian pause (intake-only) | none (instant) | 2-of-7 sub-quorum |
+| Full-stop pause | none (instant) | Multisig quorum (4-of-7); auto-expires |
+
+**REQ-SEC-053** All timelock delays, queued operations, and their calldata/instruction payloads MUST be publicly observable (on-chain queue), and queueing MUST emit monitored events (§7.1).
+
+### 4.3 Guardian pause powers
+
+Pause is an intake freeze, never an exit freeze. Per component:
+
+| Component | Intake pause freezes | Never blocked (any tier except full-stop) |
+|---|---|---|
+| Deployment/Market | New deployments, orders, bids, leases | Lease close, withdraw, escrow refund, reclamation completion |
+| Escrow | New accounts, new deposits | Settle, payment withdraw, depositor refund, account close |
+| BME | New swap requests (queue intake) | Queued executions; ACT→AKT refunds under CR-halt (the D-20 exit valve) |
+| Claims | Nothing at guardian tier | Claims processing (pausable only via full-stop, REQ-SEC-012/054) |
+| Emissions | Mint executions | n/a (no user funds) |
+
+**REQ-SEC-054** Guardian (intake) pause MUST NOT be able to block withdrawals, refunds, settlements, or closes. A full-stop pause (all state transitions of one component) MUST require multisig quorum, MUST auto-expire after ≤72 h unless renewed by a governance action, and every use MUST be publicly disclosed with cause.
+
+### 4.4 Key ceremony, rotation, loss
+
+**REQ-SEC-055** Before launch the Vendor MUST deliver, and rehearse with signers: (a) a documented, witnessed key-generation ceremony (on-device generation, no key export, recorded attestation); (b) a rotation runbook (membership swap ≤7 d); (c) a loss/compromise runbook including the ≥2-signer emergency re-key path; (d) an annual rehearsal schedule. These are audit tranche T3 artifacts (§5.1).
+
+### 4.5 Authority sunset roadmap (per D-15)
+
+| Phase | Trigger (all criteria) | Authority state |
+|---|---|---|
+| **L: Launch** | Target-chain launch | Multisig + timelock as §4.1; security-council cancel active |
+| **1: DAO-gated** | S2 complete; two consecutive clean quarters (zero SEV-1/SEV-2, §7.2); all audit criticals closed | Upgrades/params require a passed DAO vote; multisig demoted to executor of passed proposals + canceller. Solana: upgrade authority moves under Realms-governed execution with Squads as emergency council. EVM: Governor becomes sole timelock proposer; Safe retains cancel + pause only |
+| **2: Immutability (core)** | Phase 1 + burn-in of N months (default 12; ratify at G2; recorded as an open question for [13](./13-open-questions-and-assumptions.md)) + governance vote | `akash-claims`/`MigrationClaims` and the escrow core: upgrade authority revoked (Solana: set to None; EVM: upgrade path permanently disabled). Root registration already burned per REQ-SEC-005. Market/config/BME remain DAO-upgradeable; emissions mint authority remains DAO+timelock permanently |
+
+**REQ-SEC-056** The Vendor MUST implement the sunset mechanics so each phase transition is a single auditable on-chain action, and MUST publish the roadmap (triggers included) before mainnet launch.
+
+**REQ-SEC-057** Claims and escrow-core immutability (Phase 2) MUST NOT occur before all Phase-2 criteria are met, and MUST occur within 90 days after they are met unless governance explicitly votes to delay (prevents indefinite retention of the upgrade backdoor).
+
+---
+
+## 5. Audit plan
+
+### 5.1 Tranches
+
+| Tranche | Scope | Depth | Gate coupling |
+|---|---|---|---|
+| **T1: Token & claims** | AKT/ACT mints + extensions/restrictions, `akash-claims`/`MigrationClaims` incl. Wind-down Reserve + residual-root flow, signature verification library (REQ-SEC-008/009), governance/timelock/multisig wiring | 2 independent firms, full scope, fix re-verification | MUST close (all Critical/High fixed + re-verified) before any real-value deployment of token or claims; these gate S1 |
+| **T2: Marketplace & economics** | Escrow, BME, market, deployment, provider/audit registries, config, emissions | 2 independent firms + 1 economic/tokenomics review (BME CR breaker + spread + emissions interaction, run dynamics of §2.3) | MUST close before marketplace mainnet launch |
+| **T3: Off-chain** | Signer sidecar (D-17), fee relayer (§2.7), claim portal backend, monitoring pipeline, key ceremony/runbooks | 1 code-audit firm + 1 infrastructure pentest | MUST close before cutover C |
+
+**REQ-SEC-058** Each on-chain tranche MUST be audited by two independent firms (no shared ownership or staff), each covering the full tranche scope (not split halves).
+
+**REQ-SEC-059** Every Critical/High finding across all tranches MUST be fixed and re-verified by the issuing firm before **G3** (the cutover go/no-go gate per [10](./10-rollout-and-cutover.md)); no gate crossing may occur with an open Critical/High.
+
+**REQ-SEC-060** Material post-audit diffs (any change to audited fund-flow code) MUST receive a delta review by at least one of the original firms before deployment.
+
+**REQ-SEC-061** All audit reports MUST be published within 30 days of the corresponding fixes being deployed.
+
+**REQ-SEC-062** T2 MUST additionally run a public audit competition (Code4rena/Cantina-class platform; candidate, select at procurement) on the frozen codebase before mainnet launch.
+
+### 5.2 Candidate firms (examples-to-procure; candidates, NOT commitments)
+
+| Path | Code audit candidates (as of 2026-08 reputation; re-verify) | Economic review |
+|---|---|---|
+| Solana | OtterSec, Neodyme, Zellic, Trail of Bits | Quantitative-risk firm, Gauntlet-class scope (candidate class, procure at G1) |
+| EVM | Trail of Bits, Spearbit, OpenZeppelin, Zellic | same |
+
+[TO-VERIFY: firm availability, lead times, and current Solana/EVM practice depth at procurement; book slots ≥3
+months ahead; audit-firm queues routinely run a quarter long.]
+
+---
+
+## 6. Formal & property verification: the invariant set
+
+These invariants are the contract between this document and [09](./09-testing-and-verification.md), which turns
+them into fuzz targets, stateful property suites, and (where marked) on-chain assertions. This section defines
+*what* must always hold; 09 defines *how* it is exercised, not duplicated here.
+
+| ID | Invariant | Enforcement |
+|---|---|---|
+| I-1 | Escrow conservation, per account and global: Σ(deposits) == Σ(withdrawn) + Σ(refunded) + held (funds + accrued unwithdrawn payment balances) | Property suite + continuous monitor |
+| I-2 | No negative stored balance after any settle; overdrawn is expressed only as state flag + unsettled-debt field | Property suite + monitor |
+| I-3 | Claims: Σ(claimed per root) ≤ root total; each leaf claims at most once | **On-chain assertion** + monitor |
+| I-4 | BME: no ACT mint executes while CR < halt threshold (9000 bps default), evaluated at execution time | **On-chain assertion** (REQ-SEC-021) + monitor |
+| I-5 | Depositor refunds pay out in FIFO deposit order | Property suite |
+| I-6 | ACT balances change only via protocol burn/mint instructions (non-transferability, D-19) | On-chain by construction + monitor |
+| I-7 | BME vault has exactly one outflow path (REQ-SEC-020) | Code review + monitor |
+
+**REQ-SEC-063** Each invariant I-1..I-7 MUST exist as a machine-checkable property in the 09 test suites, and I-3/I-4 MUST additionally be asserted on-chain in the executing instruction/function.
+
+**REQ-SEC-064** The Vendor SHOULD apply formal or semi-formal verification (e.g., Certora-class for EVM, Kani/proptest-backed model checking for Rust; candidates) to the escrow settlement arithmetic and the claims verification library; budget carried in [11. SOW](./11-scope-of-work.md).
+
+---
+
+## 7. Operational security
+
+### 7.1 Monitoring & alerting catalog
+
+**REQ-SEC-065** The following monitors MUST be live (with tested alert delivery) before mainnet launch, each with a runbook link in its alert payload:
+
+| Monitor | Computes | Alert |
+|---|---|---|
+| Supply conservation | On-chain AKT supply == S1/S2/residual root totals + emissions − burns (and I-1 escrow conservation) | Any mismatch → SEV-1, auto-page |
+| Vault CR | BME collateral ratio + trend | ≤9700 bps warn; ≤9500 bps page; redemption-velocity spike page |
+| Claims velocity | Claimed value per rolling 1 h / 24 h vs baseline | Anomaly → page + REQ-SEC-012 breaker check |
+| Upgrade-authority activity | Any tx touching upgrade authorities, timelock queue, multisig config, mint authorities | Every event → page (no exceptions) |
+| Large withdrawals | Single or aggregate outflow above governance-set thresholds per component | Page |
+| Crank/keeper liveness | Time since last settle execution / BME epoch / residual distribution | > 2× expected cadence → warn; > 6× → page |
+| Oracle staleness | Pyth publish-time lag + confidence width vs 03/04 bounds | Lag > 50% of staleness bound → warn; bound breach → page |
+| Indexer integrity | REQ-SEC-035 divergence sampling + head lag | Mismatch, or lag > 64 slots / 30 blocks → warn |
+| Relayer health | Fee-float balance, quota saturation, rejection rate | Thresholds per REQ-SEC-032/033 |
+| Pause/breaker state | Any pause flag or MintStatus change | Every change → page |
+
+**REQ-SEC-066** Monitors MUST run on infrastructure independent of the primary RPC/indexer vendor (second data source), so a poisoned read path cannot blind them.
+
+**REQ-SEC-067** Supply-conservation (I-1/I-3) violations SHOULD trigger a pre-authorized automatic guardian intake pause of the affected component (policy decision at G2), and MUST page regardless.
+
+### 7.2 Incident response
+
+| Severity | Definition | Response |
+|---|---|---|
+| SEV-1 | Active exploit or invariant violation; funds moving or mintable | War room ≤15 min; pause decision ≤30 min (REQ-SEC-068); public ack ≤2 h |
+| SEV-2 | Confirmed exploitable vulnerability, no active loss; or critical dependency down (oracle halt, sequencer outage) | War room ≤1 h; mitigation plan ≤24 h |
+| SEV-3 | Degraded operation (crank stalls, indexer lag, relayer down) | Business-hours response ≤24 h |
+| SEV-4 | Minor defect, no fund/liveness impact | Tracked, next release |
+
+**REQ-SEC-068** For SEV-1, elapsed time from declaration to a landed pause transaction MUST be ≤30 minutes, demonstrated in a live drill before launch and re-drilled quarterly.
+
+**REQ-SEC-069** A named incident-response roster (roles, contacts, escalation, pause-capable signer quorum per timezone) MUST exist before launch, with 24/7 coverage during: launch week, the S1/C cutover window, each weekly residual-root publication, the S2/H window, every upgrade execution, and the Alpenglow activation window (A-13) on the Solana path.
+
+**REQ-SEC-070** Comms templates (status page, X/Discord, exchange notice, provider mailing list) and a disclosure policy MUST be prepared pre-launch; every SEV-1/SEV-2 gets a public post-mortem ≤14 days after resolution.
+
+**REQ-SEC-071** Console/client UX MUST include low-escrow-balance warnings ahead of depletion (default: alert at ≤72 h of runway), the compensating control for the §2.2 settle-front-running residual.
+
+### 7.3 Bug bounty
+
+**REQ-SEC-072** An Immunefi-class bug bounty (platform selection at G2) MUST be live at least 2 weeks before mainnet launch, covering the final audited code, and MUST remain funded through at least the end of the claim window.
+
+Indicative tiers (final sizing at G2; payouts capped at 10% of demonstrably at-risk funds):
+
+| Tier | Examples | Indicative range (USD) |
+|---|---|---|
+| Critical | Theft/freezing of funds, unauthorized mint, root substitution, claims bypass | $250k–$1,000,000 |
+| High | Temporary fund lock-up, breaker bypass, griefing with direct economic loss | $50k–$100k |
+| Medium | Griefing without direct loss, quota/allow-list bypass on relayer | $10k–$25k |
+| Low | Best-practice deviations with a plausible path to impact | $1k–$5k |
+
+In scope: all protocol programs/contracts, token mints, claims + portal backend, relayer, signer sidecar. Out of
+scope: testnets, indexer/Console issues without fund impact (separate web-tier bounty), known issues, social
+engineering, physical attacks, third-party dependencies (Pyth, Squads, Safe; report upstream).
+
+### 7.4 Reproducible & verifiable builds
+
+**REQ-SEC-073** Solana specifics: every deployed program MUST be built via the verifiable-build toolchain (`solana-verify`-class, pinned container digest) with the on-chain hash matching published source at a tagged commit; verification data published so third parties can independently confirm.
+
+**REQ-SEC-074** Ethereum specifics: every deployed contract MUST have source verified on the canonical explorer(s) and Sourcify, built with pinned compiler version/settings committed to the repo.
+
+**REQ-SEC-075** Dependency hygiene: lockfiles committed; `cargo audit`/`cargo vet` (Rust) and dependency audit (Solidity/TS) in CI; release artifacts signed; no unpinned toolchains in release paths.
+
+---
+
+## 8. Bridge stance
+
+Per D-05 there is **no persistent bridge**: migration is one-way Merkle claims plus exchange swaps, and the
+claims system is time-bounded and sunset per §4.5. This is a deliberate security posture, not a gap: a standing
+bridge would be a second honeypot with an indefinite lifetime.
+
+**REQ-SEC-076** The Vendor MUST NOT deploy any burn/mint or lock/mint pathway for AKT or ACT beyond the claims system and the emissions minter specified in this document set.
+
+If governance later pursues multichain AKT, the design constraint is the **KelpDAO incident (2026-04)**: ~$292M
+lost through a LayerZero deployment configured with a single verifier (1-of-1 DVN) whose RPC infrastructure
+attackers (attributed to Lazarus) compromised. The framework held; the verifier quorum configuration was the
+failure.
+
+**REQ-SEC-077** Any future multichain AKT deployment MUST use a burn/mint framework (NTT-class), MUST require ≥3 independent verifiers under distinct operators and infrastructure (no 1-of-N or vendor-default configs), MUST enforce per-chain rate limits sized to observed organic daily volume, and MUST pass a dedicated security review + audit under this document's process before launch.
+
+---
+
+## Cross-references
+
+- [01. Current architecture](./01-current-architecture.md): the mechanisms whose semantics §2 threat models preserve.
+- [03. Solana architecture](./03-solana-architecture.md) / [04. Ethereum architecture](./04-ethereum-architecture.md): PDA schemas, oracle bounds, parameter ranges consumed by REQ-SEC-017/037/046.
+- [05. Token migration](./05-token-migration.md): claim digest specification, root construction, Wind-down Reserve.
+- [09. Testing & verification](./09-testing-and-verification.md): executable form of §6 invariants; drills and dress rehearsals.
+- [10. Rollout & cutover](./10-rollout-and-cutover.md): gates G0–G5 (REQ-SEC-059 binds to G3), war-room windows.
+- [11. Scope of work](./11-scope-of-work.md): audit/bounty/monitoring budget and staffing.
+- [12. Risk register](./12-risk-register.md): risk-level treatment of the §1.2 surfaces.
+- [13. Open questions](./13-open-questions-and-assumptions.md): Q-08 (collateral), Q-11 (Realms gaps), A-13 (Alpenglow).
+
+## Feeds into
+
+- **09**: invariants I-1..I-7, drill requirements, monitor alert tests.
+- **10**: gate entry criteria (audit closure REQ-SEC-058..061), pause runbooks, war-room windows.
+- **11**: audit tranches, bounty, monitoring, key-ceremony deliverables as SOW line items.
+- **12**: §1/§2 threat surfaces as risk-register entries with owners.

--- a/spec/aep-79/doc/09-testing-and-verification.md
+++ b/spec/aep-79/doc/09-testing-and-verification.md
@@ -1,0 +1,554 @@
+# 09. Testing & Verification
+
+| | |
+|---|---|
+| **Document** | 09. Testing & verification |
+| **Doc ID** | AKASH-MIG-09 |
+| **Version** | 0.9 (draft for review) |
+| **Date** | 2026-08-10 |
+| **Owner** | Overclock Labs |
+| **Audience** | Vendor engineering, Vendor QA, Akash core team, auditors |
+| **Status** | Normative where marked (MUST/SHALL); informative otherwise |
+
+## Purpose
+
+Define the complete verification program for the migration: layered test strategy, the differential
+("parity") harness against current-chain behavior, property/fuzz/invariant suites, integration
+environments, the public testnet program, migration rehearsals, load/performance targets, CI/release
+engineering, and the acceptance/traceability machinery that gates every milestone. The central
+thesis: this program migrates a live economy, so **behavioral equivalence with `akashnet-2` is the
+primary acceptance criterion**, proven by replaying recorded history, not argued from code review.
+
+## In scope
+
+- Test layers, tooling, and ownership for both candidate target paths (D-01; selected at Gate 0).
+- The golden-vector differential harness against recorded `akashnet-2` behavior.
+- Integration localnet definition and the numbered scenario catalog (PR gate).
+- Public testnet phases, migration rehearsals, load/perf targets, CI/release gates, traceability.
+
+## Out of scope
+
+- Audit scope, bug-bounty terms, incident response: [08. Security & audits](./08-security-and-audits.md).
+- Snapshot/export/transform pipeline design: [06. State & data migration](./06-state-and-data-migration.md) (this doc verifies it).
+- Gate definitions and the cutover runbook: [10. Rollout & cutover](./10-rollout-and-cutover.md) (this doc supplies their testing exit criteria).
+- Team sizing and QA workstream staffing: [11. Scope of work](./11-scope-of-work.md).
+
+---
+
+## 1. Test strategy overview
+
+The current chain ships test infrastructure the Vendor should mine, not discard: Go keeper unit
+tests (`make test`), tagged integration tests (`make test-integration`, tag `e2e.integration` over
+`tests/e2e/...`), full-app simulations (`make test-sims`), an upgrade-rehearsal harness that
+testnetifies real mainnet snapshots (`tests/upgrade`, `script/upgrades.sh`, tag `e2e.upgrade`;
+`akash in-place-testnet` from `cmd/akash/cmd/testnetify/`, `app/testnet.go`), and a scripted
+localnet under `_run/`. Keeper tests and testnetify tooling feed layers L4 and L7 directly.
+
+**REQ-TST-001** The Vendor MUST implement the nine-layer verification program in Table 1; no layer
+MAY be skipped for the target selected at Gate 0 (gates per [10](./10-rollout-and-cutover.md)).
+
+Table 1. Test layers, tooling, ownership:
+
+| # | Layer | Purpose | Solana tooling | EVM tooling | Owner | Cadence |
+|---|---|---|---|---|---|---|
+| L1 | Unit | Instruction/function correctness, error paths | LiteSVM (in-process SVM) + Mollusk (instruction harness, CU metering); Anchor test suites | Foundry `forge test` | Vendor protocol team | Every PR |
+| L2 | Property / fuzz / invariant | Randomized state machines against invariants (§3) | proptest/cargo-fuzz driving LiteSVM/Mollusk state machines | Foundry fuzz + invariant testing | Vendor protocol team | PR (bounded) + nightly + weekly deep |
+| L3 | Integration (full-stack localnet) | Cross-program flows + off-chain stack (§4) | solana-test-validator / Surfpool localnet + cranks + indexer + provider adapter | Anvil + keeper automation mocks + indexer + provider adapter | Vendor QA | Every PR (subset), nightly (full) |
+| L4 | Differential vs current chain | Golden-vector replay of recorded `akashnet-2` behavior (§2) | Vector runner over LiteSVM | Vector runner over Foundry/Anvil | Vendor QA + Overclock counterpart | PR (core subset) + nightly (full corpus) |
+| L5 | Fork / mainnet-sim | New programs against real deployed dependencies (Pyth, the settlement stablecoin, Squads/Safe, Realms/Governor) on forked target-chain state | Surfpool mainnet fork; bankrun for fast fork-level JS tests | Anvil `--fork-url` (host chain) | Vendor QA | Nightly + pre-release |
+| L6 | Public testnet | Real providers, real hardware, real wallets (§5) | Solana devnet/testnet deployment | Host-chain public testnet (e.g. Base Sepolia or Arbitrum Sepolia) | Vendor + community providers | Continuous from M-phase per [11](./11-scope-of-work.md) |
+| L7 | Migration rehearsals | Full dry-runs of S1/S2 pipeline + cutover runbook on forked mainnet state (§6) | testnetify (`in-place-testnet`) old chain + target-chain rehearsal deploys | same | Vendor + Overclock, observed by community | R1–R3 pre-G3, plus R4 final dress at S1−14d ([10](./10-rollout-and-cutover.md)) |
+| L8 | Chaos / load | Throughput, latency, congestion, fault injection (§7) | Load generator + Surfpool/testnet congestion sims | Load generator + Anvil/testnet fee sims | Vendor infra + QA | Weekly from feature-complete; pre-gate |
+| L9 | Audits as verification | External audits + bounty converted into executable regressions | per [08](./08-security-and-audits.md) | per [08](./08-security-and-audits.md) | Auditors + Vendor | Per audit window |
+
+**REQ-TST-002** All test code, vectors, harnesses, and CI definitions MUST live in the protocol
+monorepo (or pinned submodules) and MUST be deliverables of the engagement: reviewable, runnable by
+Akash without Vendor infrastructure.
+
+**REQ-TST-003** Each layer MUST have a named owner on the Vendor side; the Vendor MUST staff a test
+lead (see [11](./11-scope-of-work.md) RACI) accountable for the traceability matrix (§9).
+
+**REQ-TST-004** Layers L1–L4 artifacts (vector corpus, scenario catalog, invariant definitions) MUST
+be target-neutral in specification form so that the non-selected path's suites remain executable
+until Gate 0 ratifies D-01; after Gate 0 only the selected target's suites are maintained.
+
+**REQ-TST-005** Every externally reported defect (audit finding, bounty submission, testnet bug)
+MUST gain a failing regression test before its fix is merged, tagged with the finding ID from
+[08](./08-security-and-audits.md).
+
+---
+
+## 2. Differential (parity) testing against the current chain
+
+This is the signature element of the program. Rewriting ~10 modules of settled economic logic
+(escrow streaming, FIFO refunds, overdrawn debt, BME queue/circuit-breaker; see
+[01](./01-current-architecture.md)) invites silent divergence. The defense is a **golden-vector
+harness**: recorded input→outcome traces from the current implementation and from `akashnet-2`
+mainnet itself, replayed through the new programs/contracts, asserting identical integer outcomes.
+
+A **golden vector** is a self-contained, canonical-JSON record: `{vector_id, family, source,
+pre_state, ops[] (each with height/timestamp), expected_post_state, expected_transfers[],
+expected_events[]}`; schema versioned, byte-deterministic, committed to the repo.
+
+```mermaid
+flowchart LR
+    KT[Instrumented Go keeper tests] --> EX[Vector extractor]
+    AR[(akashnet-2 archive node<br/>state + tx + event history)] --> EX
+    EX --> GV[(Golden vector corpus<br/>canonical JSON, versioned)]
+    GV --> VAL[Reference executor<br/>current Go keepers replay<br/>corpus self-check]
+    GV --> NORM[Normalizer<br/>per-block to per-second + rounding ledger]
+    NORM --> SR[Solana runner - LiteSVM]
+    NORM --> ER[EVM runner - Foundry/Anvil]
+    SR --> CMP{Comparator<br/>integer-exact}
+    ER --> CMP
+    CMP --> REP[Parity report artifact<br/>published per release]
+```
+
+### 2.1 Vector sources
+
+**Source (a): keeper-derived vectors.** The existing Go keeper test suites already encode the
+protocol's hardest edge cases; the Vendor MUST instrument them (with Overclock support) to emit
+vectors rather than re-derive scenarios by hand.
+
+| Family | Extracted from (current code) | Representative cases |
+|---|---|---|
+| VEC-ESC-SETTLE | `x/escrow/keeper` settle paths (`accountSettle`, `accountSettleFullBlocks`) | multi-payment accrual, zero-height delta, settle-at-close |
+| VEC-ESC-FIFO | `deductFromBalance` FIFO over `Deposits` | multi-depositor ordering, partial depletion, zero-balance pruning |
+| VEC-ESC-OVER | overdrawn transitions (negative funds, `Unsettled` debt, frozen `SettledAt`) | shortfall mid-stream, deposit-while-overdrawn, close-while-overdrawn |
+| VEC-ESC-FALLBACK | `settleFromAktFallback` | ACT debt settled in AKT at oracle price under BME CR-halt; blocked under oracle-halt |
+| VEC-ESC-REFUND | close/refund paths incl. grant-restore (`saveAccount` grant refund) | balance vs grant sources, allowance restoration amounts |
+| VEC-BME-QUEUE | `x/bme` EndBlocker epoch execution | batch cap (MaxEndblockerRecords=50), retry→cancel at MaxPendingAttempts=3, spread application |
+| VEC-BME-CR | `calculateCR` + `mintStatusUpdate` | healthy↔warning↔halt_cr↔halt_oracle transitions, backoff schedule, refund-under-CR-halt |
+| VEC-MKT-MATCH | market bid/lease handlers | price ceiling, max-bids, attribute matching, losing-bid closure |
+| VEC-DEP-LIFE | deployment/group state machine + escrow hooks | close cascade, pause/start, insufficient-funds group state |
+
+**Source (b): mainnet-derived vectors.** Real escrow account and payment lifecycles exported from
+`akashnet-2` archive data: for a sampled entity, the full op sequence (create, deposits, settles,
+withdrawals, close) with the chain's actual recorded outcomes (transfer amounts, final balances,
+state transitions) as the expected values. Sampling MUST cover: long-lived leases (>30d), multi-denom
+accounts (uakt+uact), grant-funded multi-depositor deployments, overdrawn closures, BME swap epochs
+around the v2.x activations, and high-frequency-withdrawal providers. Addresses MAY be pseudonymized
+via a deterministic mapping (chain data is public; anonymization is a presentation/legal option per
+Q-10, not an integrity mechanism).
+
+**REQ-TST-006** The Vendor MUST build the golden-vector harness: extractor(s), normalizer,
+per-target runners, integer-exact comparator, and report generator, runnable offline and in CI.
+
+**REQ-TST-007** The corpus MUST be self-validated: replaying every vector through the current Go
+keeper code (reference executor) MUST reproduce the recorded expected outcomes bit-exactly; vectors
+failing self-validation MUST be excluded and the extraction defect fixed.
+
+**REQ-TST-008** Source (a) MUST cover every family in the table above, with ≥5 vectors per family at
+G1 and full keeper-test coverage (every keeper test case that touches funds emits a vector) by G2.
+
+**REQ-TST-009** Source (b) MUST deliver ≥250 complete mainnet lifecycles by G2, meeting the sampling
+coverage list above; the extraction tool and sample manifest are deliverables of
+[06](./06-state-and-data-migration.md)'s export pipeline.
+
+**REQ-TST-010** The vector schema MUST be versioned; any schema change MUST re-run corpus
+self-validation (REQ-TST-007) before merge.
+
+### 2.2 Tolerance and normalization rules
+
+The old and new implementations differ in two documented, deliberate ways; vectors are normalized for
+exactly these, and nothing else:
+
+1. **Time basis (D-21).** Current rates are per-block on a 6.5 s target (`util/network/network.go:8`,
+   `AverageBlockTime = 6500ms`). Vectors record heights; the normalizer converts rate and elapsed
+   time to per-second using the single conversion factor fixed at S1, storing both raw and normalized
+   forms, so both implementations compute accrual over identical time deltas.
+2. **Rounding rules.** The current chain computes in 18-decimal fixed point (`LegacyDec`) and
+   truncates to integer micro-units at transfer boundaries (deposit fetch, `paymentWithdraw`).
+   [03](./03-solana-architecture.md)/[04](./04-ethereum-architecture.md) define the target's integer
+   math. Every place the target's rounding provably differs MUST be recorded as a numbered entry
+   (`ROUND-nn`) in a **Rounding Ledger** with worst-case bound analysis and client sign-off; the
+   normalizer applies only signed-off ledger entries.
+
+**REQ-TST-011** After normalization per the Rounding Ledger, all integer micro-unit outcomes
+(transfer amounts, balances, debt, spread) MUST match exactly (zero tolerance); any divergence is a
+release-blocking defect or requires a new signed-off `ROUND-nn` entry.
+
+**REQ-TST-012** The per-block→per-second conversion factor MUST appear exactly once in the harness
+(shared constant with the [05](./05-token-migration.md)/[06](./06-state-and-data-migration.md)
+transform pipeline), never re-derived per test.
+
+**REQ-TST-013** Harness and comparator MUST use integer/fixed-point arithmetic exclusively; binary
+floating point MUST NOT appear anywhere in vector generation, normalization, or comparison.
+
+### 2.3 Parity report
+
+**REQ-TST-014** Every tagged release MUST publish a **parity report** artifact: corpus version and
+size per family, pass/fail counts per target, the complete Rounding Ledger, every open divergence
+with disposition, and reproduction instructions. The report is public (published with release
+assets) and is an input to gate reviews.
+
+**REQ-TST-015** The parity suite (core subset on PR, full corpus nightly) MUST be a merge gate for
+any change touching escrow, BME, market matching, claims, or token programs/contracts.
+
+**REQ-TST-016** Corpus milestones: ≥10 vectors running end-to-end at G1 (≥6 escrow-family); ≥500
+total vectors (≥250 mainnet-derived) all green at G2; corpus frozen (additions only for defects
+found) from G3.
+
+---
+
+## 3. Property, fuzz & invariant suites
+
+The current chain registers **no** invariants (crisis module effectively unwired; see
+[01](./01-current-architecture.md)); correctness rests on keeper tests alone. The target MUST be
+strictly stronger: the protocol invariants defined in [08 §6](./08-security-and-audits.md) are the
+contract, enforced as fuzz properties (L2) and as runtime monitors in integration/testnet (L3/L6).
+
+| Invariant (from 08 §6) | Property encoding (what the fuzzer asserts) |
+|---|---|
+| Conservation | Σ(deposits) = Σ(withdrawals + refunds + held funds + recorded debt) per escrow account and globally; BME vault + supplies conserve value net of spread |
+| No-negative | No token balance, allowance, or fund entry below zero except the documented overdrawn marker semantics, which MUST be internally consistent |
+| One-claim-per-leaf | A Merkle claim leaf can be consumed at most once, under concurrent/replayed submission |
+| CR-gating | No ACT mint executes while CR < halt threshold; ACT→AKT refunds allowed under CR-halt, blocked under oracle-halt |
+| FIFO order | Refunds consume depositors strictly in deposit order; grant refunds restore exactly the unspent allowance |
+| Settle idempotency | settle(t); settle(t) ≡ settle(t); and settle(t1); settle(t2) ≡ settle(t2) for t1<t2 |
+| Close-always-refunds | Account close in any reachable state returns every residual balance to the correct depositor |
+| Rent-refund-on-close (Solana) | Closing any terminal-state entity account refunds rent lamports to the designated payer; no orphaned accounts |
+
+**REQ-TST-017** Every invariant listed in [08 §6](./08-security-and-audits.md) MUST be encoded (a) as
+a fuzz/invariant property over a randomized operation state machine and (b) as a runtime monitor
+executed continuously against localnet and testnet state; the two encodings MUST share one
+declarative invariant definition.
+
+**REQ-TST-018** Line coverage MUST be ≥85% across all protocol programs/contracts, measured by
+`cargo llvm-cov` over host-executed program crates (Solana) and `forge coverage` (EVM), reported per
+release.
+
+**REQ-TST-019** Branch coverage MUST be 100% on three subsystems: Merkle claims verification, escrow
+settlement math (accrual, FIFO deduction, overdrawn transitions, fallback), and BME collateral-ratio
+computation and status transitions; CI MUST fail on regression below 100%.
+
+**REQ-TST-020** Fuzz budgets: every PR runs the bounded seeded suite (persisted corpus + regression
+seeds, ≤10 min wall clock); nightly ≥4 h per protocol program/contract suite; weekly ≥24 h with
+corpus persistence. Every fuzz-found defect adds its input to the regression seed set permanently.
+
+### Solana specifics
+
+**REQ-TST-021** Compute-unit budgets: the per-instruction CU budgets defined in
+[03](./03-solana-architecture.md) MUST be enforced as Mollusk CU-metering tests; CI MUST fail if any
+instruction exceeds its budget or regresses >5% against the last tagged baseline without an approved
+budget change.
+
+**REQ-TST-022** Property suites MUST execute the real compiled programs via LiteSVM/Mollusk (not
+extracted pure functions alone), so account-model concerns (signer/writable flags, PDA seed
+collisions, account-close/revival, CPI depth) are inside the fuzzed surface.
+
+### Ethereum specifics
+
+**REQ-TST-023** Foundry invariant testing MUST run with ≥256 runs × depth ≥15 nightly (bounded PR
+config documented in CI), with handler-based state machines covering the full escrow/BME/market
+operation set including adversarial actors (non-owner callers, reentrant tokens where interfaces
+allow).
+
+**REQ-TST-024** Gas snapshots (`forge snapshot`) MUST be committed; CI MUST fail on >5% gas
+regression for any externally callable function against the budgets defined in
+[04](./04-ethereum-architecture.md) without an approved change.
+
+---
+
+## 4. Integration environment & scenario catalog
+
+The PR gate is a **full-stack migration localnet**: one command brings up the target chain, all
+protocol programs/contracts, the off-chain stack, and deterministic test actors, the successor to
+the current `_run/` localnet as the day-to-day development environment.
+
+| Component | Solana form | EVM form |
+|---|---|---|
+| Chain | `solana-test-validator` or Surfpool localnet, deterministic genesis | Anvil, deterministic genesis/chain-id |
+| Protocol programs/contracts | all `akash-*` programs per [03](./03-solana-architecture.md) | all contracts per [04](./04-ethereum-architecture.md) |
+| Tokens | AKT (Token-2022), ACT (NonTransferable), test settlement-stablecoin mint | AKT/ACT ERC-20s, test settlement stablecoin |
+| Oracle | fake Pyth feed: price simulator with scriptable modes (fixed, step, ramp, stale, deviation-spike) writing pull-oracle updates | MockPyth-style contract, same scriptable modes |
+| Cranks/automation | permissionless crank runner (Tuk Tuk-style) for settle/BME epochs/residuals | keeper automation mock (Gelato/Chainlink-style scheduler) |
+| Indexer | Geyser/webhook → Postgres indexer serving Console API shapes (D-16) | Ponder-class indexer, same API shapes |
+| Provider | `provider-services` with chain adapter (D-17) against kind/k3d or mock-cluster mode | same |
+| Console | Console dev build pointed at localnet indexer + RPC | same |
+| Claims | `akash-claims` / `MigrationClaims` with a fixture Merkle distribution (synthetic S1) | same |
+| Invariant monitor | runtime monitor per REQ-TST-017 | same |
+
+**REQ-TST-025** The migration localnet MUST start from a single command (containerized), reach ready
+state in ≤5 min on a developer workstation, and be fully deterministic (fixed keys, fixed genesis,
+scriptable clock/oracle).
+
+**REQ-TST-026** CI MUST run the PR-gate scenario subset (marked ▲ below) on every PR and the full
+catalog nightly; a red scenario blocks merge.
+
+**REQ-TST-027** The fake Pyth feed MUST support scripted staleness and deviation injection so oracle-
+halt paths (S-08, S-21) are exercised deterministically.
+
+**REQ-TST-028** The Vendor MUST implement every scenario in Table 2 as an automated test; the
+catalog MAY grow but MUST NOT shrink without client sign-off.
+
+Table 2. Scenario catalog (▲ = PR gate subset). "Verifies" lists the owning docs/decisions; exact
+REQ-ID bindings live in the traceability matrix (§9).
+
+| ID | Scenario | Key assertions | Verifies |
+|---|---|---|---|
+| S-01 ▲ | Happy path: create deployment (ACT deposit) → order → bid → lease → stream → withdraw → tenant close | escrow accrual exact; provider paid 100% (no take); refunds on close | 03/04 market+escrow; D-09, D-21 |
+| S-02 ▲ | Multi-group deployment: 2 groups, independent leases; close one group, other unaffected | per-group orders; close cascade scoped | 03/04; D-09, D-23 |
+| S-03 | GPU attributes + audited attributes: order requires audited attrs; only audited provider matches | attribute + audit matching parity | 03/04 provider/audit; D-09 |
+| S-04 | Max-bids rejection: bids up to OrderMaxBids (default 20) accepted, next rejected | param-driven cap enforced | 03/04 market params |
+| S-05 ▲ | Losing-bid refunds: N bids, 1 wins; losers closed and collateral refunded at match | bid escrow close-on-lost; refund exactness | 03/04; D-23 |
+| S-06 ▲ | Grant-funded deposit: delegated-deposit allowance funds deployment; close restores unspent allowance | allowance decrement/restore-on-refund | D-21; 03/04 escrow |
+| S-07 ▲ | Insufficient funds → overdrawn cascade: funds drain; permissionless settle flags overdrawn; lease→insufficient_funds; group→insufficient_funds; debt recorded | overdrawn semantics + hook cascade parity | D-21; 01 hooks; 03/04 |
+| S-08 ▲ | AKT-fallback settlement: BME at CR-halt, account holds AKT → ACT debt settled in AKT at oracle price; blocked under oracle-halt | fallback conversion math; halt-mode gating | D-20, D-21 |
+| S-09 ▲ | BME mint/burn epochs: queued swaps execute in time-based epoch batches with spread; batch cap honored | queue order, spread, epoch timing via crank/keeper | D-20 |
+| S-10 ▲ | BME breaker trip/recovery: drive CR <9000 bps → halt; ACT→AKT refunds still allowed; recover above warn → epochs resume with backoff | CR transitions + backoff parity | D-20 |
+| S-11 | BME retry/cancel: failing record retried to MaxPendingAttempts (3) then canceled, funds returned | cancel reason + refund | D-20 |
+| S-12 | Reclamation: provider starts reclaim → early close rejected → deadline elapses → close succeeds | 1h–720h window bounds; deadline math | D-24 |
+| S-13 | Provider registration + key rotation: rotate on-chain signing key; JWTs from old key rejected, new accepted | registry as JWT trust root | D-10; 07 |
+| S-14 ▲ | JWT auth to provider gateway: tenant claims lease → wallet-derived JWT → gateway grants scoped access; expired/mis-scoped rejected | end-to-end auth chain | D-10; 07 |
+| S-15 ▲ | Claim (single wallet): S1 leaf → claim → balance credited; second claim rejected | Merkle proof + one-claim-per-leaf | 05; 08 §6 |
+| S-16 | Claim (multisig): Squads (Solana) / Safe (EVM) executes claim for a multisig leaf | multisig claim path | 05 |
+| S-17 | Claim (vesting): vesting account re-created with identical remaining schedule; release curve asserted over simulated time | D-06 vesting fidelity | 05 |
+| S-18 | Residual distribution: old-chain wind-down settlement → weekly Merkle drop from Wind-down Reserve → provider claims | D-05 residual cycle mechanics | 05/06 |
+| S-19 | Escrow top-up: deposit AKT and ACT into a live account; deposit while overdrawn settles and clears debt per current semantics | top-up + overdrawn-deposit parity | D-21; 01 escrow |
+| S-20 | Stablecoin settlement: lease priced/settled in the natively-issued settlement stablecoin end-to-end | D-14 first-class stable settlement | 03/04 |
+| S-21 | Oracle degradation: stale/deviant price → oracle-halt: BME swaps rejected both directions, AKT-fallback blocked; recovery restores service | D-13/D-20 oracle gating | 03/04 |
+| S-22 | Governance param update: DAO+timelock changes a protocol param (e.g. min deposit); takes effect after delay; direct/unauthorized update rejected | D-11 governance path | 03/04; 08 |
+| S-23 | Emissions epoch: scheduled mint to provider-incentives pool + community treasury; hard cap enforced | D-12 mechanism (curve per Q-01) | 03/04 |
+| S-24 | Indexer integrity: kill/restart indexer mid-flow; catches up with no gaps; Console API shapes unchanged; (EVM) reorg replay correct | D-16, D-23 events-as-history | 07 |
+| S-25 | Deployment update: manifest hash update on-chain; provider fetches/validates new manifest; mismatch rejected | D-09 manifest pointer flow | 03/04; 07 |
+| S-26 | Crank/keeper outage: automation down 1 h; lazy accrual stays correct; on resume settlement catches up; (Solana) closing terminal entities refunds rent | D-21 laziness; D-23 close/rent-refund | 03; 08 §6 |
+
+**REQ-TST-029** Each scenario MUST assert on indexer-reported state as well as chain state, so the
+indexer (the system of record for history per D-23) is inside the tested surface.
+
+---
+
+## 5. Public testnet program
+
+| Phase | What | Entry criteria | Exit criteria |
+|---|---|---|---|
+| P1 Internal devnet | Continuous deployment target for Vendor + Overclock; synthetic actors only | Localnet PR gate green; CD pipeline live (§8) | 14 consecutive days uptime; full scenario catalog green on devnet; invariant monitors clean |
+| P2 Incentivized provider testnet (≥6 weeks) | Public testnet with real providers on real hardware, incentives program, Console testnet UI, claims dress-rehearsal distribution | P1 exit; provider onboarding docs + adapter GA-candidate; bounty scope extended to testnet ([08](./08-security-and-audits.md)) | Participation targets met (REQ-TST-031); ≥500 real deployments cumulative; load targets demonstrated (§7); zero open sev-1/sev-2 |
+| P3 Migration dress rehearsal (community-open) | Rehearsal R3 (§6) run in public: claims portal, residual cycle, provider re-registration, exchange sandbox | P2 exit; rehearsals R1/R2 complete; audit fixes merged | R3 pass criteria met (§6); community-reported blocker count = 0 for 14 days |
+
+**REQ-TST-030** The three phases MUST run in order; each exit MUST be evidenced in a signed-off
+report attached to the corresponding gate package (§9).
+
+**REQ-TST-031** P2 MUST reach: ≥25 independent provider operators, spanning ≥3 geographic regions,
+including ≥5 providers offering GPUs, each sustaining leases for ≥2 consecutive weeks.
+
+**REQ-TST-032** P2 MUST include a claims dress-rehearsal distribution whose Merkle tree is generated
+by the real [06](./06-state-and-data-migration.md) pipeline from a testnetified `akashnet-2` export
+(not synthetic fixtures) so claim UX meets realistic leaf shapes (single, multisig, vesting).
+
+**REQ-TST-033** The bug-bounty program defined in [08](./08-security-and-audits.md) MUST include the
+public testnet and the claims portal in scope no later than P2 start.
+
+**REQ-TST-034** Testnet deployments MUST be continuously deployed from `main` (§8) with an on-chain
+version registry (`akash-config` / `AkashConfig`) so clients can negotiate versions, preserving the
+current chain's discovery/`min_client_version` contract per [07](./07-offchain-and-clients.md).
+
+---
+
+## 6. Migration rehearsals
+
+Rehearsals execute the [06](./06-state-and-data-migration.md) snapshot/transform pipeline and the
+[10](./10-rollout-and-cutover.md) cutover runbook end-to-end on **forked mainnet state**, using the
+in-repo testnetify tooling (`akash in-place-testnet`; the `tests/upgrade` + `script/upgrades.sh`
+pattern: download real snapshot → testnetify → run the sunset upgrade under automation).
+
+| Rehearsal | Anchor | Scope | Pass criteria (all MUST hold) |
+|---|---|---|---|
+| R1 | During program phase P3 ([10](./10-rollout-and-cutover.md) §1); first dry-run | Pipeline shakeout: fork mainnet, run sunset upgrade, export S1, build distribution, deploy claims to rehearsal env, sample claims | Root reproducibility (REQ-TST-036); pipeline completes within 2× timing budget; ≥100 sampled claims verified incl. vesting |
+| R2 | During program phase P3, after R1 passes | Full runbook: T-minus schedule executed verbatim; wind-down simulation with live-fire providers from P2; residual cycle ×2; rollback drill | Timing budget met (REQ-TST-037); claims E2E incl. Ledger + multisig (REQ-TST-038); residual ×2 (REQ-TST-039); rollback drill pass (REQ-TST-040) |
+| R3 | G3 evidence (run within testnet phase P3, §5) | Dress rehearsal on candidate release + frozen runbook, community-observed; exchange sandbox swaps; G3 evidence | All R2 criteria on frozen artifacts; zero manual interventions outside runbook; exchange sandbox pass (REQ-TST-041) |
+| R4 | S1−14d (per [10](./10-rollout-and-cutover.md) §4.1) | Final dress on fresh mainnet-fork state: frozen R3 release + runbook re-run | All R3 criteria re-confirmed on the frozen artifacts; failure routes to the [10](./10-rollout-and-cutover.md) §6.1 abort review |
+
+**REQ-TST-035** The Vendor MUST execute ≥3 full rehearsals (R1–R3) before G3; R3 MUST run on the frozen
+release candidate and frozen runbook; any material change after R3 requires a repeat rehearsal. R4, the
+final dress at S1−14d per [10](./10-rollout-and-cutover.md) §4.1, re-runs the frozen R3 configuration.
+
+**REQ-TST-036** Merkle distribution roots (S1 and each residual) MUST be reproduced bit-identically
+from the same export by two independent implementations of the transform pipeline (per
+[06](./06-state-and-data-migration.md)'s dual-implementation requirement) in every rehearsal.
+
+**REQ-TST-037** The S1 pipeline (halt-marker → export → transform → root) MUST complete within the
+budget allocated in [10](./10-rollout-and-cutover.md)'s T-minus schedule; for planning this doc assumes
+≤6 h export-to-root and attested root published ≤24 h after C (REQ-ROL-029). Rehearsals MUST additionally
+drill claims-open at the rehearsed C+8–10 d offset (after the 7-day public verification window per
+D-05.b, compressed on the rehearsal clock with every step executed in full); reconcile with 10 at G2.
+
+**REQ-TST-038** Claims MUST be exercised end-to-end in R2 and R3 with real wallet vectors: hot
+wallets, Ledger hardware wallets (current firmware), a Squads (Solana) or Safe (EVM) multisig, and a
+re-created vesting account; each claim verified against the expected leaf to the micro-unit.
+
+**REQ-TST-039** The weekly residual-distribution cycle (D-05) MUST be simulated at least twice
+within a rehearsal: old-chain wind-down events → weekly export → residual Merkle drop from the
+Wind-down Reserve → provider claim, asserting conservation (Reserve debits = old-chain entitlements)
+each cycle.
+
+**REQ-TST-040** The pre-S1 rollback plan defined in [10](./10-rollout-and-cutover.md) MUST be
+drilled in at least one rehearsal: abort at the latest allowed T-minus step, old chain resumes
+normal operation, target-chain artifacts safely quarantined; drill timed and reported.
+
+**REQ-TST-041** Before G3, ≥2 exchange venues (from the Q-04 coordination list) MUST complete
+sandbox integration tests: test swap of custodial balances against a rehearsal distribution,
+deposit/withdrawal pause/resume choreography, and address-format validation; results recorded per venue.
+
+**REQ-TST-042** Each rehearsal MUST produce a published report: timings per runbook step, root
+hashes, claim samples, defects found, runbook deltas; R-report sign-off is a gate input (§9).
+
+---
+
+## 7. Load & performance
+
+Design targets derive from the live-chain operation mix. The Q-19 kickoff data pull (archive/indexer
+analysis of tx and query volumes by type, peak bid-storm shapes, settlement cadence) is the
+methodological basis; the prior shared-security RFP cited ≈30M marketplace operations/day, which
+this program treats as an **upper-bound planning figure**: it includes read/query traffic, not
+on-chain writes [TO-VERIFY: decompose the 30M ops/day figure into writes vs reads from Q-19 data].
+
+Methodology: an open-source load generator replays the Q-19-derived op mix (scaled) against testnet
+(L6) and fork (L5) environments; every target below is measured under the sustained profile with the
+invariant monitor (REQ-TST-017) running, and with real provider daemons for REQ-TST-047.
+
+**REQ-TST-043** The system MUST sustain ≥50 marketplace tx/s (mixed op profile) for ≥60 min with
+zero protocol-level failures.
+
+**REQ-TST-044** The system MUST absorb bursts of ≥500 tx/s for ≥60 s (bid-storm profile) with no
+lost protocol operations beyond the documented client retry policy.
+
+**REQ-TST-045** Under the sustained profile, settlement-due→settlement-executed lag
+(crank/keeper-driven) MUST be ≤60 s p95.
+
+**REQ-TST-046** Chain-event→API-visible indexer lag MUST be ≤2 s p95 / ≤10 s p99 under sustained load.
+
+**REQ-TST-047** Provider bid-engine end-to-end latency (order seen → bid landed) MUST be ≤5 s p95
+under sustained load.
+
+**REQ-TST-048** The load generator (op-mix replay, configurable scale, seeded randomness) MUST be a
+delivered artifact with the derivation from Q-19 data documented.
+
+**REQ-TST-049** A chaos suite MUST run weekly against testnet: crank/keeper outage (≥1 h), oracle
+staleness injection, RPC brownout, indexer restart, (EVM) reorg replay, asserting recovery within
+documented RTOs and zero invariant violations.
+
+### Solana specifics
+
+**REQ-TST-050** Congestion simulation: under synthetic fee pressure on a Surfpool/testnet
+environment, the priority-fee escalation policy defined in [03](./03-solana-architecture.md)/[07](./07-offchain-and-clients.md)
+MUST land ≥99% of protocol transactions within its fee ceiling and bounded retries; policy
+parameters validated against 2026 congestion profiles.
+
+**REQ-TST-051** Hot-account contention: a dedicated test MUST drive concurrent load against the BME
+queue and other shared PDAs to demonstrate epoch execution sustains target throughput within
+Solana's 12M CU per-writable-account per-block cap (as of 2026-08), and that market-state sharding
+(D-23) keeps marketplace throughput unaffected by BME contention.
+
+### Ethereum specifics
+
+**REQ-TST-052** Host-chain fee-spike simulation (blob-fee-driven): replay historical host-chain/L1 blob-fee spike profiles against
+the fee-management policy; assert per-op fee ceilings hold, batch operations (settlement sweeps,
+residual publications) defer per the documented degradation policy, and no correctness-critical
+operation is ever skipped, only delayed within REQ-TST-045's bound or a documented degraded-mode bound.
+
+**REQ-TST-053** Performance MUST be tracked per release against all §7 targets with dashboards;
+regression >10% on any target triggers a release-blocking review.
+
+---
+
+## 8. Release & CI engineering
+
+Table 3. CI matrix:
+
+| Suite | PR | Nightly | Weekly | Release tag |
+|---|---|---|---|---|
+| L1 unit + lint + coverage delta | ✔ | ✔ | ✔ | ✔ |
+| L2 fuzz (bounded seeded) | ✔ (≤10 min) | ≥4 h | ≥24 h | ✔ |
+| L3 localnet scenarios | ▲ subset | full catalog | full + chaos | full |
+| L4 parity vectors | core subset | full corpus | full | full + report |
+| L5 fork tests | none | ✔ | ✔ | ✔ |
+| CU/gas budgets (REQ-TST-021/024) | ✔ | ✔ | ✔ | ✔ |
+| IDL/ABI drift (REQ-TST-056) | ✔ | ✔ | ✔ | ✔ |
+| Verifiable build (REQ-TST-055) | none | ✔ | ✔ | ✔ (gate) |
+
+**REQ-TST-054** The Vendor MUST implement the CI matrix above; PR wall-clock budget ≤30 min for the
+required-to-merge set.
+
+**REQ-TST-055** Releases MUST be reproducible and verifiable: for Solana, deterministic builds with
+published hashes matching on-chain bytecode (solana-verify/Anchor verifiable-build flow, as of
+2026-08); for EVM, pinned compiler/settings with on-chain source verification; a release that fails
+verification MUST NOT be deployed.
+
+**REQ-TST-056** CI MUST regenerate the program IDL (Solana) / contract ABI (EVM) on every build and
+diff it against the artifacts consumed by chain-sdk/client codegen ([07](./07-offchain-and-clients.md));
+drift without a version bump and changelog entry MUST fail the build, with a breaking/non-breaking
+classification in the diff output.
+
+**REQ-TST-057** Continuous deployment: merges to `main` MUST auto-deploy to the internal devnet
+within 1 h; promotion to public testnet MUST be a tagged, signed release through the same pipeline
+used for mainnet (no snowflake deploy path).
+
+**REQ-TST-058** Versioning: semantic versions per program/contract suite with `-rc.N` release
+candidates; every deployed environment MUST expose its versions via the on-chain version registry
+(REQ-TST-034); git tags MUST be signed.
+
+**REQ-TST-059** Every release MUST complete a sign-off checklist recorded in the repo: all Table 3
+suites green; coverage report ≥ targets; parity report published (REQ-TST-014); CU/gas budget report;
+verifiable-build hashes; IDL/ABI diff disposition; traceability delta (§9); open-findings list with
+severities; upgrade-authority/timelock state verified against [08](./08-security-and-audits.md)'s
+key-management spec.
+
+---
+
+## 9. Acceptance & traceability
+
+**REQ-TST-060** The Vendor MUST maintain a machine-readable **requirement traceability matrix**
+(committed to the repo, CI-validated) mapping every `REQ-*` in documents
+[03](./03-solana-architecture.md)–[08](./08-security-and-audits.md) and [10](./10-rollout-and-cutover.md)
+to one or more concrete test IDs (vector families, scenario IDs, property IDs, rehearsal criteria),
+including the REQ-TST set itself.
+
+**REQ-TST-061** At G3 there MUST be zero orphan requirements: every in-scope `REQ-*` maps to at
+least one passing test or an explicit client-approved waiver; CI MUST list orphans on every run.
+
+**REQ-TST-062** Waivers MUST be individually approved by the client, time-boxed or gate-boxed, and
+logged in the traceability matrix with rationale; waivers MUST NOT apply to requirements tagged
+security-critical in [08](./08-security-and-audits.md).
+
+Testing exit criteria contributed to the program gates (gates themselves defined in
+[10](./10-rollout-and-cutover.md); payment linkage in [11](./11-scope-of-work.md)):
+
+| Gate | Testing exit criteria (all MUST hold) |
+|---|---|
+| G1 | Parity harness operational end-to-end on ≥10 golden vectors (≥6 escrow-family) on the selected target (REQ-TST-016); migration localnet one-command boot (REQ-TST-025); S-01 green; CI matrix live for L1/L2-bounded/L3-subset |
+| G2 | Full suite green across Table 3; coverage targets met (REQ-TST-018/019); full vector corpus ≥500 green (REQ-TST-016); scenario catalog complete (REQ-TST-028); P1 exit achieved; timing-budget reconciliation with 10 done (REQ-TST-037) |
+| G3 | Rehearsal R3 passed on frozen artifacts (REQ-TST-035..042); audits complete with fixes merged + regressions added (REQ-TST-005, per [08](./08-security-and-audits.md)); load/perf targets met (REQ-TST-043..052); P2 exit incl. provider targets (REQ-TST-031); zero orphan REQs (REQ-TST-061); exchange sandbox complete (REQ-TST-041) |
+| G4 | Mainnet smoke passed (REQ-TST-064); claims E2E live check passed; parity report for the deployed release published; §7 dashboards live against mainnet |
+
+**REQ-TST-063** Each gate review MUST receive an evidence package: current traceability matrix,
+parity report, coverage/CU/gas reports, rehearsal and testnet-phase reports, open-defect list by
+severity, all published to the community alongside the gate decision.
+
+**REQ-TST-064** Mainnet smoke test: after mainnet deployment and before public cutover announcement,
+the Vendor MUST execute on mainnet with real funds: one canary deployment→bid→lease→settle→close
+cycle (provider operated by Overclock), one BME swap round-trip, and ≥3 live claims from a
+rehearsal-reserved test allocation (hot wallet, Ledger, multisig), all verified to the micro-unit
+and reported in the G4 package.
+
+---
+
+## Cross-references
+
+- [01. Current architecture](./01-current-architecture.md): behavior being preserved; escrow/BME mechanics referenced by vector families.
+- [03. Solana architecture](./03-solana-architecture.md) / [04. Ethereum architecture](./04-ethereum-architecture.md): CU/gas budgets, fee policies, program/contract surfaces under test.
+- [05. Token migration](./05-token-migration.md): Merkle distribution format, claim flows, residual cycle verified here.
+- [06. State & data migration](./06-state-and-data-migration.md): export/transform pipeline and dual-implementation root verification exercised by §6 rehearsals.
+- [07. Off-chain & clients](./07-offchain-and-clients.md): indexer, provider adapter, JWT auth, chain-sdk codegen consumed by §4/§8.
+- [08. Security & audits](./08-security-and-audits.md): invariant list (§6 there) imported by §3; audits/bounty as layer L9.
+- [10. Rollout & cutover](./10-rollout-and-cutover.md): gate definitions, T-minus schedule, rollback plan drilled in §6.
+- [11. Scope of work](./11-scope-of-work.md): QA workstream, test lead role, milestone/payment linkage.
+- [13. Open questions](./13-open-questions-and-assumptions.md): Q-04 (exchanges), Q-19 (op-mix data pull), Q-01 (emissions curve).
+
+## Feeds into
+
+- [10. Rollout & cutover](./10-rollout-and-cutover.md): gate exit evidence (§9), rehearsal results (§6).
+- [11. Scope of work](./11-scope-of-work.md): test deliverables, ownership, and acceptance criteria bound to payment gates.
+- [12. Risk register](./12-risk-register.md): residual risks from waived/orphan requirements and unmet load targets.
+- [08. Security & audits](./08-security-and-audits.md): regression-test obligations for findings (REQ-TST-005).

--- a/spec/aep-79/doc/10-rollout-and-cutover.md
+++ b/spec/aep-79/doc/10-rollout-and-cutover.md
@@ -1,0 +1,539 @@
+# 10. Rollout, Cutover & Old-Chain Sunset
+
+| | |
+|---|---|
+| **Document** | 10. Rollout, cutover & old-chain sunset |
+| **Doc ID** | AKASH-MIG-10 |
+| **Version** | 0.9 (draft for review) |
+| **Date** | 2026-08-10 |
+| **Owner** | Overclock Labs |
+| **Audience** | Vendor engineering & delivery leads, Overclock ops/comms, community reviewers |
+| **Status** | Normative where marked (MUST/SHALL); informative otherwise |
+
+## Purpose
+
+The program spine: phase plan (P0–P7), decision gates (G0–G5), the governance sequence on the Cosmos chain, the S1
+cutover runbook, wind-down operations through halt, rollback/contingency handling, operational notifications, and
+post-migration hypercare/handover. Event notation (fixed in [D-05/D-18](./13-open-questions-and-assumptions.md)): **C** = cutover;
+**S1** = supply snapshot at C; **H** = final halt = C+90d; **S2** = residual snapshot at H.
+
+## In scope
+
+- Phase plan (gate/event-bounded); gate definitions (entry, exit, evidence, approver).
+- The on-chain governance sequence on `akashnet-2` (Akash mainnet), including proposal skeletons.
+- The S1 cutover runbook (T-minus schedule with owners) and the C→H wind-down operating rhythm.
+- Rollback and contingency mechanics, including the abort switch and the point of no return.
+- Operational notifications, hypercare SLAs, success metrics, handover, decommission pointer.
+
+## Out of scope
+
+- The program calendar and the audience-facing communications plan: maintained client-side in the
+  program & comms plan, outside this technical set.
+- Claims/token mechanics and exchange swap design: [05. Token migration](./05-token-migration.md).
+- Snapshot/export tooling, verification internals, archives, decommission details: [06. State & data migration](./06-state-and-data-migration.md).
+- Rehearsal/dry-run definitions and pass criteria: [09. Testing](./09-testing-and-verification.md).
+- RACI, staffing, payment milestones M0..Mn: [11. Scope of work](./11-scope-of-work.md).
+- Risk scoring: [12. Risk register](./12-risk-register.md).
+
+## 1. Phase plan (P0–P7)
+
+**REQ-ROL-001** The program SHALL be executed as eight phases P0–P7 separated by gates G0–G5 (§2). Work gated behind
+a pending gate MUST NOT start, except the "in parallel while pending" items enumerated per gate in §2.
+
+**REQ-ROL-002** The program calendar is maintained client-side outside this technical set; the calendar date of S1
+SHALL be set exclusively by the governance sequence in §3; external communications MUST quote governance-set dates
+only.
+
+| Phase | Bounded by | Principal contents | Exits via |
+|---|---|---|---|
+| P0 Mobilization + Stage A verification | T0 (Vendor kickoff) → G0 | Staffing, environments, re-verification of volatile facts ([13 §4](./13-open-questions-and-assumptions.md)), live-state data pull (Q-19), exchange outreach start (Q-04), prototype spikes (Q-15), signal proposal (§3.i), G0 decision package | **G0** |
+| P1 Design freeze | G0 → G1 | Selected-path architecture ([03](./03-solana-architecture.md)/[04](./04-ethereum-architecture.md)) REQ baseline, [05](./05-token-migration.md)/[06](./06-state-and-data-migration.md)/[07](./07-offchain-and-clients.md) designs, G1-gated Q-xx resolutions, emissions model ratified (Q-01) | **G1** |
+| P2 Build | G1 → G2 | Programs/contracts, claims stack, migration pipeline v1, chain adapter, indexer, Console port | **G2** |
+| P3 Testnet + audits | P2 tail (audit prep on frozen components) → G3 | Public testnet, two audit rounds ([08](./08-security-and-audits.md)), load tests, migration dry-runs R1–R2 ([09](./09-testing-and-verification.md)) | feeds G3 |
+| P4 Rehearsals + governance ratification | dry-run R2 pass → G3 | Rehearsal R3 (mainnet-fork dress, G3 evidence), binding proposals (§3.ii–iii), exchange commitments | **G3** |
+| P5 Launch + S1 cutover + verification | G3 → G4 | Target-chain launch + provider onboarding open (launch precedes C, [07](./07-offchain-and-clients.md)); rehearsal R4 (final dress, S1−14d); §4 runbook: sunset upgrade at C, snapshot, root attestation + 7-day public verification (D-05.b), exchange swaps, claims open ≈C+8–10d | **G4** |
+| P6 Wind-down operations | C → H (90d ≈ 13 wk) | §5: weekly residual distributions, provider migration KPIs, validator wind-down administration, tenant notices (§5.4) | feeds G5 |
+| P7 S2 + sunset + close-out | H → H+13 wk close-out | S2 residual snapshot + final distribution, halt, archives, infra decommission (H+90d), hypercare exit, handover | **G5** |
+
+P3 overlaps P2's tail (audit prep on frozen components); P4 overlaps P3's (rehearsals start once dry-run R2 passes).
+
+## 2. Decision gates (G0–G5)
+
+**REQ-ROL-003** Each gate SHALL be passed by a recorded sign-off from its named approver(s), referencing the
+evidence bundle; gate reviews and outcomes are logged in the program repository.
+
+**REQ-ROL-004** Gate evidence bundles MUST be archived (hashes recorded) and retrievable through H+5y; they are
+contractual acceptance artifacts referenced by [11](./11-scope-of-work.md) payment milestones.
+
+### G0. Target ratification (end of P0)
+
+Implements D-01: final selection between the Solana and Ethereum paths.
+- **Entry:** kickoff verification sprint complete (volatile-facts report delivered); [02](./02-target-selection.md)
+  analysis re-validated; community **signal proposal** (§3.i) submitted on `akashnet-2`.
+- **Exit checklist:**
+  - [ ] Signal proposal passed (quorum ≥20%, majority yes) on `akashnet-2`.
+  - [ ] Overclock leadership sign-off memo naming the target (D-01 → Fixed in [13](./13-open-questions-and-assumptions.md)).
+  - [ ] Vendor contract phase-2 trigger executed (target-specific build authorized per [11](./11-scope-of-work.md)).
+  - [ ] Program calendar re-baselined in the client-side program & comms plan (REQ-ROL-002).
+- **Evidence:** proposal tally export, leadership memo, verification-sprint report, updated doc 13.
+- **Approver:** joint, Akash governance (signal) + Overclock leadership; Vendor acknowledges.
+- **In parallel while pending:** target-neutral workstreams (token-migration design, claims UX, indexer schema, chain-adapter interface, exchange outreach). No target-specific mainnet code.
+
+**REQ-ROL-005** The Vendor MUST NOT begin target-specific implementation (beyond design spikes and prototypes)
+before G0 passes.
+
+**REQ-ROL-006** G0 SHALL NOT pass without all four exit items; a failed signal proposal returns the program to
+option analysis ([02](./02-target-selection.md)) with no Vendor obligation beyond P0.
+
+### G1. Architecture freeze (end of P1)
+
+- **Entry:** design reviews of [03](./03-solana-architecture.md)/[04](./04-ethereum-architecture.md) (selected path)
+  + [05](./05-token-migration.md)/[06](./06-state-and-data-migration.md)/[07](./07-offchain-and-clients.md) complete; all Q-xx items "needed by G1" resolved.
+- **Exit checklist:**
+  - [ ] REQ baseline of docs 03/04 (selected path) + 05/06/07 frozen at version 1.0.
+  - [ ] Provisional decisions due at G1 (D-03, D-07, D-11, D-17) confirmed or amended in doc 13.
+  - [ ] Exchange coordination plan v1 (venues, lead times, coverage math; Q-04) approved.
+  - [ ] Thresholds proposed in this document (70% exchange coverage, genesis-provider counts, KPI intervention levels) ratified or amended.
+- **Evidence:** design-review minutes, frozen doc versions, exchange plan.
+- **Approver:** joint, Overclock (accepts design) + Vendor (commits to build).
+- **In parallel while pending:** build of already-approved components; testnet tooling; comms hub.
+
+**REQ-ROL-007** After G1, changes to frozen REQ baselines SHALL flow through change control (README §change control)
+with schedule and audit-scope impact assessment; no silent drift.
+
+### G2. Code complete, audits started, testnet live (end of P2)
+
+- **Entry:** all in-scope REQs implemented, unit/integration tests green; public-testnet deployment candidate ready;
+  audit firms contracted ([08](./08-security-and-audits.md)).
+- **Exit checklist:**
+  - [ ] Public testnet live with full protocol + claims stack and seeded test state.
+  - [ ] Audit round 1 formally started on a frozen commit (code-freeze tag).
+  - [ ] Migration dry-run R1 (pipeline on synthetic + testnet state) passed per [09](./09-testing-and-verification.md).
+  - [ ] Old-chain upgrade freeze in effect: no state-layout-affecting `akashnet-2` upgrades from G2 to H (A-01), coordinated with the core team.
+- **Evidence:** testnet endpoints + uptime report, audit engagement letters + freeze tag, dry-run R1 report.
+- **Approver:** Vendor delivers; Overclock accepts.
+- **In parallel while pending:** audit-prep docs, rehearsal planning, exchange tech-pack drafting, provider daemon beta.
+
+**REQ-ROL-008** Components under audit MUST be code-frozen; any post-freeze change re-enters audit scope (delta
+review at minimum) before G3.
+
+**REQ-ROL-009** G2 SHALL include written confirmation from Overclock that the `akashnet-2` upgrade freeze (A-01) is
+in effect through H.
+
+### G3. Launch readiness (end of P4; gates S1)
+
+- **Entry:** audits complete; rehearsals R2–R3 executed; §3.ii proposal drafted; ops staffing plan signed.
+- **Exit checklist:**
+  - [ ] Audits clean: all critical and high findings fixed **and re-verified by the auditor**; mediums dispositioned with published rationale ([08](./08-security-and-audits.md)).
+  - [ ] Rehearsal R3 (full dress on a mainnet-fork snapshot) passed within its target windows ([09](./09-testing-and-verification.md)); rehearsal R4 scheduled at S1−14d.
+  - [ ] Exchange commitments: written swap playbooks from venues jointly covering **≥70% of trailing-90d AKT spot volume** (proposed value, ratified at G1; REQ-ROL-012).
+  - [ ] **Binding on-chain governance approval** of the migration + S1 schedule passed (§3.ii).
+  - [ ] War-room staffing, monitoring dashboards, status page, and operational-notification artifacts ready (§4.4, §7).
+  - [ ] Claims portal + CLI release candidates signed off after a mainnet-fork claim dry-run.
+- **Evidence:** final audit reports + re-verification letters, rehearsal R3 report, signed exchange commitments, on-chain tally of §3.ii, runbook sign-off.
+- **Approver:** Akash governance (binding vote) + joint Overclock/Vendor go decision.
+- **In parallel while pending:** provider re-registration (§4.1 S1−30d items), rehearsal R4 prep.
+
+**REQ-ROL-010** G3 SHALL NOT pass with any unremediated critical/high audit finding; re-verification MUST be
+performed by the issuing auditor, not self-attested.
+
+**REQ-ROL-011** G3 SHALL NOT pass unless rehearsal R3 met the §4.3 cutover time targets end to end on the
+rehearsal environment: export → verified root within the ≤24h publication budget, plus a claims-open drill
+at the rehearsed C+8–10d offset (verification window compressed on the rehearsal clock, steps executed in
+full; D-05.b; [09](./09-testing-and-verification.md)).
+
+**REQ-ROL-012** G3 SHALL NOT pass until exchange swap commitments cover ≥70% of trailing-90-day AKT spot volume
+[TO-VERIFY: per-venue AKT volume distribution; the Q-04 data pull establishes the denominator]. Waiving or lowering
+the threshold requires Overclock leadership sign-off recorded in doc 13.
+
+**REQ-ROL-013** No irreversible action on `akashnet-2` (sunset-upgrade submission, module-account commitments, cutover dates presented as final) SHALL occur before the binding governance approval (§3.ii) passes, i.e., before G3.
+
+### G4. S1 executed and verified (end of P5)
+
+- **Entry:** §4 runbook executed through the first weekly residual cycle (S1+7d) and self-custody
+  claims-open (≈C+8–10d per D-05.b).
+- **Exit checklist:**
+  - [ ] Sunset upgrade activated at height C; old chain producing blocks in wind-down mode.
+  - [ ] S1 dual-implementation verification passed; root attestation published (§4.3); 7-day public
+    verification window completed with no substantiated objection and the root armed (D-05.b).
+  - [ ] Self-custody claims opened on schedule (≈C+8–10d) and live ≥7d with success rate ≥99%; no open P1 incidents.
+  - [ ] Exchange swaps executing (majors credited or in announced windows).
+  - [ ] Marketplace open on target chain with genesis providers live and ≥1 independent funded deployment completing an order→bid→lease cycle.
+  - [ ] First weekly residual cycle (§5.1) executed.
+- **Evidence:** attestation bundle, claims/swap telemetry, incident log, marketplace dashboards.
+- **Approver:** joint war-room sign-off (roster §4.2); reported to governance via forum post.
+- **In parallel while pending:** wind-down operations (§5) run regardless; G4 only closes P5.
+
+**REQ-ROL-014** G4 SHALL NOT be declared while any P1 incident is open or any exit item is unmet; failure to reach
+G4 by S1+21d escalates to the contingency board (§6.3).
+
+### G5. S2, sunset complete, program close (end of P7)
+
+- **Exit checklist:**
+  - [ ] S2 residual snapshot at H exported, verified to the same dual-implementation standard, and final residual distribution published ([05](./05-token-migration.md)).
+  - [ ] Chain halted at H; archives published per [06](./06-state-and-data-migration.md): full state export, indexer DB, static explorer.
+  - [ ] Infrastructure decommission checklist ([06](./06-state-and-data-migration.md)) complete at H+90d.
+  - [ ] Hypercare exit criteria met (§8.1); success-metric scorecard published (§8.2).
+  - [ ] Handover package accepted and key ceremony completed (§8.3).
+- **Evidence:** archive hashes + locations, decommission checklist, scorecard, handover acceptance.
+- **Approver:** Overclock (accepts handover); result posted to the community forum.
+
+**REQ-ROL-015** G5 SHALL NOT pass until archives are published at permanent, publicly documented locations and the
+handover package (§8.3) is accepted in writing.
+
+## 3. Governance sequence on `akashnet-2`
+
+A **governance proposal** is an on-chain vote among staked-AKT holders on the Cosmos chain (mechanics in
+[01](./01-current-architecture.md)). Current parameters: **voting period 3 days**, **minimum deposit 2,500 AKT**,
+**quorum 20%** of bonded stake, max deposit period 14 days; with the deposit self-funded, a proposal completes in
+~3–4 days wall clock. Expedited proposals (shortened voting for emergencies) exist in the chain's SDK version
+[TO-VERIFY: live `akashnet-2` expedited governance parameters (voting period and minimum deposit) at P0].
+
+**REQ-ROL-016** The governance sequence SHALL execute in order (i)→(ii)→(iii)→(iii-b); a later proposal MUST NOT be
+submitted before its predecessor passes. Proposal skeletons (full texts are a P4 deliverable; Overclock owns,
+Vendor supplies technical content):
+
+- **(i) Signal: "Migrate the Akash protocol to [target]"** (text proposal, P0; G0 entry). States intent to migrate
+  per the AKASH-MIG document set (version pinned by hash), summarizes the dual-snapshot mechanism (S1 at cutover,
+  90-day wind-down, S2 at halt, 2-year claim window) and the Gate 0 process, and asks the community to signal
+  support. Explicitly non-binding: no height, no date, no funds movement.
+- **(ii) Binding migration approval** (text proposal, submitted during P4; G3 exit condition per REQ-ROL-013). Ratifies:
+  execution per the doc set; the sunset upgrade **name `v3.0.0-sunset`**; the **S1 height formula** (C = first
+  block whose timestamp ≥ the approved cutover instant, with the concrete height
+  computed at proposal-(iii) submission as `h_submit + ceil((T_cutover − t_submit)/6.5s)` from the chain's 6.5 s
+  average block time); H = C+90d; the wind-down message allow-list policy (Q-17); claim windows per D-05; and the
+  point-of-no-return declaration (§6.2) verbatim.
+- **(iii) Sunset software upgrade** (software-upgrade proposal, submitted S1−21d). The standard Cosmos mechanism
+  directing every validator's Cosmovisor supervisor to swap binaries at an exact height: schedules `v3.0.0-sunset`
+  at the concrete height C per (ii), binary URLs + SHA-256 checksums in the info field. The upgrade installs the
+  wind-down message filter and min-gas raise (D-18; detail in [06](./06-state-and-data-migration.md)).
+  **(iii-b)** mirrors this at H−21d, scheduling the final halt at height H.
+- **(iv) Emergency path (C→H)** (expedited, as needed). Pre-drafted expedited proposals covering: cancellation of a
+  scheduled upgrade (pre-S1 abort, §6.1); wind-down extension (replacement halt height); sunset anti-spam parameter
+  adjustment (Q-17); supplemental validator-incentive funding. Deposits pre-funded from an ops account.
+
+**REQ-ROL-017** Proposal (ii) MUST contain, at minimum: doc-set version hash, upgrade name, S1 height formula and
+target instant, H offset, claim-window durations, and the §6.2 point-of-no-return text. Any later material deviation
+requires a superseding proposal.
+
+**REQ-ROL-018** Proposal (iii) SHALL be submitted no later than S1−21d and MUST encode the concrete height C;
+predicted-time drift handling per REQ-ROL-024.
+
+**REQ-ROL-019** Proposal (iii-b) SHALL be submitted no later than H−21d; H MUST equal C+90d unless a
+governance-approved extension (path iv) supersedes it.
+
+**REQ-ROL-020** The emergency templates (iv) MUST exist, be rehearsed (used verbatim in rehearsal R3), and have
+funding arranged before G3.
+
+## 4. S1 cutover runbook
+
+**REQ-ROL-021** The cutover SHALL be executed from a versioned, executable copy of this runbook; every deviation
+MUST be logged in real time in the war-room log and reviewed at the S1 retrospective.
+
+### 4.1 T-minus schedule
+
+| T | Action | Owner | Notes |
+|---|---|---|---|
+| S1−35d | Target-chain production deployment complete: programs/contracts live, order intake disabled via config ([03](./03-solana-architecture.md)/[04](./04-ethereum-architecture.md)) | Vendor | G3 evidence |
+| S1−30d | **Formal exchange notices**: exact cutover instant, height formula, per-venue swap tech pack final | Overclock BD | Precedent: 3–6mo engagement, 30d formal notice (RNDR/HNT playbooks) |
+| S1−30d | **Provider re-registration opens** on target chain; **provider daemon GA** (chain adapter, [07](./07-offchain-and-clients.md)) | Vendor eng + Overclock provider team | D-08: launch precedes C |
+| S1−30d | Validator coordination channel stood up; abort-procedure instructions distributed (§6.1) | Overclock ops | Validators = the ≤100 block-producing operators of the Cosmos chain |
+| S1−28d | Claims portal + CLI final RC; mainnet-fork claim dry-run | Vendor | [05](./05-token-migration.md) |
+| S1−21d | Sunset upgrade proposal (iii) submitted with concrete height C | Overclock on-chain ops | §3 |
+| S1−17d | Voting closes; C confirmed (or program re-baselines) | Akash governance | 3d voting period |
+| S1−14d | **Rehearsal R4**: final dress on fresh mainnet-fork state | Vendor | [09](./09-testing-and-verification.md); failure → §6.1 abort review |
+| S1−14d | IBC voucher-return final call (Osmosis/Hub frontends, wallets) | Overclock comms | D-07; IBC = Cosmos cross-chain transfer protocol, see [01](./01-current-architecture.md) |
+| S1−7d | **Genesis providers confirmed**: ≥20 providers including top-5 by GPU capacity registered, bid engines live (threshold ratified at G1) | Overclock provider team | Go/no-go input |
+| S1−7d | War-room shifts locked; status page live; dashboards frozen | Joint ops | §4.4 |
+| **S1−72h** | **Go/no-go #1** | Roster §4.2 | Abort → §6.1 path A |
+| S1−48h | Height re-estimates published every 12h (block-time drift) | Overclock ops | REQ-ROL-024 |
+| **S1−24h** | **Exchange/custodian deposit + withdrawal freeze** for Cosmos-chain AKT | Exchanges (coordinated by Overclock BD) | HNT precedent: ~1-day pause |
+| S1−24h | Wallets pause stake/redelegate UX; Console blocks new old-chain deployments (UI-level; chain enforces at C) | Wallet partners / Console team | |
+| **S1−6h** | **Go/no-go #2 (final)** | Roster §4.2 | After "go", no abort (§6.2) |
+| **S1 (height C)** | **Sunset upgrade activates**: marketplace-entry messages filtered, min-gas raised; chain continues in wind-down mode. S1 balance baseline = committed state at height C−1 (last pre-upgrade block; the upgrade handler moves no balances) | Validators (Cosmovisor) | D-18; [06](./06-state-and-data-migration.md) |
+| C → +20h | Snapshot export ×2 independent pipelines; transform; Merkle roots computed and compared (§4.3) | Vendor + Overclock (independent operators) | [06](./06-state-and-data-migration.md) |
+| +20h → +24h | Root attestation window: signer quorum per §4.3 | Attestation roster | |
+| ≤ S1+24h | **Root published on target chain; Wind-down Reserve minted; BME vault seeded** (REQ-ROL-029). Self-custody claims do NOT open yet (D-05.b) | Vendor | [05](./05-token-migration.md) |
+| S1 → +7d | **Exchange swaps execute**. Custodial crediting is NOT gated on the verification window or claims-open (D-05.b; venue allocations reserved in the S1 tree): majors ≤~1 day (HNT precedent); stragglers staggered up to ~4 wk (RNDR precedent); day-1 auto-convert is the requested default (ASI precedent) | Exchanges / Overclock BD | Per-venue windows on status page |
+| S1+24h | **Marketplace order intake enabled** on target (providers already registered); first funded deployments expected ≤S1+48h once exchange-swapped AKT circulates (self-custody claims open ≈C+8–10d) | Vendor + Overclock | D-08 |
+| S1+24h → ≈C+8d | **7-day public verification window** on the published S1 root: dual-implementation match published, community recomputation invited; root armed at window close ([06](./06-state-and-data-migration.md) §4.3) | Vendor + community | D-05.b; REQ-ROL-030 |
+| S1+72h | War-room review #1: swap coverage, verification-window telemetry, incident log; staffing step-down decision | Joint | §4.4 |
+| S1+7d | First weekly residual cycle executes (§5.1); S1 retrospective published; G4 review scheduled | Joint | §5 |
+| ≈C+8–10d | **Self-custody claims open** (portal + CLI) once the verification window closes and the root is armed | Vendor | [05](./05-token-migration.md); D-05.b |
+
+**REQ-ROL-022** Formal exchange notices MUST be sent no later than S1−30d and MUST include the point-of-no-return
+declaration (§6.2) and the per-venue technical pack (§7).
+
+**REQ-ROL-023** Provider re-registration and the GA provider daemon release MUST be available no later than S1−30d,
+so that supply exists on the target chain before demand cuts over (D-08).
+
+**REQ-ROL-024** From S1−48h, Overclock ops SHALL publish height-to-time re-estimates at least every 12h; if the
+predicted cutover drifts >6h from the announced instant, an advisory MUST go to all §7 notification audiences (the height, not the wall-clock time, is authoritative).
+
+Sequencing note: the Helium L1→Solana migration (2023-04-18) took a ~30h full chain halt between the final L1 block
+and Solana state going live. Akash's design is strictly softer: **the old chain never stops at S1**. The sunset
+upgrade only freezes marketplace entry; the balance "halt" is *logical* at height C. Transfers, refunds, settlement,
+withdrawals, and BME burns keep working through H, so the ≤24h target (REQ-ROL-029) bounds only root-publication
+latency (self-custody claims open after the 7-day public verification window, ≈C+8–10d per D-05.b).
+
+### 4.2 Go/no-go governance
+
+**REQ-ROL-025** Go/no-go reviews SHALL be held at S1−72h and S1−6h with this roster: Overclock executive sponsor
+(chair), Overclock ops lead, Vendor engineering lead, Vendor security lead, Vendor claims/token lead, one
+provider-community representative, one validator representative. Quorum = ≥5 of 7 including the chair, Vendor engineering lead, and Vendor security lead.
+
+**REQ-ROL-026** A "go" requires unanimous assent of chair + Vendor engineering lead + Vendor security lead, plus a
+majority of members present. The chair holds sole **abort authority**: the chair MAY abort unilaterally, and an
+abort cannot be overruled at the same review. Go/no-go criteria checklists (from rehearsal R4) are pre-published;
+ad-hoc criteria additions require chair approval.
+
+### 4.3 Snapshot verification and root attestation
+
+**REQ-ROL-027** The S1 snapshot SHALL be exported and transformed by **two independent pipeline implementations run
+by different operators** (Vendor and Overclock) from independently synced nodes; the resulting Merkle roots MUST
+match bit-for-bit before publication ([06](./06-state-and-data-migration.md) defines the pipelines; [05](./05-token-migration.md) the tree format).
+
+**REQ-ROL-028** The matched root SHALL be attested by ≥4-of-5 designated signers (Overclock, Vendor, two independent
+community auditors, Vendor security lead) over the root, snapshot height, and supply-conservation totals; the
+attestation bundle is published alongside the root.
+
+**REQ-ROL-029** Target for height C → attested root published on the target chain is **≤24h**. Exceeding 24h is a
+declared incident with §7 notifications; exceeding 72h escalates per §6.3 row B. Self-custody claims-open follows at
+≈C+8–10d after the 7-day public verification window (D-05.b); that offset is schedule, not an incident trigger.
+
+**REQ-ROL-030** Self-custody claims MUST NOT open before (a) the attestation bundle is published AND (b) the ≥7-day
+public verification window ([06](./06-state-and-data-migration.md) §4.3) has elapsed with the root armed (D-05.b).
+Exchange custodial swaps execute from S1 against venue allocations reserved in the S1 tree and are NOT gated on the
+verification window or on claims-open.
+
+### 4.4 Monitoring thresholds and war-room
+
+**REQ-ROL-031** A war-room SHALL run 24/7 from S1−24h to at least S1+72h (three 8h shifts, each staffed with
+incident commander, claims on-call, protocol on-call, old-chain ops, indexer/Console on-call, comms lead). Step-down below 24/7 requires the S1+72h review's approval; §8.1 on-call coverage continues through hypercare.
+
+**REQ-ROL-032** The following thresholds SHALL be armed from S1−24h; each breach triggers its action:
+
+| Metric | Threshold | Action |
+|---|---|---|
+| Claims success rate (rolling 15 min) | <99% | P1 incident; guardian pause evaluation (§6.3 row A) |
+| Root verification | any mismatch | Stop publication; §6.3 row B |
+| Target-chain protocol tx failure rate (non-user-error) | >0.5% over 30 min | P1 incident |
+| Escrow settlement lag | p95 >60s over 1h | P2; crank/keeper capacity response ([03](./03-solana-architecture.md)/[04](./04-ethereum-architecture.md)) |
+| Old-chain block interval | >15s sustained 30 min | Validator ops escalation; §6.3 row E |
+| Old-chain bonded voting power online | <80% | Activate validator contingency (§5.2, §6.3 row E) |
+| Exchange swap coverage at S1+7d | <95% of exchange-held supply | BD escalation; per-venue status publication (§6.3 row C) |
+| Claim-portal availability | <99.5% daily | P2 |
+
+### 4.5 Target-specific runbook deltas
+
+#### Solana specifics
+
+A Solana cluster halt (historical precedent exists) triggers §6.3 row D: claims are not time-critical and wait out
+a restart. Root publication lands in `akash-claims`; attestation signing uses the Squads v4 flow in [08](./08-security-and-audits.md).
+
+#### Ethereum specifics
+
+On the host chain, sequencer downtime is the analogous outage (L1 forced inclusion exists but is unnecessary for a delayable
+claims-open). Root publication lands in `MigrationClaims`; attestation signing uses the Safe flow in [08](./08-security-and-audits.md).
+
+## 5. Wind-down operations (C → H)
+
+### 5.1 Weekly residual distribution cycle (D-05)
+
+Old-chain escrow settlements, refunds, and withdrawals during C→H are honored on the target chain from the Wind-down
+Reserve via weekly Merkle distributions ([05](./05-token-migration.md) defines amounts; cadence per Q-18).
+
+| Day (weekly) | Step | Owner |
+|---|---|---|
+| Mon | Export old-chain state at designated height h_n | Overclock ops |
+| Tue | Dual-pipeline diff vs h_(n−1): per-address residual deltas; candidate root + full CSV published | Vendor |
+| Tue → Thu | **48h public dispute window**: anyone can recompute from published inputs | Community / auditors |
+| Thu | Attestation signing (REQ-ROL-028 standard); root published on target; distribution claimable from Wind-down Reserve | Vendor |
+| Fri | KPI dashboard refresh + weekly public update | Overclock comms |
+
+**REQ-ROL-033** Residual cycles SHALL run weekly from S1+7d through H, each with a published candidate root, a ≥48h
+dispute window, and attestation before distribution.
+
+**REQ-ROL-034** A substantiated dispute SHALL halt that cycle's distribution only; the cycle re-runs after
+resolution and the next cycle absorbs any delay. Disputes and resolutions are published.
+
+### 5.2 Validator wind-down administration
+
+The old chain needs ≥2/3 of bonded voting power online through H to keep producing blocks; the incentive design for
+validators serving through halt is specified in [06](./06-state-and-data-migration.md), funded per Q-13.
+
+**REQ-ROL-035** Overclock SHALL administer the validator wind-down program weekly: publish the uptime roster, accrue
+incentives per the [06](./06-state-and-data-migration.md) formula, and settle them in the terminal distribution at
+H. Validator-set health feeds the §4.4 thresholds.
+
+### 5.3 Provider migration KPI dashboard and interventions
+
+**REQ-ROL-036** A public dashboard SHALL be updated at least weekly during C→H with, at minimum: % of active
+providers re-registered on the target chain; % of GPU capacity live on target (vs the S1−30d baseline); active lease
+count old vs new chain; escrow value remaining on the old chain; cumulative residual distributions paid.
+
+**REQ-ROL-037** The following intervention thresholds SHALL trigger their playbooks without further approval
+(playbooks owned by Overclock, funded per the D-12 provider-incentive pool):
+
+| Trigger | Playbook |
+|---|---|
+| <50% GPU capacity live on target at C+30d | **Incentive boost**: raise provider-incentive pool rewards, direct outreach to top-20 providers, migration office hours, white-glove re-registration support |
+| <60% capacity at C+45d | Above + governance consultation on wind-down extension (§3.iv) |
+| Active new-chain leases <30% of baseline at C+45d | Tenant-side incentives (deployment credits via Console), demand-side comms push |
+| Escrow value on old chain >25% of S1 level at C+75d | Targeted outreach on remaining leases; confirm forced-close notices (§5.4) |
+
+### 5.4 Tenant communications cadence
+
+**REQ-ROL-038** Tenants with leases still active on the old chain SHALL receive: weekly general updates; direct
+notices (Console, provider relays) at C+30d, C+60d, and C+75d; and a final forced-close warning no later than
+**7 days before H**, stating that leases open at H are force-closed with escrow refunds honored in the S2 distribution ([05](./05-token-migration.md), [06](./06-state-and-data-migration.md)).
+
+## 6. Rollback and contingency
+
+### 6.1 Pre-S1: abort paths (old chain unaffected)
+
+Before the sunset upgrade activates, aborting leaves `akashnet-2` untouched, which is the point of REQ-ROL-013 (no
+irreversible old-chain action before the G3 binding vote): the program can stop at any gate with no protocol damage.
+
+**REQ-ROL-039** The scheduled sunset upgrade MUST carry an abort switch usable until the S1−6h go/no-go, implemented
+as two windows:
+
+- **Path A (until ≈S1−36h): governance cancellation.** A pre-drafted, pre-funded expedited proposal invoking the
+  chain's upgrade-cancellation message (the standard Cosmos mechanism for de-scheduling an upgrade) is held ready
+  from S1−72h; expedited voting completes before C [TO-VERIFY: expedited voting period, per §3].
+- **Path B (≈S1−36h → S1−6h): coordinated validator skip.** Validators restart with the standard skip-upgrade flag
+  for height C (`--unsafe-skip-upgrades <C>`); effective when operators representing >2/3 of voting power apply it.
+  Instructions and the coordination channel exist from S1−30d (§4.1); the cancellation proposal is still submitted
+  afterward to ratify the abort on-chain.
+
+An abort via either path returns the program to P4; rescheduling requires a new proposal (iii). Between C and root
+publication one damage-limited recovery remains: if S1 verification fails catastrophically (§6.3 row B exhausted),
+an emergency proposal (§3.iv) re-opens the marketplace by reverting the message filter, a disaster path that
+exists only until claims open.
+
+### 6.2 Post-S1: point of no return
+
+**REQ-ROL-040** The point of no return is the **execution of S1 itself** (activation of the sunset upgrade at C and
+the start of exchange custodial swaps): from that moment the migration cannot be reversed. The subsequent
+publication of the attested S1 root and the opening of claims (≈C+8–10d per D-05.b) is the **final verification
+milestone**, after which no accounting adjustment to the S1 distribution is possible. Both statements MUST appear
+verbatim in proposal (ii), all exchange notices, the claim portal, and the migration hub page.
+
+### 6.3 Contingency matrix
+
+**REQ-ROL-041** The following matrix SHALL be maintained as a live document, and rows A–E SHALL each be exercised at
+least once across rehearsals R3–R4 ([09](./09-testing-and-verification.md)).
+
+| # | Scenario | Detection | Immediate action | Authority | Comms |
+|---|---|---|---|---|---|
+| A | Claims bug discovered post-S1 | §4.4 thresholds; bug bounty; user reports | **Pause claims only** via guardian role ([08](./08-security-and-audits.md)); marketplace and residual cycles keep running; patch via timelock-expedited path; root unchanged | Guardian (pause) + upgrade multisig (patch) | Status page ≤1h; post-mortem ≤72h |
+| B | Snapshot verification mismatch (pipelines disagree) | REQ-ROL-027 comparison | Delay root publication ≤72h; triage board (Vendor eng lead, Overclock ops, one attestor-auditor) isolates divergence; if unresolved, a third independent implementation adjudicates | Triage board; chair decides publish/hold | Incident notice at +24h (REQ-ROL-029); daily updates |
+| C | Exchange fails to swap on time | Venue status tracking | None on-chain; custodial users' entitlements are unaffected (venue allocation reserved per [05](./05-token-migration.md)); publish per-venue status; RNDR precedent: staggered windows up to ~4 wk are normal | Overclock BD | Per-venue status rows; user guidance |
+| D | Target-chain outage during S1 window | Chain monitoring | Claims are not time-critical: delay claims-open/marketplace-open until stable; old chain continues wind-down unaffected (§4.5) | War-room chair | Status page; revised timeline notice |
+| E | Mass provider no-show / old-chain validator attrition | §5.3 KPIs; §4.4 voting-power threshold | Provider side: §5.3 incentive boost, then governance-approved wind-down extension (§3.iv). Validator side: Q-13 incentives; worst case, accelerate S2 from the last good height by emergency governance + social consensus | Overclock + governance | Weekly updates; dedicated notices |
+
+**REQ-ROL-042** The guardian pause (row A) MUST be scoped to claim execution only; it SHALL NOT be able to pause
+marketplace programs/contracts, already-attested residual distributions, or transfers of already-claimed AKT.
+
+**REQ-ROL-043** Root-publication delay (row B) beyond 72h total requires the chair to invoke either the
+third-implementation adjudication or the §6.1 disaster re-open path; silent extension is prohibited.
+
+## 7. Operational notifications
+
+The audience-facing communications plan is maintained in the client-side program & comms plan, outside this
+technical set. This section retains only the notifications execution depends on; their runbook triggers live in
+§4.1, §5.4, and §6.
+
+**REQ-ROL-044** [RELOCATED] Audience×milestone communications-artifact matrix and migration-hub-page canonical
+index: maintained in the client-side program & comms plan, outside this technical set.
+
+Operational notifications (execution-required; REQ IDs below remain active):
+
+| Notification | Latest trigger | Owner | Reference |
+|---|---|---|---|
+| Exchange/custodian formal notice + final technical pack | S1−30d (pack delivered ≥16 wk before C) | Overclock BD; pack content by Vendor | §4.1; REQ-ROL-022, REQ-ROL-046; [11](./11-scope-of-work.md) REQ-SOW-026 |
+| Exchange/custodian deposit + withdrawal freeze notice | S1−24h freeze | Exchanges, coordinated by Overclock BD | §4.1 |
+| Provider daemon-GA upgrade notice + re-registration opening | S1−30d | Vendor eng + Overclock provider team | §4.1; REQ-ROL-023 |
+| Validator upgrade coordination channel + abort-procedure instructions | S1−30d | Overclock ops | §4.1, §6.1 |
+| IBC counterparty notices | S1−60d | Overclock | REQ-ROL-045 |
+| Tenant wind-down notices + forced-close warning | C+30d/C+60d/C+75d; ≤H−7d | Overclock | §5.4; REQ-ROL-038 |
+| Height re-estimates + drift advisories | from S1−48h, every ≤12h | Overclock ops | §4.1; REQ-ROL-024 |
+
+**REQ-ROL-045** IBC counterparty notices (at minimum an Osmosis governance forum post and a Cosmos Hub forum post)
+MUST be published no later than S1−60d, covering the voucher-return campaign, the stranded-voucher redemption
+process, and channel wind-down ([05](./05-token-migration.md)).
+
+**REQ-ROL-046** The exchange-facing technical pack MUST include: snapshot/height definition, Merkle proof format +
+verification tooling, venue swap-allocation mechanics, test vectors, target-chain integration guide (mint/contract addresses, finality guidance), freeze-window recommendation, and support escalation contacts.
+
+**REQ-ROL-047** A public status page SHALL run from S1−7d through G5; during C→H a written weekly update SHALL be
+published (residual cycle results, KPIs, incidents) per §5.
+
+## 8. Post-migration: hypercare, success metrics, handover
+
+### 8.1 Hypercare (90 days, C → H; reduced through G5)
+
+**REQ-ROL-048** The Vendor SHALL provide hypercare from S1 through H at the following SLAs, and from H through G5 at
+P1/P2-only coverage:
+
+| Severity | Definition | Response | Mitigation/workaround | Resolution target |
+|---|---|---|---|---|
+| P1 | Funds at risk, claims blocked, marketplace down, snapshot integrity in question | **2h, 24/7** | 12h | 72h (patch via [08](./08-security-and-audits.md) expedited path) |
+| P2 | Core flow degraded (settlement lag, indexer lag, portal errors) | 8h | 48h | 7d |
+| P3 | Non-core defect, tooling issues | 24h | none | next scheduled release |
+| P4 | Cosmetic, docs | 72h | none | backlog |
+
+Exit criteria (G5 input): 30 consecutive days with no P1, ≤2 open P2s, every runbook executed once by Overclock staff with the Vendor observing.
+
+### 8.2 Success metrics
+
+**REQ-ROL-049** The program scorecard SHALL be measured continuously and published at H and at G5. The
+protocol-verifiable acceptance rows are the table below; market/adoption success targets (exchange-swap and
+claim-adoption percentages, provider-capacity retention, lease-volume recovery) are maintained in the client-side
+program & comms plan and do not gate acceptance under this set; the operational intervention thresholds that
+trigger runbook playbooks remain normative in §4.4 and §5.3.
+
+| Metric | Target |
+|---|---|
+| Fund-loss incidents unrecovered | 0 |
+| S1 root-publication latency | ≤24h (REQ-ROL-029); self-custody claims-open on the D-05.b schedule (≈C+8–10d) |
+| Residual cycles executed on schedule | 13/13 |
+
+Misses do not retroactively fail gates; each miss requires a published root-cause and remediation plan at G5.
+
+### 8.3 Handover package and key ceremony
+
+**REQ-ROL-050** Before G5 the Vendor SHALL deliver, and Overclock accept, a handover package containing: executable
+versions of every runbook in this document (cutover, residual cycle, contingency rows A–E, emergency governance
+templates); monitoring dashboards + alert configurations with thresholds as code; incident playbooks; operational
+documentation for claims, cranks/keepers, indexer, RPC dependencies (ownership per Q-07); and a training sign-off from the receiving Overclock operators.
+
+**REQ-ROL-051** A witnessed **key ceremony** SHALL transfer or verify all operational authorities per
+[08](./08-security-and-audits.md): upgrade-authority multisig seats (Squads v4 for Solana; Safe for EVM) and timelock
+roles, claims guardian keys, crank/keeper operator keys, attestation-signer set retirement, and mint-authority state
+verification (D-03/D-04). The ceremony record (who holds what, from when) is a G5 evidence artifact.
+
+### 8.4 Decommission
+
+**REQ-ROL-052** Old-chain infrastructure decommission SHALL follow the checklist in
+[06. State & data migration](./06-state-and-data-migration.md) (archives published at H; RPC/seed/snapshot
+endpoints retired at H+90d per D-18); completion evidence feeds G5.
+
+## Cross-references
+
+- [02. Target selection](./02-target-selection.md): Gate 0 selection basis; ratified at G0.
+- [05. Token migration](./05-token-migration.md): S1/S2 contents, claims, exchange allocations, Wind-down Reserve, IBC redemption.
+- [06. State & data migration](./06-state-and-data-migration.md): sunset upgrade internals, export/verification pipelines, validator incentive formula, archives, decommission.
+- [07. Off-chain services & clients](./07-offchain-and-clients.md): provider daemon GA, Console, wallet integrations (§4/§7).
+- [08. Security & audits](./08-security-and-audits.md): audit gates, guardian role, timelock paths, key ceremony detail.
+- [09. Testing & verification](./09-testing-and-verification.md): dry-runs R1–R2, rehearsals R3–R4, pass criteria behind G2/G3.
+- [11. Scope of work](./11-scope-of-work.md): milestones M0..Mn and payment gates mapped to G0–G5; RACI for the §7 operational notifications.
+- [12. Risk register](./12-risk-register.md): risks whose triggers reference §4.4/§5.3 thresholds.
+- [13. Open questions](./13-open-questions-and-assumptions.md): D-01, D-05, D-08, D-18; Q-04, Q-13, Q-17, Q-18, Q-19.
+
+## Feeds into
+
+- [11. Scope of work](./11-scope-of-work.md): phases/gates become milestones and payment triggers.
+- [12. Risk register](./12-risk-register.md): contingency matrix rows map to risk mitigations.
+- [05](./05-token-migration.md)/[06](./06-state-and-data-migration.md): execute inside the §4/§5 runbooks defined here.
+- Vendor project plan and the go/no-go checklists derived from §4.

--- a/spec/aep-79/doc/11-scope-of-work.md
+++ b/spec/aep-79/doc/11-scope-of-work.md
@@ -1,0 +1,767 @@
+# 11. Scope of Work (Vendor Statement of Work)
+
+| | |
+|---|---|
+| **Document** | 11. Scope of work |
+| **Doc ID** | AKASH-MIG-11 |
+| **Version** | 0.9 (draft for review) |
+| **Date** | 2026-08-10 |
+| **Owner** | Overclock Labs |
+| **Audience** | Vendor commercial and engineering leadership; Overclock program management |
+| **Status** | Normative (MUST/SHALL) and commercial; attached to the executed contract as its statement of work; informative where not marked |
+
+## Purpose
+
+- Define the commercial engagement under which an external developer agency ("the Vendor") executes the migration
+  specified by document set AKASH-MIG (docs 00–14).
+- Fix workstreams, deliverables, milestones, payment gates, effort envelope, team shape, and the split of
+  responsibilities between the Vendor, Overclock Labs, community governance, and third parties.
+- Provide the qualification and proposal-format requirements for the RFP process this SOW feeds.
+
+## In scope
+
+- Two-stage commercial structure (Stage A target-neutral; Stage B single-target build and launch).
+- Workstreams WS0–WS8 with numbered deliverables (D-WSn.m) and acceptance criteria.
+- Milestones M0–M8 mapped to gates G0–G5 (gates defined in [10](./10-rollout-and-cutover.md)).
+- Effort estimates, team composition, RACI, change control, IP/licensing, warranty, exclusions.
+
+## Out of scope
+
+- Technical requirements: they live in docs [03](./03-solana-architecture.md)–[10](./10-rollout-and-cutover.md) and
+  are incorporated by reference via their `REQ-*` IDs.
+- Legal terms beyond the scaffold in §6 (liability, insurance, jurisdiction; counsel finalizes).
+- Tokenomics decisions (the Vendor models; the client and governance decide; see D-12, Q-01).
+- Risk treatment detail: see [12. Risk register](./12-risk-register.md).
+
+## 1. Engagement overview
+
+### 1.1 Parties and governing artifacts
+
+The client is **Akash Network, contracting via Overclock Labs, Inc.** ("Overclock", "the client"), acting as steward
+for the Akash community; community governance retains the decision rights listed in §5. The supplier is **the
+Vendor**, selected through the RFP process in §7. The governing technical artifacts are the documents of this set
+(AKASH-MIG 00–14) at the contracted version. The protocol being migrated is the Akash v2 line as at commit `096bff57`
+(A-12); Akash/Cosmos concepts are defined in [01. Current architecture](./01-current-architecture.md).
+
+**REQ-SOW-001** The contract SHALL incorporate documents AKASH-MIG-00 through AKASH-MIG-14 by reference at a pinned
+version, and every Vendor obligation SHALL be traceable to a numbered `REQ-*` requirement or a numbered deliverable
+(D-WSn.m) in this document.
+
+**REQ-SOW-002** In case of conflict, precedence SHALL be: (1) the executed contract, (2) this SOW including its
+REQ-SOW requirements, (3) numbered `REQ-*` requirements in the other documents of this set, (4) informative prose and
+diagrams. Conflicts SHALL be resolved through change control (§6.2).
+
+### 1.2 Two-stage commercial structure
+
+The engagement is contracted in two stages so the client's Gate 0 target selection (D-01, ratified per
+[10](./10-rollout-and-cutover.md)) neither stalls mobilization nor forces the Vendor to price target-specific risk
+before the target is chosen.
+
+| Stage | Window | Pricing | Content |
+|---|---|---|---|
+| **Stage A: target-neutral foundation** | T0 → M1 | Firm fixed price | Kickoff verification sprint (volatile facts, [13 §4](./13-open-questions-and-assumptions.md)); tokenomics modeling start (WS1); migration-engine detailed design (WS3); REQ-baseline confirmation of docs [03](./03-solana-architecture.md)/[04](./04-ethereum-architecture.md); prototype spikes incl. the Q-15 Go–Solana prototype; Q-05/Q-11/Q-12/Q-19 investigations; G0 decision package |
+| **Stage B: single-target build and launch** | G0 → M8 | Fixed per milestone, priced per path (two-column bid) | Full build, audit, testnet, launch, cutover (S1), wind-down (S2), sunset, hypercare on the **selected** target only |
+
+**REQ-SOW-003** Stage A SHALL be target-neutral: its deliverables MUST be equally valid for the Solana and Ethereum
+paths, and the Vendor SHALL NOT begin target-exclusive production implementation before G0.
+
+**REQ-SOW-004** The Vendor's proposal SHALL price Stage A as a firm fixed price and Stage B as two separate
+fixed-price milestone schedules (one per path); only the selected path's Stage B price becomes payable.
+
+**REQ-SOW-005** After G0, the Vendor SHALL implement exactly one target path. The non-selected path's architecture
+document ([03](./03-solana-architecture.md) or [04](./04-ethereum-architecture.md)) SHALL be retained as documentation
+only: at each gate review the Vendor SHALL record learnings that would materially invalidate it, but SHALL NOT build
+against it.
+
+**REQ-SOW-006** Stage B SHALL NOT start before (a) client acceptance of M1 and (b) the G0 decision; the Stage B
+schedule (calendar maintained client-side; milestone sequence per §3.1) re-baselines from the actual G0 date (A-14).
+
+### 1.3 Program shape
+
+Nine workstreams (§2) run across nine milestones (§3) aligned to gates G0–G5 defined in
+[10. Rollout & cutover](./10-rollout-and-cutover.md). The effort envelope is 142–200 person-months across the milestone
+sequence (§3.1), plus wind-down and hypercare tails (§4), a planning estimate refined at M1 (REQ-SOW-045). Precedents ran
+longer end-to-end (Helium ≈ 2 years from vote to L1 sunset; Render ≈ 2 years to completed ticker swap; see
+[02](./02-target-selection.md)); this program compresses the build because the specification is complete before T0,
+while the exchange/claims tail remains calendar-bound, not effort-bound.
+
+## 2. Workstreams
+
+Each workstream states objective, scope, out-of-scope, numbered deliverables with acceptance criteria, dependencies,
+and Overclock-side prerequisites. Deliverable IDs `D-WSn.m` are stable and contractual.
+
+**REQ-SOW-007** Each deliverable SHALL be accepted only against its stated acceptance criteria and the `REQ-*`
+families it references; partial acceptance SHALL be recorded with a written punch list and a remediation date.
+
+### WS0. Program management & architecture stewardship
+
+**Objective.** Keep the program on schedule, every obligation REQ-traceable, and the architecture coherent as
+decisions land.
+
+**Scope.**
+- Program plan, weekly reporting, monthly steering support, gate review packages (§9).
+- REQ-traceability matrix upkeep across all `REQ-*` families → deliverables → tests → evidence.
+- Risk register ([12](./12-risk-register.md)) co-ownership; decision-log hygiene (D/A/Q items appended to
+  [13](./13-open-questions-and-assumptions.md) via PR); change-impact analysis for every CR touching docs 03–10.
+
+**Out of scope.** Community governance operations and legal coordination (Overclock).
+
+| ID | Deliverable | Acceptance criteria | Due |
+|---|---|---|---|
+| D-WS0.1 | Program management plan (schedule, staffing, tooling, comms per §9) | Client review; covers all WS and M0–M8 | M0 |
+| D-WS0.2 | Weekly status reports | Format per REQ-SOW-050; delivered every week, no gaps | recurring |
+| D-WS0.3 | REQ-traceability matrix (living) | Every in-scope `REQ-*` mapped to deliverable + test + status; refreshed at each milestone | each M |
+| D-WS0.4 | Gate review packages G0–G5 | Contents per [10](./10-rollout-and-cutover.md) gate entry criteria | each G |
+| D-WS0.5 | Monthly risk reviews | R-xx deltas with mitigation status; steering minutes | recurring |
+
+**REQ-SOW-008** The Vendor SHALL maintain the REQ-traceability matrix such that at every milestone review 100% of
+in-scope requirements have a status of satisfied, in-progress with plan, or CR-pending.
+
+**REQ-SOW-009** The Vendor SHALL deliver each gate review package no less than 5 business days before the scheduled
+gate review.
+
+**Dependencies.** None (starts at T0). **Overclock prerequisites.** Named program lead and steering members at T0;
+decision SLAs per §9.
+
+### WS1. Tokenomics & economic modeling
+
+**Objective.** Produce the quantitative basis for the emissions replacement (D-12), BME parameters (D-20), and
+validator wind-down incentives, for the client and governance to decide on.
+
+**Scope.**
+- Supply accounting workbook from a live `akashnet-2` state export: mint/inflation parameters and vesting-account
+  inventory (Q-19: on-chain state, not in source), module-account balances, IBC-out supply.
+- Emissions curve modeling (Q-01): gross rate, decay, provider-incentive/community-treasury split, hard cap; ≥3
+  scenarios with sensitivity analysis; provider-incentive budget sizing and payout options.
+- BME parameter study: CR thresholds (9500/9000 bps defaults per D-20), mint-spread sensitivity, time-based epoch
+  length, vault seeding from the S1 Wind-down Reserve ([05](./05-token-migration.md)).
+- Validator wind-down incentive sizing (Q-13) for `akashnet-2` validators operating the chain C→H.
+
+**Out of scope.** Making the decisions: parameters are ratified by the client and, where
+[10](./10-rollout-and-cutover.md) requires, by on-chain governance. Token price forecasting.
+
+| ID | Deliverable | Acceptance criteria | Due |
+|---|---|---|---|
+| D-WS1.1 | Supply accounting workbook (Q-19 data pull) | Reconciles to on-chain total supply at export height; feeds [05](./05-token-migration.md) REQ-TOK accounting | M1 |
+| D-WS1.2 | Emissions model + scenario report (Q-01) | Reproducible model (open source, pinned inputs); ≥3 scenarios; sensitivity documented | M1 (v1), M2 (final) |
+| D-WS1.3 | BME parameter study | Covers CR thresholds, spread, epoch timing under time-based execution; parity notes vs current params | M2 |
+| D-WS1.4 | Validator wind-down incentive sizing (Q-13) | Options with cost per option; feeds Overclock/governance decision | M2 |
+| D-WS1.5 | Final tokenomics report, ratified | Client sign-off + governance ratification recorded; parameters frozen into config for build | G1 gate evidence |
+
+**REQ-SOW-010** All WS1 models SHALL be delivered as reproducible artifacts (source + pinned inputs + run
+instructions), not as spreadsheets alone.
+
+**REQ-SOW-011** The Vendor SHALL present tokenomics outputs as decision options with quantified trade-offs; the Vendor
+SHALL NOT self-select final parameter values (decision rights per §5).
+
+**Dependencies.** Archive-node access (Q-19). **Overclock prerequisites.** Finance counterpart; governance-forum
+ratification process; archive node or trusted state export by M0.
+
+### WS2. On-chain protocol (programs / contracts)
+
+**Objective.** Implement the selected target architecture (marketplace, tokens, governance wiring, emissions) to the
+REQ sets of [03](./03-solana-architecture.md) or [04](./04-ethereum-architecture.md).
+
+**Scope.**
+- Tokens: AKT (D-03 Token-2022 / D-04 ERC-20) and ACT as restricted protocol asset (D-19).
+- Marketplace: deployment, market (order→bid→lease, reclamation D-24), escrow with streaming settlement (D-21),
+  provider registry, audit registry; BME engine port (D-20) with crank/keeper execution.
+- Config/governance wiring (D-11): parameter accounts/contracts, timelock, upgrade authority per
+  [08](./08-security-and-audits.md); Realms gap analysis (Q-11) in Stage A.
+- Emissions program/contract implementing the ratified WS1 schedule (D-12: timelocked, DAO-adjustable, hard-capped);
+  Pyth pull-oracle integration (D-13); settlement-stablecoin path (D-14).
+
+**Out of scope.** The non-selected path (REQ-SOW-005); migration/claims logic (WS3); off-chain services (WS4); any
+general smart-contract platform successor (D-22).
+
+| ID | Deliverable | Acceptance criteria | Due |
+|---|---|---|---|
+| D-WS2.1 | REQ-baseline confirmation report for docs 03 and 04 | Every REQ-SOL and REQ-EVM confirmed feasible or flagged with a CR; Stage A spike results attached (escrow/BME core-loop CU-or-gas benchmark, Q-05 Token-2022 support matrix, Q-12 dseq check) | M1 |
+| D-WS2.2 | Token deployments (AKT, ACT) on devnet/testnet | Conform to D-03/D-04/D-19; token REQs demonstrated; metadata correct | M2 |
+| D-WS2.3 | Core marketplace programs/contracts, feature-complete | Full order→bid→lease→settle→close lifecycle on persistent devnet; parity harness (D-WS6.1) green on marketplace golden vectors | M3 |
+| D-WS2.4 | BME + escrow settlement engine | REQ family satisfied incl. CR breaker, AKT-fallback, FIFO refunds, delegated-deposit allowance (D-21); invariant suite green | M3 |
+| D-WS2.5 | Governance/config wiring + emissions | Parameter changes only via governance path; emissions mint matches ratified schedule across ≥2 simulated epochs on testnet | M4 |
+| D-WS2.6 | Mainnet deployment + verified builds | Reproducible build hashes published; upgrade authority per key ceremony (D-WS5.5) | M5 |
+
+**REQ-SOW-012** WS2 SHALL implement 100% of the selected path's `REQ-SOL-*` or `REQ-EVM-*` requirements except those
+explicitly deferred by an approved CR.
+
+**REQ-SOW-013** Every WS2 code module SHALL carry test references to the REQ IDs it satisfies, and CI SHALL fail on
+untraceable normative behavior changes.
+
+**Dependencies.** G0 (target); WS1 parameter freeze at G1; WS5 reviews inline. **Overclock prerequisites.** Timely
+decisions on Q-08 (provider collateral) and Q-11 by G1.
+
+### WS3. Migration engine
+
+**Objective.** Build and operate the machinery that moves value (snapshots, Merkle claims, Wind-down Reserve,
+residual distributions, IBC redemption, old-chain sunset) per [05](./05-token-migration.md) and
+[06](./06-state-and-data-migration.md).
+
+**Scope.**
+- Snapshot exporter: **two independent implementations** (S1- and S2-capable) covering balances, vesting schedules,
+  bonded/unbonding stake incl. accrued rewards (D-06), and module accounts.
+- Merkle tooling: tree construction, root verification, proof service, independent-verifier kit; claims
+  program/contract (`akash-claims` / `MigrationClaims`) incl. Wind-down Reserve and vesting re-creation (D-05/D-06).
+- Residual-distribution pipeline: automated weekly old-chain→new-chain Merkle drops C→H (D-05, Q-18); IBC-redemption
+  support tooling (D-07) incl. counterparty voucher snapshots per Q-03.
+- Old-chain sunset upgrade (D-18): msg-type filter + min-gas raise at C (Q-17 calibration with the core team), halt at
+  H, final state export and archives per [06](./06-state-and-data-migration.md).
+
+**Out of scope.** Any persistent two-way bridge (excluded by D-05). Exchange-side swap execution (§5). Custodial
+mechanics for Console managed wallets (Q-14: Console team leads).
+
+| ID | Deliverable | Acceptance criteria | Due |
+|---|---|---|---|
+| D-WS3.1 | Migration engine detailed design | Covers all REQ-TOK/REQ-STA machinery; reviewed by client + WS5 | M1 |
+| D-WS3.2 | Snapshot exporter ×2 (independent) | No shared code beyond protobuf schemas; **byte-identical Merkle roots** on ≥3 mainnet state exports and every rehearsal | M3 |
+| D-WS3.3 | Claims program/contract + proof service | REQ-TOK claims requirements demonstrated end-to-end on testnet from a real mainnet snapshot; audited (WS5) | M4 |
+| D-WS3.4 | Residual-distribution pipeline | One-command weekly cycle: old-chain delta export → Merkle drop → publication; ≤7-day lag shown in rehearsal | M5 |
+| D-WS3.5 | IBC redemption tooling (D-07) | Counterparty snapshot list per Q-03; redemption flow tested with stand-in data | M5 |
+| D-WS3.6 | Sunset upgrade for `akashnet-2` | Passes upgrade tests against mainnet state export; msg allow-list per D-18/Q-17; adopted on rehearsal network | M5 |
+| D-WS3.7 | Supply reconciliation dashboard | Live proof that minted(new) + reserved = snapshot supply at all times ([05](./05-token-migration.md)) | M6 |
+
+**REQ-SOW-014** The two snapshot exporters SHALL be built by non-overlapping engineer sets with no shared code except
+canonical schema definitions, and both SHALL run at every rehearsal and at S1/S2.
+
+**REQ-SOW-015** A snapshot output SHALL be usable for S1/S2 only when both exporters produce identical Merkle roots;
+any divergence is a program-halting defect until root-caused.
+
+**REQ-SOW-016** The residual-distribution pipeline SHALL honor old-chain escrow settlements, refunds, and withdrawals
+occurring C→H in new-chain AKT with a lag of ≤7 days (D-05; cadence per Q-18).
+
+**Dependencies.** A-01 (upgrade freeze from G2); WS2 token mints; docs
+[05](./05-token-migration.md)/[06](./06-state-and-data-migration.md) baselines. **Overclock prerequisites.** Core-team
+review bandwidth for the sunset upgrade; validator outreach channel; archive infrastructure decision (Q-09) by G3.
+
+### WS4. Off-chain services & clients
+
+**Objective.** Adapt the off-chain estate (provider daemon, indexing, SDKs, CLI, claim portal) per
+[07. Off-chain & clients](./07-offchain-and-clients.md), preserving the Console API surface (A-11).
+
+**Scope.**
+- `provider-services` chain adapter (`pkg/chain`) + Solana signer sidecar if required (D-17); Stage A Q-15 prototype
+  decides the sidecar question.
+- Indexer per D-16 (Geyser/webhooks→Postgres on Solana; Ponder-class on EVM) exposing existing Console API shapes;
+  events as system of record for history (D-23).
+- `chain-sdk` v2 (TypeScript and Go) replacing the `pkg.akt.dev/go` chain surface; CLI re-target; JWT auth continuity
+  (D-10).
+- Claim portal (web) for S1/residual/S2 claims incl. proof generation and wallet flows; provider re-registration
+  wizard (keys, attributes, collateral per Q-08, JWT signing-key anchoring).
+- Console integration support: interface contracts, fixtures, liaison; Console team implements Console changes
+  (Q-14).
+
+**Out of scope.** Console feature development; wallet vendors' own integrations (Vendor supplies specs); running
+production infra beyond hypercare (Q-07).
+
+| ID | Deliverable | Acceptance criteria | Due |
+|---|---|---|---|
+| D-WS4.1 | Q-15 prototype report (Go–Solana feasibility) | Working prototype; sidecar go/no-go recommendation with benchmarks | M1 |
+| D-WS4.2 | Chain adapter + (if needed) signer sidecar | provider-services runs full lease lifecycle against testnet with unmodified Kubernetes logic; REQ-OFF satisfied | M3 |
+| D-WS4.3 | Indexer + Console-shape API | Existing Console API contract tests pass modulo address/tx-hash formats (A-11); backfill from genesis demonstrated | M3 |
+| D-WS4.4 | chain-sdk v2 (TS + Go) + CLI | Full protocol coverage; used by parity harness and portal; semver prereleases | M4 |
+| D-WS4.5 | Claim portal + provider re-registration wizard | End-to-end on public testnet with real snapshot fixtures; rate-limit review; screening hooks per Q-10 decision | M4 |
+| D-WS4.6 | Console integration support package | Interface contracts + fixtures delivered; Console team sign-off on sufficiency | M4 |
+| D-WS4.7 | Production releases of all clients | Versioned, signed releases; provider upgrade path validated by ≥3 external testnet providers (A-05) | M5 |
+
+**REQ-SOW-017** The indexer SHALL preserve existing Console API shapes such that Console requires only
+address/tx-hash-format changes (A-11); breaking shape changes require a CR.
+
+**REQ-SOW-018** All client deliverables SHALL ship with migration guides and compatibility matrices (WS8) at the same
+milestone.
+
+**Dependencies.** WS2 interface definitions (IDL/ABI) from M2; D-17/Q-15 decision at G1. **Overclock prerequisites.**
+Console counterpart from G0; maintainer access to `akash-network/provider`, `pkg.akt.dev/go`, and chain-sdk repos;
+provider-council testers (A-05).
+
+### WS5. Security
+
+**Objective.** Execute the security program of [08. Security & audits](./08-security-and-audits.md): internal
+reviews, external audits, bounty, monitoring, key ceremonies, incident response.
+
+**Scope.**
+- Threat-model upkeep; internal security review of every WS2/WS3/WS4 deliverable before external audit.
+- Audit management: scoping, data rooms, firm liaison, finding triage, fix cycles, re-audit (firms contracted by
+  Overclock per §6.6, Vendor-managed technically).
+- Bug bounty setup (platform, scope, severity/payout ladder) live before mainnet deploy.
+- Monitoring/alerting build: supply-conservation monitors, escrow/BME invariant watchers, crank/keeper liveness,
+  claims anomaly detection.
+- Key ceremonies (upgrade authority, multisig, timelock) per [08](./08-security-and-audits.md); incident-response
+  playbooks, drills, on-call design for launch and wind-down.
+
+**Out of scope.** Performing the external audits (independent firms); custody of client keys (Overclock/multisig
+signers).
+
+| ID | Deliverable | Acceptance criteria | Due |
+|---|---|---|---|
+| D-WS5.1 | Threat model + internal review reports | Every audited component has a pre-audit internal review with closed criticals | M3 (rolling) |
+| D-WS5.2 | Audit round managed to closure | ≥2 independent firms; all critical/high findings fixed + re-verified; reports published | M5 (G3 evidence) |
+| D-WS5.3 | Bug bounty live | Public program with funded pool (client-side, §6.6) before mainnet deploy | M5 |
+| D-WS5.4 | Monitoring & alerting stack | REQ-SEC monitors live against mainnet deployment before S1; runbook-linked alerts | M5 |
+| D-WS5.5 | Key ceremony execution + records | Documented, witnessed ceremonies; custody per [08](./08-security-and-audits.md); recovery drills passed | M5 |
+| D-WS5.6 | Incident-response playbooks + drill results | ≥2 game-day drills covering cutover-window scenarios from [12](./12-risk-register.md) | M5 |
+
+**REQ-SOW-019** External audit scope SHALL cover, at minimum: all WS2 programs/contracts, the WS3 claims path and
+exporters, and the sunset upgrade; ≥2 independent firms for the on-chain protocol and ≥1 for the migration engine.
+
+**REQ-SOW-020** No mainnet deployment SHALL occur with an open critical or high audit finding; G3 SHALL NOT pass
+without published audit reports and verified fixes.
+
+**REQ-SOW-021** The bug bounty program SHALL be live and funded before any mainnet deployment and SHALL remain in
+force through hypercare exit (M8).
+
+**Dependencies.** WS2/WS3 deliverable freezes (audit entry); Overclock audit contracting by M2. **Overclock
+prerequisites.** Audit budget and firm contracts (Q-20); multisig signer availability; legal review of bounty terms.
+
+### WS6. Quality & testnets
+
+**Objective.** Prove behavioral parity with the current chain and operational readiness for cutover, per
+[09. Testing & verification](./09-testing-and-verification.md).
+
+**Scope.**
+- Parity harness + golden vectors: current-chain behavior fixtures (escrow settlement math, BME epoch execution, FIFO
+  refunds, reclamation windows) replayed against the target implementation.
+- Fuzz/invariant suites (supply conservation, escrow non-negativity, CR-breaker monotonicity).
+- Public incentivized testnet: deployment, operations, telemetry, participant support.
+- Migration rehearsals ×3 against mainnet-scale state exports, each exercising S1 → claims → residual cycle → S2
+  end-to-end; load/performance testing against [09](./09-testing-and-verification.md) targets.
+
+**Out of scope.** Testnet participant rewards funding (client-side, Q-21); Console QA (Console team).
+
+| ID | Deliverable | Acceptance criteria | Due |
+|---|---|---|---|
+| D-WS6.1 | Parity harness + golden vectors | Vectors generated from current-chain code/state; CI-integrated; covers all REQ-TST parity items | M2 (v1), M3 (full) |
+| D-WS6.2 | Fuzz + invariant suites | Run continuously in CI; zero outstanding invariant violations at each gate | M3 |
+| D-WS6.3 | Public testnet, live and operated | Uptime and participation targets per REQ-TST; ≥3 external providers run real workloads (A-05) | M4 (G2 evidence) |
+| D-WS6.4 | Migration rehearsals 1–3 + reports | Rehearsal 3 at mainnet scale within REQ-TST time/error budgets; both exporters byte-identical (REQ-SOW-015) | M4–M5 |
+| D-WS6.5 | Load/perf test report | Meets [09](./09-testing-and-verification.md) targets on mainnet-candidate infrastructure | M5 (G3 evidence) |
+
+**REQ-SOW-022** The Vendor SHALL execute no fewer than three full migration rehearsals; the final rehearsal SHALL use
+a full mainnet state export and satisfy the acceptance thresholds of [09](./09-testing-and-verification.md) before G3.
+
+**REQ-SOW-023** Golden vectors SHALL be derived mechanically from current-chain code or recorded mainnet behavior,
+never hand-written from documentation.
+
+**Dependencies.** WS2/WS3/WS4 drops; testnet infra budget (§6.6). **Overclock prerequisites.** Incentivized-testnet
+reward budget (Q-21) by G1; provider-council recruitment (A-05).
+
+### WS7. Launch & wind-down operations
+
+**Objective.** Execute the runbooks of [10. Rollout & cutover](./10-rollout-and-cutover.md): mainnet launch, S1
+cutover, weekly residual cycles, S2, old-chain sunset, hypercare.
+
+**Scope.**
+- Target-chain launch operations: deployments, provider-onboarding window (launch precedes C, D-08).
+- S1 cutover execution at C per the T-minus runbook: snapshot, root attestation support, claims opening, exchange-swap
+  support window.
+- Weekly residual-distribution cycles C→H (≈13 cycles, D-05) with published per-cycle reports.
+- S2 at H: final snapshot, residual distribution, halt coordination, archive publication (D-18).
+- Hypercare: 90 days post-S2 (H → M8); on-call, defect remediation, operational tuning, handover shadowing.
+
+**Out of scope.** Exchange-side execution; validator operation of the old chain (validators/community); post-hypercare
+operations (Q-07: separately contractable).
+
+| ID | Deliverable | Acceptance criteria | Due |
+|---|---|---|---|
+| D-WS7.1 | Mainnet launch executed | Programs/contracts live; provider registrations meet [10](./10-rollout-and-cutover.md) launch criteria | M5→M6 |
+| D-WS7.2 | S1 cutover executed | Runbook completed within its window; roots attested; claims open; reconciliation clean (D-WS3.7) | M6 (G4) |
+| D-WS7.3 | Residual cycles operated | Every cycle ≤7-day lag (REQ-SOW-016); per-cycle report published | C→H |
+| D-WS7.4 | S2 + sunset executed | Halt at H; archives published per [06](./06-state-and-data-migration.md); final conservation report | M7 (feeds G5) |
+| D-WS7.5 | Hypercare period + exit report | SLAs per REQ-SOW-024 met; open-defect count within warranty terms; handover complete (WS8) | M8 |
+
+**REQ-SOW-024** From launch through hypercare exit, the Vendor SHALL staff on-call with: P1 (funds-at-risk or
+protocol-halt) response ≤2 h and mitigation plan ≤24 h; P2 response ≤1 business day; post-incident reports within 5
+business days.
+
+**REQ-SOW-025** The Vendor SHALL execute cutover only on the go/no-go "go" authorization recorded per
+[10](./10-rollout-and-cutover.md) §4.2 (G4 subsequently verifies the executed S1), and SHALL abort per the
+runbook's rollback criteria without requiring a change order.
+
+**Dependencies.** G3 (launch) and G4 (cutover) authorizations; WS3/WS5 tooling live. **Overclock prerequisites.**
+Governance halt-height proposal passed (A-02); exchange coordination complete (Q-04); comms execution; foundation ops
+for the IBC redemption window (D-07).
+
+### WS8. Documentation, devrel & handover
+
+**Objective.** Make the migrated protocol operable and adoptable without the Vendor.
+
+**Scope.**
+- Protocol documentation for the target chain (concepts, accounts/contracts, instruction/function reference;
+  complements [14](./14-appendix-protocol-mapping.md)).
+- Provider migration guide, tenant migration guide, wallet/holder claim guides, exchange technical pack.
+- Operational runbooks (indexer, cranks/keepers, monitors); handover training to the operator chosen under Q-07;
+  recorded training for Overclock engineering and the provider community.
+
+**Out of scope.** Marketing content; community management; translations beyond English.
+
+| ID | Deliverable | Acceptance criteria | Due |
+|---|---|---|---|
+| D-WS8.1 | Protocol + API documentation | Complete for every shipped program/contract and client; reviewed by Overclock eng | M5 |
+| D-WS8.2 | Provider & tenant migration guides | Validated by ≥3 external testnet providers completing migration unaided | M5 |
+| D-WS8.3 | Exchange technical pack | Delivered to Overclock BD ≥16 weeks before planned C; swap runbook + test vectors + contacts | M4 |
+| D-WS8.4 | Claim-portal user guides + holder FAQ | Published with portal; covers S1/residual/S2 and IBC-redemption cases | M6 |
+| D-WS8.5 | Runbooks + training + handover | Named operator (Q-07) runs one full residual cycle and one incident drill unaided | M8 |
+
+**REQ-SOW-026** The exchange technical pack SHALL be delivered no less than 16 weeks before the planned cutover date C
+(exchange lead times per [05](./05-token-migration.md); precedent: 3–6 month notice).
+
+**REQ-SOW-027** Handover SHALL be evidenced by the receiving operator executing the core operational procedures
+without Vendor assistance, recorded as part of M8 acceptance.
+
+**Dependencies.** All WS outputs. **Overclock prerequisites.** Docs-site access; Q-07 operator named by G3; BD channel
+to exchanges.
+
+## 3. Milestones, gates, and payment schedule
+
+### 3.1 Milestone sequence and gate mapping
+
+Gates G0–G5 are defined in [10. Rollout & cutover](./10-rollout-and-cutover.md); glosses below are informative. The
+milestone sequence and gate mapping below are contractual; the calendar targets (offsets from Vendor kickoff T0) are
+maintained in the client-side program & comms plan and are re-baselined at M1 (REQ-SOW-045) and at the actual G0 date.
+
+| M | Gate | Milestone content (headline) |
+|---|---|---|
+| M0 | none | Mobilization complete: verification sprint done (volatile facts re-verified, [13 §4](./13-open-questions-and-assumptions.md)); environments and CI up; program plan accepted (D-WS0.1) |
+| M1 | feeds **G0** (target selection) | Stage A complete: G0 decision package; REQ-baseline confirmation (D-WS2.1); migration-engine design (D-WS3.1); tokenomics model v1 (D-WS1.2); Q-15 verdict (D-WS4.1) |
+| M2 | **G1** (architecture freeze) | Detailed design frozen on selected target; tokenomics ratified (D-WS1.5); tokens on devnet (D-WS2.2); parity harness v1 (D-WS6.1) |
+| M3 | none | Feature-complete on persistent devnet: marketplace + BME/escrow (D-WS2.3/2.4), exporters ×2 (D-WS3.2), adapter + indexer (D-WS4.2/4.3); internal security reviews current (D-WS5.1) |
+| M4 | **G2** (code complete; audits started; public testnet live; old-chain upgrade freeze per A-01) | Public testnet live (D-WS6.3); claims end-to-end on testnet (D-WS3.3); SDKs/portal (D-WS4.4/4.5); audits underway; exchange pack delivered (D-WS8.3); rehearsal 1 done |
+| M5 | **G3** (launch readiness) | Audits closed (D-WS5.2); rehearsal 3 at mainnet scale (D-WS6.4); load targets met (D-WS6.5); mainnet deployed + key ceremonies (D-WS2.6/5.5); monitoring + bounty live (D-WS5.3/5.4); launch executed, provider onboarding open (D-WS7.1) |
+| M6 | **G4** (S1 executed and verified; cutover at C per the [10](./10-rollout-and-cutover.md) §4.2 go/no-go) | S1 executed (D-WS7.2); claims open; exchange swaps in progress; residual cycle 1 complete; reconciliation dashboard clean (D-WS3.7) |
+| M7 | feeds **G5** (at H = C+90 d) | All residual cycles done (D-WS7.3); S2 + halt + archives (D-WS7.4); final supply-conservation report |
+| M8 | **G5** (sunset complete; program close) | Hypercare exit (90 d post-S2, D-WS7.5); handover complete (D-WS8.5); warranty transition per §6.4 |
+
+**REQ-SOW-028** A milestone SHALL be deemed achieved only when all its listed deliverables are accepted (or
+punch-listed per REQ-SOW-007) and, where a gate is attached, the gate decision is recorded per
+[10](./10-rollout-and-cutover.md).
+
+**REQ-SOW-029** The client SHALL complete each milestone acceptance review within 10 business days of the Vendor's
+submission; the review clock and the gate-decision clock run concurrently where applicable.
+
+### 3.2 Payment schedule (suggested, negotiable)
+
+Fixed price per milestone, payable on acceptance of the milestone's gate/deliverable evidence (§3.1, §3.3). The
+percentage allocation across milestones is a commercial matter maintained in the client-side program & comms plan,
+outside this technical set. Stage A (M0–M1) is invoiced under the Stage A order; M2–M8 under the Stage B order for
+the selected path.
+
+**REQ-SOW-030** Payments SHALL be tied exclusively to accepted milestones per §3.1; no time-based fees under the
+fixed-price component (T&M applies only where §6.1 says so).
+
+**REQ-SOW-031** [RELOCATED] Minimum share of the program fee retained payable at or after M7; maintained in the
+client-side program & comms plan, outside this technical set.
+
+### 3.3 Per-milestone demonstration and evidence requirements
+
+**REQ-SOW-032** Each milestone submission SHALL include a live demonstration and an evidence bundle (reports, test
+outputs, tracker links) covering at minimum:
+
+- **M0**: verification-sprint report vs [13 §4](./13-open-questions-and-assumptions.md); CI/environments walkthrough.
+- **M1**: G0 package walkthrough; spike demos (Q-15 prototype live; escrow/BME benchmarks on both targets); D-WS2.1
+  deviations list; tokenomics model run live.
+- **M2**: devnet demo (token mints + a governance parameter change through timelock); D-WS1.5 ratification records.
+- **M3**: full lifecycle demo on persistent devnet (deploy → bid → lease → settle → close, BME swap epoch,
+  forced-settle crank/keeper); exporter ×2 root match on a fresh mainnet export; parity run.
+- **M4**: public-testnet walkthrough with external providers; claims end-to-end from real snapshot fixtures; audit
+  kickoff evidence; rehearsal-1 report.
+- **M5**: audit reports + fix verification; rehearsal-3 metrics vs [09](./09-testing-and-verification.md) thresholds;
+  mainnet build-hash and authority-custody verification; monitoring live-fire test; signed launch runbook.
+- **M6**: S1 execution log vs runbook; attested roots + independent-verifier confirmations; claims telemetry;
+  reconciliation review; exchange status summary.
+- **M7**: residual-cycle ledger (all cycles, lags, amounts); S2 execution log; archive URLs + integrity hashes; final
+  conservation report (liquid@S1 + reserved@S1 = total; reserved fully allocated by S2, D-05).
+- **M8**: hypercare metrics vs REQ-SOW-024; open-defect register; handover evidence per REQ-SOW-027; warranty-period
+  plan.
+
+## 4. Effort estimate and team
+
+### 4.1 Effort by workstream (person-months)
+
+Planning estimate, **not a commitment**; the Vendor bids its own numbers, and the estimate is re-baselined at M1
+(REQ-SOW-045). Ranges cover both target paths.
+
+| WS | Workstream | Low PM | High PM | Primary roles |
+|---|---|---|---|---|
+| WS0 | Program mgmt & architecture | 12 | 16 | Engagement lead, protocol architect |
+| WS1 | Tokenomics & modeling | 6 | 9 | Economist/quant (may be subcontracted), architect |
+| WS2 | On-chain protocol | 40 | 55 | Senior Rust/Anchor or Solidity |
+| WS3 | Migration engine | 18 | 26 | Go (Cosmos-side), Rust/Solidity (claims) |
+| WS4 | Off-chain & clients | 30 | 42 | Go/backend, TS full-stack |
+| WS5 | Security | 10 | 14 | Security engineer, audit liaison |
+| WS6 | Quality & testnets | 16 | 22 | QA lead, devops/SRE |
+| WS7 | Launch & wind-down ops | 6 | 10 | SRE, engagement lead |
+| WS8 | Docs, devrel & handover | 4 | 6 | Tech writer, devrel |
+| **Total** | | **142** | **200** | planning envelope, refined at M1 (REQ-SOW-045); calendar client-side |
+
+### 4.2 Estimating assumptions
+
+1. Basis is the Solana path; on the Ethereum path WS2 skews ≈10% lower (mature Solidity tooling, no crank
+   infrastructure) and WS4 drops the signer sidecar, with the total envelope unchanged.
+2. Includes Stage A (≈ 12–16 PM inside the totals). Excludes external audit-firm effort (client-side, §6.6); includes
+   Vendor audit management and remediation (WS5).
+3. Assumes this document set as the frozen baseline; REQ-affecting changes adjust effort via CR (§6.2).
+4. Assumes Overclock counterpart availability per §4.5 (A-03); slippage converts to schedule/effort CRs.
+5. Console changes are performed by the Console team (D-WS4.6 support only); custodial-wallet migration (Q-14) is not
+   Vendor effort.
+6. The 90-day wind-down and 90-day hypercare tails are fractional-team operations (§4.3).
+
+### 4.3 Team composition by phase (FTE)
+
+| Role | Stage A (T0→M1) | Build (→M3) | Harden (→M5) | Launch/wind-down (→M7) | Hypercare (→M8) |
+|---|---|---|---|---|---|
+| Engagement lead / PM | 1 | 1 | 1 | 1 | 0.5 |
+| Protocol architect | 1 | 1 | 1 | 0.5 | 0.25 |
+| Senior Rust/Anchor **or** Solidity engineers | 2 | 4 | 3 | 1 | 0.5 |
+| Go/backend engineers (migration engine, adapter) | 1 | 2 | 2 | 1 | 0.5 |
+| TS full-stack (SDK, portal, indexer) | 0.5 | 2 | 2 | 1 | 0.5 |
+| DevOps / SRE | 0.5 | 1 | 1 | 1 | 0.5 |
+| QA lead (+1 QA eng during hardening) | 0.5 | 1 | 2 | 1 | 0.25 |
+| Security engineer / audit liaison | 0.25 | 0.5 | 1 | 0.5 | 0.25 |
+| Tech writer / devrel | 0.25 | 0.5 | 0.5 | 0.5 | 0.25 |
+| **Total FTE** | **7.0** | **13.0** | **13.5** | **7.5** | **3.5** |
+
+### 4.4 Named key personnel and substitution
+
+**REQ-SOW-033** The Vendor SHALL name, in its proposal and the contract: the engagement lead, the protocol architect,
+the security lead, and the two most senior target-chain engineers ("key personnel"), with CVs and shipped-protocol
+references.
+
+**REQ-SOW-034** Key personnel SHALL be allocated ≥80% to this engagement from G0 through G4 and SHALL NOT be
+substituted without client consent; substitutes MUST have equal or better demonstrated qualifications, with ≥10
+business days' notice and a paid overlap period at the Vendor's cost.
+
+**REQ-SOW-035** Substitution of more than two key personnel before G4 SHALL entitle the client to a remediation plan
+and, if unresolved within 30 days, termination for cause under the contract.
+
+### 4.5 Overclock counterpart commitments (A-03)
+
+Overclock commits, for the engagement duration: **≥2 FTE counterpart engineers** (old-chain expertise, review
+bandwidth, sunset-upgrade co-development); **product/comms staffing** for holder, provider, and exchange
+communications; **governance operations** (proposal drafting, forum management, vote logistics per A-02); a finance
+counterpart for WS1; a Console-team counterpart from G0; timely decisions per §9. These are conditions precedent to
+the Vendor's schedule obligations; shortfalls route through §6.2.
+
+## 5. RACI
+
+R = responsible (does the work), A = accountable (owns the outcome; one A per row), C = consulted, I = informed.
+"Governance" = Akash on-chain/community governance.
+
+| # | Activity | Vendor | Overclock | Governance | Third parties |
+|---|---|---|---|---|---|
+| 1 | Target selection (G0, D-01) | C | R | **A** | none |
+| 2 | REQ baseline changes (change control §6.2) | R (impact) | **A** | I | none |
+| 3 | Tokenomics parameters (Q-01, D-12) | R (model) | C | **A** | none |
+| 4 | Protocol implementation (WS2–WS4) | **A**/R | C | I | none |
+| 5 | Deliverable acceptance & milestone sign-off | C | **A**/R | I | none |
+| 6 | Audit firm selection & contracting (Q-20) | C | **A**/R | I | audit firms: I |
+| 7 | External audits: execution + remediation | R (manage/fix) | **A** | I | audit firms: R |
+| 8 | Governance proposals (migration approval, halt height; A-02) | C (drafting) | R | **A** | none |
+| 9 | Snapshot execution S1/S2 (D-05) | R | **A** | I | exchanges: I |
+| 10 | Merkle root attestation & publication | R (compute/verify) | **A** (attest) | I | independent verifiers: C |
+| 11 | Exchange coordination (Q-04) | C (tech pack, D-WS8.3) | **A**/R | I | exchanges: R |
+| 12 | Community & holder communications | C (content) | **A**/R | I | wallets/DEX frontends: C |
+| 13 | Treasury & Wind-down Reserve operations | R (tooling/execution) | **A** (custody) | C (policy) | none |
+| 14 | Key ceremonies & upgrade-authority custody (D-15) | R (ceremony) | **A** (custodian) | I | independent witness: C |
+| 15 | Incident command (launch → hypercare exit) | R (technical lead, on-call) | **A** (severity, external comms) | I | infra providers: C |
+| 16 | Old-chain validator coordination (sunset upgrade, D-18; Q-13) | R (artifact) | **A**/R (outreach) | C | validators: R (adopt) |
+| 17 | Legal/regulatory review (Q-02/Q-03/Q-10) | I | **A** | C | counsel: R |
+
+**REQ-SOW-036** The Vendor SHALL NOT execute any activity for which another party holds A (rows 1, 3, 8, 11, 17) on
+its own authority; where the Vendor holds R for such rows it acts only on the accountable party's recorded
+instruction.
+
+## 6. Commercial terms scaffold
+
+Informative except where marked; contract counsel finalizes wording.
+
+### 6.1 Pricing structure
+
+Recommended: **fixed price per milestone** (§3.2) for M0–M7 scope, plus a **T&M pool with a not-to-exceed cap** for
+WS7 operational tails (residual cycles beyond plan, hypercare surge, incident response beyond SLA baselines) at
+rate-card rates. Alternates the client will entertain: capped T&M throughout, or fixed price with a shared risk/reward
+band on the cutover date.
+
+**REQ-SOW-037** The Vendor's rate card (all roles) SHALL be fixed for the engagement duration and SHALL apply to any
+T&M component and to CR pricing.
+
+### 6.2 Change control
+
+**REQ-SOW-038** Any change that adds, removes, or alters a numbered `REQ-*` requirement, a deliverable's acceptance
+criteria, a milestone date, or the price SHALL flow through a written change request (CR) containing: motivation,
+affected REQ/D/Q/R IDs, schedule impact, cost impact, and risk impact.
+
+**REQ-SOW-039** The Vendor SHALL deliver CR impact assessments within 10 business days of request; the client SHALL
+decide CRs within 10 business days of receipt; undecided CRs escalate per §9.4.
+
+**REQ-SOW-040** The Vendor SHALL NOT perform work against an unapproved CR; an emergency path (security-critical
+fixes) MAY proceed on the engagement lead + client program lead's joint written authorization within 48 hours, with
+the CR regularized within 10 business days.
+
+### 6.3 Intellectual property and licensing
+
+**REQ-SOW-041** All deliverables (programs/contracts, tooling, tests, documentation) SHALL be licensed Apache-2.0 or
+MIT (matching the existing Akash codebase's open-source posture), with copyright assigned to or licensed irrevocably
+for Akash Network's benefit as counsel directs.
+
+**REQ-SOW-042** All development SHALL occur in public repositories under the `akash-network` GitHub organization from
+day one; private repositories are permitted only for undisclosed security fixes and key-ceremony material, and MUST be
+published after remediation/ceremony.
+
+**REQ-SOW-043** The Vendor SHALL NOT introduce dependencies with licenses incompatible with Apache-2.0/MIT
+distribution, nor proprietary services in the critical path, without an approved CR.
+
+### 6.4 Warranty, hypercare, and re-baseline
+
+**REQ-SOW-044** Beyond hypercare (D-WS7.5), the Vendor SHALL provide a 90-day warranty from M8 acceptance: defects in
+accepted deliverables against their REQ acceptance criteria are remediated at the Vendor's cost, with P1/P2 response
+times per REQ-SOW-024.
+
+**REQ-SOW-045** At M1 the parties SHALL re-baseline the Stage B schedule and effort estimate against Stage A findings,
+preserving the milestone/gate structure of §3.1; the re-baseline is executed as a CR.
+
+### 6.5 Liability, insurance, termination
+
+- **Liability cap and carve-outs:** [placeholder; legal to finalize; market practice is a cap at a multiple of fees
+  with carve-outs for willful misconduct and IP indemnity].
+- **Insurance:** [placeholder; professional indemnity/E&O and cyber minimums; legal to finalize].
+- **Termination for convenience:** client may terminate on 30 days' notice.
+
+**REQ-SOW-046** On any termination, the Vendor SHALL be paid for accepted milestones plus a pro-rata amount for
+demonstrably complete work-in-progress, and SHALL deliver within 15 business days: all repositories current,
+credentials rotated and handed over, an open-items register, and a written state-of-work report sufficient for a
+successor to continue.
+
+### 6.6 Third-party costs: excluded from Vendor fees (client-side budget lines)
+
+Vendor fees exclude the following; they are budgeted and paid client-side. Ranges are indicative planning figures as
+of 2026-08-10, not quotes [TO-VERIFY: market quotes at M1 for audit, bounty-platform, and RPC/infra lines].
+
+| Budget line | Indicative range | Notes |
+|---|---|---|
+| Security audits (≥2 firms; protocol + migration engine + sunset upgrade) | US$400k–1.0M | Pass-through per REQ-SOW-047; firm selection Q-20 |
+| Bug bounty pool + platform fees | US$250k–1.0M funded ceiling | Severity-tiered; pool pays out only on valid findings |
+| RPC / indexer / testnet infrastructure opex | US$10k–40k / month | Program duration + hypercare; post-M8 per Q-07 |
+| Incentivized-testnet rewards | per Q-21 decision | Community incentives, provider participation (A-05) |
+| Exchange integration costs | per venue; expected minimal for 1:1 swaps | Q-04; precedent: swaps typically fee-free but venue-specific |
+| Old-chain archive hosting (≥5 y) | per Q-09 decision | Storage vendor + funding source |
+| Key-ceremony hardware (HSMs, air-gapped machines) | US$10k–30k | Retained by Overclock |
+| Legal counsel (claims, unclaimed funds, screening) | client-side | Q-02, Q-03, Q-10 |
+
+**REQ-SOW-047** Where the Vendor administers third-party spend (e.g., audit logistics), it SHALL be billed as
+pass-through at cost with zero markup, under a client-approved cap per line; forecast overruns SHALL be flagged before
+commitment.
+
+## 7. Vendor qualification and proposal requirements
+
+This SOW feeds an RFP. Responses not meeting §7.1 are non-conforming.
+
+### 7.1 Qualification criteria
+
+**REQ-SOW-048** The Vendor SHALL demonstrate all of the following in its proposal:
+
+1. ≥2 production protocol launches on Solana and/or EVM mainnets with ≥US$100M TVL-equivalent secured at peak
+   (per-path evidence for whichever paths the Vendor bids), with links to deployed programs/contracts.
+2. Prior token-migration or genesis-event experience (chain migration, large claims/airdrop event, or token swap of
+   comparable scale), with a written retrospective or reference.
+3. Audit track record: ≥3 completed third-party audits of Vendor-authored code with published reports; disclosure of
+   any post-audit exploits and remediation.
+4. Open-source history: maintained public repositories evidencing the proposed team's work.
+5. ≥2 client references for engagements ≥US$1M or ≥12 months, contactable by Overclock.
+6. Capacity: named key personnel per REQ-SOW-033 available at ≥80% from the proposed T0.
+
+### 7.2 Proposal response format
+
+**REQ-SOW-049** Proposals SHALL contain, in order: (1) executive summary (≤2 pages); (2) per-workstream approach for
+WS0–WS8 (≤3 pages each) explicitly citing the REQ families each WS satisfies; (3) team: org chart, key-personnel CVs,
+phase-staffing table in the §4.3 format; (4) fixed-price table per milestone (M0–M8, per the §3.1 sequence and §3.2 terms), Stage A firm, Stage
+B priced per path; (5) rate card; (6) assumptions register (numbered, each with the consequence if false); (7)
+qualification evidence per REQ-SOW-048; (8) exceptions taken to this SOW, as redlines referencing REQ-SOW IDs.
+Proposals that restate this document set without workstream-specific engineering substance will be scored down.
+
+## 8. Assumptions and exclusions
+
+### 8.1 Commercial assumptions (imported from [13](./13-open-questions-and-assumptions.md))
+
+The full register lives in doc 13; the subset below is load-bearing for price and schedule. If one fails, the affected
+obligations re-open via CR (§6.2).
+
+| ID | Assumption (abbreviated) | Commercial consequence if false |
+|---|---|---|
+| A-01 | `akashnet-2` stable; state-affecting upgrade freeze from G2 | WS3 rework; schedule CR |
+| A-02 | Governance approves migration and halt-height proposals | Program pause/termination per §6.5 |
+| A-03 | Overclock counterparts per §4.5 | Schedule/effort CR |
+| A-04 | ≥85–90% of circulating AKT reachable via exchanges + claims within 12 months | Extended claims-support tail (Q-07 scope) |
+| A-05 | Providers accept one daemon upgrade + re-registration | WS4/WS8 extra enablement effort |
+| A-07 | Ecosystem facts re-verified at kickoff hold | Stage A CRs before G0 (cheapest point to absorb) |
+| A-09 | AKT ticker retained across venues | Exchange-pack rework (D-WS8.3) |
+| A-12 | Baseline = v2 line at `096bff57`; pre-G1 protocol changes folded into docs 01/14 | Re-baseline CR at M1 |
+| A-14 *(new)* | Client renders the G0 decision ≤10 business days after M1 acceptance | Stage B calendar slips day-for-day |
+| A-15 *(new)* | Single prime Vendor; subcontractors (e.g., WS1 economist) only with client approval and prime liability | Contract restructuring |
+
+### 8.2 Exclusions: not in Vendor scope or fees
+
+1. Legal opinions, regulatory filings, jurisdictional analyses (client counsel; Q-02, Q-03, Q-10).
+2. Exchange listing/negotiation and any listing or integration fees (Overclock BD; Vendor delivers D-WS8.3 and
+   engineering support only).
+3. Marketing and paid communications spend (Vendor supports technical content only).
+4. **Tokenomics decisions**: the Vendor models (WS1); the client and governance decide (D-12, Q-01).
+5. Post-hypercare operations: indexer, RPC, cranks/keepers, fee-sponsorship relayer, claims support beyond M8, unless
+   separately contracted per Q-07.
+6. Old-chain validator operations C→H (validators/community; Vendor ships the sunset upgrade, D-WS3.6).
+7. Console product development and custodial managed-wallet migration execution (Console team; Q-14).
+8. Market making, liquidity provisioning, or DeFi listings for AKT on the target chain.
+9. Third-party costs per §6.6; hardware procurement beyond development needs.
+10. Building the non-selected target path (documentation stewardship only, REQ-SOW-005).
+
+## 9. Engagement reporting and governance
+
+### 9.1 Weekly status
+
+**REQ-SOW-050** The Vendor SHALL publish a written weekly status report (≤2 pages) in the shared repository
+containing: milestone burn-up vs plan; per-WS RAG status with deltas; deliverable (D-WSn.m) state changes; new/changed
+risks (R-xx) and open questions (Q-xx); decisions needed with owner and need-by date; REQ-traceability delta;
+next-week plan.
+
+### 9.2 Monthly steering
+
+**REQ-SOW-051** A monthly steering committee (Vendor engagement lead + architect; Overclock program lead + engineering
+counterpart; others as agenda requires) SHALL review schedule, burn on any T&M pools, top risks, and pending CRs;
+minutes and actions are recorded in the tracker.
+
+### 9.3 Gate reviews
+
+**REQ-SOW-052** Gate reviews G0–G5 SHALL follow the entry/exit criteria of
+[10. Rollout & cutover](./10-rollout-and-cutover.md), using the Vendor's gate package (D-WS0.4); the client records the decision
+(pass / conditional pass with punch list / hold) within 10 business days.
+
+### 9.4 Escalation path
+
+**REQ-SOW-053** Disputes and blocked decisions SHALL escalate: WS leads (48 h) → Vendor engagement lead + Overclock
+program lead (5 business days) → steering committee (next or extraordinary session within 10 business days) →
+executive sponsors under the contract's dispute clause. Escalation SHALL NOT stop non-disputed work.
+
+### 9.5 Tooling
+
+**REQ-SOW-054** The engagement SHALL run on: a shared issue tracker whose tickets are keyed to REQ-*/D-WSn.m/Q-xx/R-xx
+IDs; public `akash-network` repositories (REQ-SOW-042) with CI visible to the client; a shared communications channel
+with Overclock counterparts; and document-set changes via pull request per the
+[README change-control convention](./README.md). The tracker is the single source of truth for deliverable status.
+
+## Cross-references
+
+- [03. Solana](./03-solana-architecture.md) / [04. Ethereum architecture](./04-ethereum-architecture.md): REQ sets WS2 implements.
+- [05. Token migration](./05-token-migration.md), [06. State & data migration](./06-state-and-data-migration.md):
+  REQ sets WS3 implements.
+- [07. Off-chain & clients](./07-offchain-and-clients.md): REQ set WS4 implements.
+- [08. Security & audits](./08-security-and-audits.md): WS5 program (audits, key ceremonies, monitoring).
+- [09. Testing & verification](./09-testing-and-verification.md): WS6 acceptance thresholds.
+- [10. Rollout & cutover](./10-rollout-and-cutover.md): gates G0–G5 and the runbooks WS7 executes.
+- [12. Risk register](./12-risk-register.md): risks WS0 co-owns.
+- [13. Open questions & assumptions](./13-open-questions-and-assumptions.md): D/A/Q items cited throughout.
+
+## Feeds into
+
+- The RFP package and the executed contract (this document becomes its statement of work).
+- [12. Risk register](./12-risk-register.md): commercial risks and owners.
+- [13. Open questions & assumptions](./13-open-questions-and-assumptions.md): new items A-14, A-15, Q-20, Q-21
+  (recorded via lead).

--- a/spec/aep-79/doc/12-risk-register.md
+++ b/spec/aep-79/doc/12-risk-register.md
@@ -1,0 +1,346 @@
+# 12. Risk Register
+
+| | |
+|---|---|
+| **Document** | 12. Risk register |
+| **Doc ID** | AKASH-MIG-12 |
+| **Version** | 0.9 (draft for review) |
+| **Date** | 2026-08-10 |
+| **Owner** | Overclock Labs |
+| **Audience** | Program leadership (Vendor + client), all workstream leads |
+| **Status** | Normative where marked (MUST/SHALL); informative otherwise |
+
+## Purpose
+
+Single register of program risks for the Akash chain migration, with a uniform scoring method,
+proactive mitigations, reactive contingencies, named owners, and leading indicators. This is the
+operational artifact the program office (PMO) walks monthly and at every gate; it links each risk to
+the documents, decisions (D-xx), assumptions (A-xx), and open questions (Q-xx) that govern its
+treatment. Risk IDs (R-xx) are stable and are cited from other documents in the set.
+
+## In scope
+
+- Program risks across both target paths (Solana and Ethereum), with path-scoped rows marked.
+- Scoring method, risk statement format, owner types, review cadence, and linkage rules.
+- Escalation and acceptance rules, including which scores require steering-committee sign-off.
+- Risk-budget linkage to the contingency reserve established in [11. Scope of work](./11-scope-of-work.md).
+- Killed-risk log structure (empty at v0.9).
+
+## Out of scope
+
+- Requirement statements: these live in their home documents as `REQ-*`; this document allocates none.
+- Decision rationale and open-question tracking: [13. Open questions](./13-open-questions-and-assumptions.md).
+- Incident response procedures, monitoring stack, and key-management detail: [08. Security](./08-security-and-audits.md).
+- Gate definitions and cutover runbook: [10. Rollout & cutover](./10-rollout-and-cutover.md).
+- General business risks of Akash Network unrelated to the migration program.
+
+---
+
+## 1. Method
+
+### 1.1 Scoring
+
+Risks are first assessed on conventional 5-point likelihood and impact scales, then collapsed to a
+3×3 grid for reporting: raw 1–2 → **L**, 3 → **M**, 4–5 → **H**. The collapse is deliberate: 5×5
+granularity is spurious precision at pre-execution stage and produces assessor-dependent rankings;
+3×3 keeps ordering stable. Numeric values L=1, M=2, H=3; **score = likelihood × impact ∈ {1, 2, 3, 4, 6, 9}**.
+
+Anchors (program horizon = Vendor kickoff through H+90d):
+
+| Level | Likelihood | Impact |
+|---|---|---|
+| **H** | > 60% within program horizon | Any non-recoverable user-fund loss or supply-conservation breach; program stop; gate slip > 3 months; budget overrun > 25%; loss of a launch-critical constituency (validators, providers, exchanges) |
+| **M** | 25–60% | Bounded, recoverable fund exposure; gate slip 1–3 months; budget overrun 10–25%; material but recoverable adoption or reputation damage; core UX degraded > 1 week |
+| **L** | < 25% | Slip < 1 month; budget < 10%; cosmetic or short-lived degradation with a workaround |
+
+Score bands: **9 = Critical**, **6 = High**, **3–4 = Medium**, **1–2 = Low**. Handling per band is
+defined in §6. Scores in this register are current assessments as of 2026-08-10 (pre-Gate-0, both
+paths open) assuming baseline program controls only; listed mitigations are the funded plan to drive
+scores down, re-measured at each review.
+
+### 1.2 Risk statement format
+
+Every risk statement MUST use the causal form:
+
+> **Because** \<condition that exists today\>, \<event\> **may occur**, **causing** \<consequence\>.
+
+Condition and consequence must be concrete enough to test: a reviewer can check whether the condition
+still holds and whether the consequence would move an anchor in §1.1.
+
+### 1.3 Owner types
+
+Each risk has exactly one accountable owner (a role, not a person). Owners MAY delegate mitigation
+actions but not accountability, and own the monitoring of their risk's trigger.
+
+| Code | Role | Accountable for |
+|---|---|---|
+| VEL | Vendor engineering lead | Technical mitigations, parity/verification tooling |
+| VSL | Vendor security lead | Security mitigations, audit plan execution, incident readiness (with 08) |
+| OPL | Overclock protocol lead | Old-chain maintenance, protocol decisions, upgrade-authority operations |
+| OIL | Overclock infrastructure/ops lead | RPC, indexer, crank/keeper, relayer, validator-ops backstops |
+| OBD | Overclock ecosystem/BD lead | Exchanges, providers, customers |
+| OCL | Overclock community/governance lead | Governance process, comms, community programs |
+| LC | Legal counsel (client-retained) | Legal and regulatory risks |
+| PMO | Joint program office (Vendor PM + Overclock PM) | Cross-cutting program and schedule risks |
+
+### 1.4 Review cadence
+
+- **Monthly**: PMO-chaired risk review; all Medium-and-above risks walked; expected-cost estimates
+  (§6.3) refreshed; new risks admitted; trigger status confirmed.
+- **At every gate (G0–G5, per [10](./10-rollout-and-cutover.md))**: full re-score of all open risks;
+  acceptance decisions re-affirmed; gate hold rules in §6.2 applied. At Gate 0, risks scoped to the
+  unselected path retire to the killed-risk log (§5).
+- **Event-driven**: when a trigger fires or a linked assumption (A-xx) fails validation, the owner
+  MUST re-score within 5 business days and notify the PMO.
+
+Register changes flow by pull request to this file per the change-control rules in the
+[README](./README.md). R-xx IDs are never renumbered or reused.
+
+### 1.5 Linkage rules
+
+- Every risk MUST link at least one document of this set, and SHOULD link every D/A/Q item its
+  treatment depends on (`Links` column: docs; then D/A/Q IDs).
+- A failed assumption triggers immediate re-score of all risks linking it (§1.4). A resolved open
+  question triggers review of linked risks at the next monthly.
+- A risk treatment that requires a new program decision escalates through
+  [13](./13-open-questions-and-assumptions.md) (append a D-xx); this register never records decisions itself.
+
+---
+
+## 2. Master risk register
+
+Path column: **Both** = applies regardless of Gate 0 outcome; **SOL** / **EVM** = applies only to that
+path. Categories: technical, security, market, operational, legal, schedule, organizational.
+Mitigation = proactive (funded in workstream budgets, [11](./11-scope-of-work.md)); Contingency =
+reactive (funded from the contingency reserve, §6.3).
+
+| ID | Title | Category | Path | Risk statement | L | I | S | Mitigation (proactive) | Contingency (reactive) | Owner | Trigger / leading indicator | Links |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| R-01 | Claims-program exploit (migrated-supply honeypot) | Security | Both | Because the claims program/contract holds mint authority over the entire migrated AKT supply for the 2-year claim window, a proof-verification or claim-accounting flaw may be exploited, causing unauthorized minting or theft of migrated supply. | M | H | 6 | Both independent audits cover it; property-based/formal verification of Merkle-proof and double-claim logic; mint constrained by construction to roots committed at S1/S2; per-epoch mint caps; real-time supply-conservation monitor with auto-pause; top bug-bounty tier. | Guardian pause of claims; incident response per 08; patched redeploy against re-verified roots; public reconciliation report. | VSL | Conservation-monitor delta nonzero; anomalous claim velocity; audit or bounty critical finding. | 05, 08; D-05, D-15 |
+| R-02 | Snapshot accounting error / conservation mismatch | Technical | Both | Because S1 must transform every balance class (liquid, vesting, bonded/unbonding, accrued rewards, module accounts, IBC escrows) in two denoms into Merkle claims plus the Wind-down Reserve, an export or transform defect may occur, causing supply non-conservation discovered after irreversible mints. | M | H | 6 | Two independent transform implementations required to produce byte-identical output; at least 3 mainnet-export dry-runs (09); conservation equation as acceptance criterion (05); public root, per-address balance explorer, and challenge window before first mint. | Pre-open: recompute and republish root. Post-open: pause claims, freeze unclaimed tranche, corrections funded from reserve/treasury by governance. | VEL | Dry-run diffs nonzero; challenge-window findings; Q-19 data gaps at kickoff. | 05, 06, 09; D-05, D-06, Q-19 |
+| R-03 | Escrow parity defect causing tenant/provider fund loss | Technical | Both | Because escrow semantics (FIFO multi-depositor refunds, overdrawn accounting, per-block to per-second rate conversion, AKT fallback under BME halt) are re-implemented on a new VM, an undetected behavioral divergence may occur, causing tenant or provider fund loss or mis-payment at marketplace scale. | M | H | 6 | Differential replay harness against recorded akashnet-2 escrow histories (09); invariant suite (deposits = payouts + refunds; no negative payouts); audit scope weighted to escrow paths. | Pause affected instruction via upgrade authority; treasury-funded reimbursement policy; hotfix through the expedited-upgrade path in 08. | VEL | Replay-harness divergence; indexer-vs-chain reconciliation drift. | 03, 04, 09; D-21 |
+| R-04 | BME collateral-ratio manipulation via oracle latency | Security | Both | Because BME swap pricing derives from a single Pyth AKT/USD feed and executes in epoch batches, oracle latency or price manipulation in thin AKT markets may be exploited, causing vault collateral drain and a CR halt. | M | H | 6 | Carry over CR breaker (9500/9000 bps), mint spread, MinMint, and epoch batching; add per-epoch volume caps and staleness/confidence gating on Pyth reads; economic red-team exercise per 08. | CR-halt path still permits ACT-to-AKT refunds (D-20); governance vault top-up; parameter tightening via governance. | VSL | CR trending toward warn threshold; swap-queue volume anomaly vs TWAP divergence. | 03, 04, 08; D-13, D-20 |
+| R-05 | Crank/keeper liveness failure (settlement + BME epochs) | Operational | Both | Because settlement, BME epochs, and residual distributions run on permissionless cranks (Solana) or keeper automation (EVM) instead of consensus EndBlockers, incentive shortfall or operator outage may leave epochs unexecuted, causing settlement lag, stalled swaps, and late overdrawn detection with providers serving unpaid workloads. | M | M | 4 | Crank-tip economics sized in 03; redundant Vendor- and Overclock-operated fallback executors; keeper SLA contracts on EVM; epoch-lag alerting per 08. | Manual execution runbook; raise tips/keeper budgets via governance. | OIL | Epoch-execution lag over threshold; tip-balance drawdown rate. | 03, 04, 07; D-20, D-21, Q-07 |
+| R-06 | Fee-sponsorship relayer drain | Security | Both | Because a fee-sponsorship relayer/paymaster pays transaction fees for onboarding and Console flows, Sybil spam against sponsored paths may occur, causing relayer balance drain and sponsored-UX outage. | M | M | 4 | Per-account rate limits and scoped allowlists; spend caps with auto-shutoff; anomaly monitoring on sponsored spend. | Refill under tightened rules; degrade to user-paid fees (UX loss, not fund loss). | OIL | Sponsored-spend rate anomaly vs baseline. | 07; D-17, Q-07 |
+| R-07 | Alpenglow instability inside the launch window | Technical | SOL | Because Solana's Alpenglow consensus rewrite is expected to activate on mainnet inside the program window (Q3–Q4 2026, as of 2026-08), network instability or validator-economics turbulence may occur near cutover, causing launch delay or degraded early UX. | M | M | 4 | Gate criterion in 10: no cutover within a defined stability buffer after activation; design promises no specific finality figures; soak testing on Alpenglow-enabled clusters. | Hold at gate and shift C by a governance-approved delta; before Gate 0 the EVM path remains available. | PMO | Activation-schedule announcements; cluster incident reports. | 02, 03, 10; A-13, A-07 |
+| R-08 | Solana congestion / fee spikes vs marketplace UX | Technical | SOL | Because Solana fees and inclusion latency degrade during network-wide congestion events, marketplace transactions (bids, settlements, claims) may face fee spikes or drops, causing degraded bidding economics and tenant UX. | M | M | 4 | Per-entity account sharding avoids hot writable accounts (D-23); priority-fee strategy and retry logic in clients and provider daemon (07); congestion playbook per 08. | Temporary priority-fee subsidy for critical paths; batch low-urgency operations off-peak. | VEL | p95 landing latency and fee monitors breaching SLOs in 09. | 03, 07; D-23 |
+| R-09 | Token-2022 exchange-support gaps | Market | SOL | Because some exchanges and custodians still lack full Token-2022 support (as of 2026-08), onboarding of the migrated AKT mint may be delayed at some venues, causing fragmented launch liquidity or a forced late token-standard decision. | M | M | 4 | Kickoff support-matrix survey (Q-05); D-03 pre-commits a legacy-SPL fallback decided at G1 with no other design impact; early per-venue technical outreach. | Execute the D-03 fallback at G1; never operate two canonical mints. | OBD | Support matrix below threshold across top-10 venues at G1. | 02, 05; D-03, Q-04, Q-05 |
+| R-10 | Rent-cost escalation with SOL price | Technical | SOL | Because rent-exempt deposits are denominated in SOL, a sustained SOL price surge may raise per-entity account deposit costs, causing higher effective per-deployment/bid costs and provider friction. | M | L | 2 | Small per-entity accounts with close-and-refund lifecycle (D-23); ZK compression held as a designed optimization option. | Enable compression for high-volume account classes; protocol rent-subsidy pool. | VEL | SOL price sustained above the design threshold stated in 03. | 03; D-23 |
+| R-11 | Host-chain policy/economics shift (B1) or Orbit licensing change (B2) | Market | EVM | Because the EVM path deploys on third-party chains with shifting economics (Base announced its Superchain exit 2026-02; Arbitrum Orbit's AEP takes 10% of net protocol revenue), adverse policy or fee-structure changes may occur after selection, causing re-platforming pressure or margin erosion. | M | M | 4 | Gate 0 evaluation weighs policy stability; contracts kept portable EVM (no chain-specific dependencies); B2 variant maintained execution-ready as documented fallback. | Redeploy to an alternate L2 reusing 06 tooling; invoke the Q-06 revisit trigger. | PMO | Host-chain fee/policy announcements; AEP term changes. | 02, 04; D-02, Q-06 |
+| R-12 | Exchange coordination slippage incl. multi-year tail | Market | Both | Because exchange swap execution is per-venue and precedent shows long tails (Render's ticker swap completed roughly two years after its migration vote; the ASI phase-2 ticker never fully completed on major venues), some venues may lag S1 by months or years, causing fragmented liquidity, user confusion, and prolonged dual-asset support burden. | H | M | 6 | Venue coordination from G1 (Q-04) with 3–6 months notice; same-ticker chain-swap playbook (A-09), which precedent shows completes in about a day per venue; per-venue technical integration packets; dedicated BD owner. | Market-maker liquidity provisioning on live venues; extended claims support and comms for laggards. | OBD | Signed venue commitments below target at G2. | 05, 10; A-04, A-09, Q-04 |
+| R-13 | IBC-stranded AKT holders / counterparty non-cooperation | Operational | Both | Because AKT held as IBC vouchers on counterparty chains (Osmosis pools, Cosmos Hub) is invisible to S1 unless returned home, and counterparty chains have no obligation to cooperate, holders may miss the return campaign, causing stranded value and redemption disputes. | M | M | 4 | Counterparty-chain snapshots for outreach targeting (Q-03); wallet and DEX-frontend campaign; bounded foundation redemption window funded from reserved supply (D-07). | Governance-approved window extension; case-by-case foundation redemption. | OCL | IBC-out AKT balance not declining by campaign midpoint. | 05; D-07, Q-03 |
+| R-14 | Validator attrition during C→H wind-down | Operational | Both | Because old-chain AKT loses claim value at S1 and akashnet-2 configures zero downtime slashing, validators may shut down during the C-to-H wind-down before incentives land, causing loss of consensus liveness that blocks lease settlement, weekly residual distributions, and the S2 snapshot. | M | H | 6 | Validator recognition/incentive program funded before C (Q-13); rewards accrued to halt honored at S2 (D-06); signed uptime commitments covering over two-thirds of voting power as a cutover gate criterion (10); Overclock backstop validators on standby. | Coordinated restart from last committed height; execute S2 early from last committed state per the 10 contingency runbook. | OIL | Voting-power decline and missed-block rates after the migration vote passes. | 06, 10; D-18, Q-13, A-01 |
+| R-15 | Provider capacity attrition / re-registration no-show | Market | Both | Because providers must upgrade daemons and re-register on the target chain rather than being migrated automatically, operator inertia or dissent may leave capacity behind, causing a thin supply side at launch and tenant flight. | M | H | 6 | Provider council previews (A-05); migration incentives from the provider pool (D-12); one-command re-registration tooling (07); incentivized testnet with top providers by capacity; white-glove support for the top cohort. | Governance-boosted launch incentives; Overclock-operated seed capacity. | OBD | Re-registration rate below target at C−2 weeks (threshold per 10). | 07, 10; A-05, D-08, Q-08 |
+| R-16 | Tenant workload interruption blowback | Market | Both | Because running leases must conclude or redeploy within the 90-day wind-down and are force-closed at H, tenants with long-lived workloads may suffer interruption or unplanned migration work, causing churn and public criticism. | M | M | 4 | Early, repeated comms with fixed dates; Console-guided redeploy tooling (07); provider-assisted migration playbooks; forced close only at H, never before. | Escalated support plus service credits on the target chain (H itself is fixed and cannot be extended per-lease). | OBD | Share of active leases not redeployed by C+45d. | 06, 10; D-08 |
+| R-17 | Demand-side pause during migration uncertainty | Market | Both | Because customers defer spending during platform transitions, new deployments may stall between announcement and post-launch stabilization, causing a revenue dip and a weakened usage narrative during the migration year. | H | M | 6 | Target chain live before C so supply and demand overlap (D-08); migration credits; direct outreach to top tenants; parity and uptime reporting published throughout. | Treasury-funded demand incentives post-launch. | OBD | New-deployment rate decline after announcement vs trailing baseline. | 00, 10; D-08 |
+| R-18 | Competitor exploitation of the transition window | Market | Both | Because the migration consumes roadmap and attention for 12+ months, competitors (io.net and other Solana DePIN compute networks on the Solana path) may target Akash tenants and providers during the window, causing durable market-share loss. | H | L | 3 | Current chain keeps shipping until C (state-layout freeze only from G2 per A-01); differentiated positioning (general compute/containers vs GPU clusters); fast-follow feature roadmap post-launch. | Targeted win-back incentive campaigns. | OBD | Competitor campaigns referencing the migration; churn attribution in account reviews. | 00, 02; A-01 |
+| R-19 | Governance rejection or contentious vote split | Organizational | Both | Because the migration requires on-chain governance approval and ends the validator constituency's role and revenue, the binding proposal may fail or pass narrowly with a hostile minority, causing program stop at Gate 0 or a contested execution environment. | M | H | 6 | Signal proposal before G0 (A-02); validator recognition program designed before the binding vote (Q-13); public review of this document set; turnout operation sized to the 20% quorum and 3-day voting window. | Revise terms and re-vote; if permanently blocked, stop at G0 under the Vendor wind-down clause in 11. | OCL | Signal-vote margins; validator forum sentiment. | 00, 10, 11; A-02, Q-13 |
+| R-20 | Old-chain fork continuation confusion | Market | Both | Because halting akashnet-2 leaves its software and history public, a faction may continue the chain as a fork claiming the AKT name, causing market confusion and exchange listing disputes. | L | H | 3 | Exchange alignment on canonical chain identity (A-06, Q-04); trademark posture prepared by counsel; snapshot-based claims give a fork no hold on new-chain supply. | Exchange advisories; brand enforcement through counsel. | OCL | Fork coordination activity; validator hold-out blocs post-vote. | 05, 10; A-06, Q-04 |
+| R-21 | Post-S1 old-chain spam | Operational | Both | Because old-chain AKT has no claim value after S1, griefers may flood the wind-down chain with near-free transactions, causing state bloat and degraded wind-down operations. | M | L | 2 | Sunset upgrade message allow-list plus min-gas raise (D-18); calibration task Q-17; mempool and state-growth monitoring. | Further min-gas raises via emergency upgrade. | OPL | Old-chain transaction rate and state growth post-C. | 06, 10; D-18, Q-17 |
+| R-22 | Multisig signer compromise or collusion | Security | Both | Because upgrade authority and treasury sit behind Squads v4 / Safe multisigs during the transition, signer key compromise or collusion may occur, causing malicious program upgrades or treasury theft. | L | H | 3 | Signer policy per 08 (hardware keys, organizational and geographic distribution, high k-of-n); timelock on all privileged actions creating a public reaction window; independent pre-signing verification of queued actions. | Use the timelock window to alert and counteract; incident response per 08; authority rotation. | OPL | Signer device incidents; unexpected queued timelock actions. | 08; D-11, D-15 |
+| R-23 | Governance capture immediately post-launch | Security | Both | Because early post-launch DAO turnout is low while claims are still in progress and no staking lock exists, an attacker may cheaply assemble voting power, causing hostile parameter changes or treasury drain. | L | H | 3 | Launch-phase guardrails per 08: timelock everywhere, quorum floors, council veto (Realms capability check, Q-11), staged transfer of authorities, treasury spend caps. | Council veto/pause; emergency authority migration per 08. | OPL | Sudden voting-power concentration; hostile proposal queue. | 03, 08; D-11, Q-11 |
+| R-24 | Realms/SPL-governance maintenance thinness | Technical | SOL | Because SPL Governance (Realms) has been in low-velocity maintenance since spinning out of Solana Labs in 2024, features or fixes Akash governance needs may not land upstream, causing a fork-and-maintain burden on the Vendor and DAO. | M | M | 4 | Q-11 gap analysis at G1; budget line for a light fork in 11; the critical authority path is carried by actively maintained Squads v4 rather than Realms. | Fork Realms with minimal delta, or adopt an alternate governance stack at G1. | VEL | Q-11 gap-analysis results; upstream release cadence. | 03, 08, 11; D-11, Q-11 |
+| R-25 | Indexer vendor risk + Geyser/RPC vendor lock | Operational | Both | Because indexing depends on vendor infrastructure (Geyser/webhook providers and commercial RPC on Solana; Ponder, whose team joined Monad in 2026-02, on EVM), vendor pivots or price changes may occur, causing indexer rework or degraded data freshness behind the Console API. | M | M | 4 | Vendor-neutral ingestion seam (raw Geyser protocol, standard EVM logs); pin and vendor the indexer framework or select an alternative (Subsquid/Envio-class) at kickoff (A-07); at least two contracted RPC providers; self-host option costed in 11. | Swap vendor behind the seam; temporary degraded-SLA public-RPC fallback. | OIL | Vendor roadmap announcements; ingestion-lag SLO breaches. | 07; D-16, A-11 |
+| R-26 | Pyth AKT feed discontinuation or quality degradation | Operational | Both | Because BME pricing and USD-referenced flows depend on a single Pyth AKT/USD feed (continuing the current chain's single-source oracle), feed discontinuation or quality degradation may occur, causing oracle-halt that blocks new ACT issuance (and with it new deployment funding) until a feed recovers. | M | M | 4 | Publisher/SLA engagement with Pyth (Akash already integrates Pyth verifiers on the current chain); staleness and confidence gating; a secondary oracle (Switchboard-class) evaluated and kept integration-ready per 03/04. | Governance-approved switch to the secondary feed; current-chain halt semantics preserved meanwhile (oracle-halt blocks refunds too, as today). | OPL | Feed staleness/confidence metrics; publisher-count decline. | 03, 04; D-13, D-20 |
+| R-27 | Regulatory action on the claims portal | Legal | Both | Because the claims portal distributes tokens to a global holder base, securities (MiCA) obligations or sanctions-screening (OFAC) requirements may attach, causing forced geo-blocking, redesign, schedule slip, or enforcement exposure. | M | H | 6 | Legal review complete before G2 (Q-10); OFAC screening and geo-fencing designed into the portal from the start (05); claims kept non-custodial: the portal is UI only, the program verifies proofs; jurisdiction analysis feeding Q-02. | Jurisdiction-specific restrictions; the direct program/CLI claim path remains permissionless; counsel-led response. | LC | Counsel opinion; regulator inquiries; venue geo-policy changes. | 05; Q-02, Q-10 |
+| R-28 | Key-person loss (Vendor or Overclock) | Organizational | Both | Because current-chain semantics knowledge concentrates in a few Overclock engineers and target designs in a few Vendor leads, key-person loss may occur mid-program, causing schedule slip and fidelity loss in ported semantics. | M | M | 4 | Counterpart staffing of at least 2 FTE (A-03); this document set maintained as the knowledge-transfer artifact; pairing and rotation on critical components; contractual Vendor bench depth (11). | Backfill plan; schedule re-baseline at the next gate. | PMO | Attrition notices; single-owner components in the 11 RACI. | 11, 13; A-03 |
+| R-29 | Budget overrun / scope creep (REQ churn) | Schedule | Both | Because a 12-month dual-path program with a 15-document specification invites requirement churn, uncontrolled scope growth may occur, causing budget overrun and milestone slip. | H | M | 6 | Change control per README (stable REQ IDs, withdrawn-not-renumbered); PMO change board; payment gates bound to fixed milestone scope (11); Gate 0 retires one path's build scope. | Contingency-reserve drawdown per §6.3 rules; descope negotiation at gates against an out-of-scope backlog. | PMO | Change-request rate; earned-value variance per milestone. | 11, 13 |
+| R-30 | Cosmos-fork dependency decay before halt | Technical | Both | Because akashnet-2 runs on Akash-maintained forks of cosmos-sdk, CometBFT, and gogoproto while engineering attention shifts to the target chain, an upstream CVE or consensus bug may land with no staffed maintainer, causing an under-resourced emergency patch on the old chain before halt. | M | M | 4 | Named old-chain maintenance owner through H (A-01); security-patch-only policy from G2; upstream advisory monitoring; old-chain maintenance budget line in 11. | Emergency patch via the existing upgrade/height-patch machinery; governance-approved accelerated halt if catastrophic. | OPL | Upstream CVE announcements; fork divergence from upstream security branches. | 01, 06, 10; A-01 |
+| R-31 | Audit-finding cascade delays the launch gate | Schedule | Both | Because two independent audits cover novel high-value components (claims, escrow, BME), material findings are near-certain and remediation/re-audit cycles may stack, causing slip of the audit-complete launch gate (G3). | H | M | 6 | Shift-left internal security reviews and audit-readiness checks; component-staged audits with claims first (longest pole); re-audit windows pre-booked with both firms; finding-severity SLAs per 08. | Reduce launch scope to audited components; publish a revised timeline at the gate. | VSL | Open critical/high finding count vs remediation burn-down. | 08, 09, 10, 11 |
+| R-32 | SDL/manifest hash drift discovered late | Technical | Both | Because provider manifest validation depends on canonical serialization and hashing (ADR-002: manifest version = SHA-256 of sorted JSON) while the deployment hash field moves to a new chain encoding, a cross-stack serialization divergence may surface only in late end-to-end testing, causing launch-blocking integration failures. | M | M | 4 | Golden-vector corpus of recorded mainnet manifests and hashes run in CI across provider daemon, Console, and SDKs from G1 (09); SDL and serialization libraries frozen (A-10, D-09); cross-language hash conformance suite. | Fast provider-daemon hotfix (off-chain component, quick iteration); temporary dual-serialization acceptance shim. | VEL | Conformance-suite failures; testnet manifest rejection rate. | 01, 07, 09; D-09, A-10 |
+| R-33 | Unclaimed-funds policy legal challenge | Legal | Both | Because sweeping unclaimed funds to the community treasury after the 2-year window touches abandoned-property and consumer-protection law across jurisdictions, legal challenges may occur years later, causing forced window extension or clawback exposure. | L | M | 2 | Counsel opinion before G2 shapes the final policy (Q-02); policy published in claim terms up front; conservative default (extend before sweep) if the opinion is adverse. | Governance-approved window extension; segregated holdback of contested amounts. | LC | Counsel opinion; claim-rate telemetry approaching window end. | 05; D-05, Q-02 |
+| R-34 | Claim phishing / fake claim portals | Security | Both | Because the 2-year claim window requires holders to sign claim payloads naming a recipient address, and every precedent migration attracted imitation sites and wallet-drainer campaigns, fake claim portals impersonating the official one may occur, causing individual holders to sign entitlements to attacker recipients and reputational damage to the program. | H | M | 6 | Single canonical portal domain published in every governance proposal, exchange notice, and wallet integration; official-domain signing and comms discipline (no intermediate link domains); the signed ADR-036 payload binds root, claims address, and recipient, and the portal renders the recipient exactly as signed with clipboard-mismatch warnings ([05](./05-token-migration.md) §4.3, REQ-TOK-020/024); look-alike-domain and drainer-kit monitoring with takedown retainers from S1−30d; wallet-partner verified-domain allowlists. | Rapid takedown escalation (registrars, wallet blocklists, search/ad providers); incident comms per [10](./10-rollout-and-cutover.md) §6.3; support playbook for affected holders (losses are scoped to the signing holder by design, never to the distribution). | OCL | Registered look-alike domains; user phishing reports; wallet-drainer telemetry referencing the claim flow. | 05, 08, 10; D-05, Q-10 |
+| R-35 | Residual-distribution ledger disputes (weekly root challenges) | Operational | Both | Because weekly residual roots are computed off-chain from old-chain exports and any party can recompute them during the ≥48h public dispute window, a substantiated root challenge (or a flood of bad-faith ones) may occur, causing halted weekly distributions, provider payouts delayed beyond the ≤7-day lag commitment, and contested wind-down accounting. | M | M | 4 | Dual-implementation byte-equality gate before every publication ([06](./06-state-and-data-migration.md) §4.1); published inputs + recompute script per root (REQ-TOK-036); staffed objection channel with disputes scoped to reproducible discrepancies ([05](./05-token-migration.md) §6.3 / REQ-TOK-037, [06](./06-state-and-data-migration.md) §4.3); a dispute halts only the affected cycle (REQ-ROL-034). | Re-run and publish a corrected superseding root (never mutate); the next cycle absorbs the delay; PMO comms on the revised cycle calendar. | VEL | Objection reproducing a discrepancy; cycle export→distribution lag exceeding 96h (REQ-STA-030). | 05, 06, 10; D-05, Q-18 |
+
+---
+
+## 3. Top risks
+
+### 3.1 Heat map
+
+Rows = likelihood, columns = impact. Cells list R-IDs (35 open risks as of 2026-08-10).
+
+| Likelihood \ Impact | L (1) | M (2) | H (3) |
+|---|---|---|---|
+| **H (3)** | R-18 | R-12, R-17, R-29, R-31, R-34 | none |
+| **M (2)** | R-10, R-21 | R-05, R-06, R-07, R-08, R-09, R-11, R-13, R-16, R-24, R-25, R-26, R-28, R-30, R-32, R-35 | R-01, R-02, R-03, R-04, R-14, R-15, R-19, R-27 |
+| **L (1)** | none | R-33 | R-20, R-22, R-23 |
+
+No risk currently scores 9 (Critical). Thirteen risks score 6 (High); §3.2 ranks them, with ties broken
+by (a) irreversibility of the consequence, (b) proximity to the next gate, (c) mitigation leverage.
+
+### 3.2 Top-10
+
+| Rank | ID | Title | Score | Why ranked here |
+|---|---|---|---|---|
+| 1 | R-01 | Claims-program exploit | 6 | Irreversible loss of migrated supply; exposed for the full 2-year window |
+| 2 | R-02 | Snapshot conservation mismatch | 6 | Single-event S1; irreversible once mints begin |
+| 3 | R-03 | Escrow parity defect | 6 | Continuous fund flows through re-implemented core logic |
+| 4 | R-04 | BME CR manipulation | 6 | Economic attack surface on the highest-complexity ported component |
+| 5 | R-19 | Governance rejection / split | 6 | The one program-stopping risk; nearest in time (pre-G0) |
+| 6 | R-15 | Provider re-registration no-show | 6 | Launch is dead on arrival without the supply side |
+| 7 | R-14 | Validator attrition C→H | 6 | Wind-down integrity; blocks residual distributions and S2 |
+| 8 | R-12 | Exchange coordination slippage | 6 | Highest-likelihood market risk; multi-year tail per precedent |
+| 9 | R-17 | Demand-side pause | 6 | High-likelihood revenue erosion across the whole program year |
+| 10 | R-29 | Scope creep / budget overrun | 6 | Near-certain churn pressure; erodes every workstream |
+
+Just below the line, still High and steering-visible: **R-27** (claims-portal regulatory: held out
+because counsel engagement before G2 is already committed via Q-10 and the design is non-custodial by
+construction), **R-31** (audit cascade: the accepted schedule cost of the security posture; buffers
+in 10/11 exist specifically to absorb it), and **R-34** (claim phishing: losses are scoped to the
+signing holder by design; treatment is comms discipline, official-domain signing, and takedown
+operations rather than protocol code).
+
+### 3.3 Mitigation investment: top 5
+
+**R-01. Claims-program exploit.** This receives the largest single security investment in the program.
+The claims program custodies, in effect, the entire float; the Helium and Render precedents show the
+claims machinery is where value concentrates for years. Both independent audits cover it in full;
+Merkle-proof verification and double-claim prevention get property-based and, where tractable, formal
+treatment; the mint authority is constrained by construction to roots committed at S1/S2 so whole bug
+classes are unrepresentable; a supply-conservation monitor compares cumulative mints against committed
+totals in real time with an auto-pause threshold; and it anchors the top bug-bounty tier per
+[08](./08-security-and-audits.md).
+
+**R-02. Snapshot conservation.** S1 is a one-shot, irreversible event, so the mitigation buys
+redundancy and public verifiability rather than speed: two independently written export/transform
+pipelines must produce byte-identical Merkle output; at least three full dry-runs against mainnet
+exports are gated in [09](./09-testing-and-verification.md); and the root plus a per-address balance
+explorer are published for a community challenge window before the first mint. The conservation
+equation (claims + Wind-down Reserve = old-chain supply, per denom) is the acceptance criterion in
+[05](./05-token-migration.md).
+
+**R-03. Escrow parity.** The escrow engine is where tenant and provider money moves every hour, and
+its Cosmos semantics are idiosyncratic (FIFO depositors, grant-restore on refund, overdrawn debt
+accounting, AKT fallback). The investment is a differential replay harness: recorded akashnet-2
+escrow/settlement histories are replayed against the target implementation with equivalence assertions,
+plus an invariant suite. This harness is also the parity evidence used at the launch gate, so the spend
+does double duty as acceptance tooling.
+
+**R-04. BME manipulation.** The BME port carries over the defenses that exist today (CR circuit
+breaker at 9500/9000 bps, mint spread, MinMint, epoch batching) and adds per-epoch volume caps and
+staleness/confidence gating on Pyth reads, because target-chain latency characteristics differ from
+EndBlocker execution. A dedicated economic red-team exercise (simulated oracle-latency and
+thin-liquidity attacks against a forked deployment) is budgeted in [08](./08-security-and-audits.md).
+
+**R-19. Governance rejection.** Mitigation here is mostly sequencing and comms, cheap relative to
+consequence: a non-binding signal proposal runs before G0 so the program never mobilizes against a
+hostile community; the validator recognition program (Q-13) is designed *before* the binding vote so
+the constituency with the most to lose sees its treatment first; and this document set is published for
+review so the vote is on a concrete, criticizable plan rather than a narrative.
+
+---
+
+## 4. Category posture rollup
+
+**Technical (8 risks).** Posture is parity-first: differential replay against recorded mainnet
+behavior, dual-implementation of the S1 transform, and golden-vector conformance suites, per
+[09](./09-testing-and-verification.md). Platform risks (Alpenglow, congestion, rent) are absorbed by
+schedule buffers and by design decisions already fixed (D-23 per-entity sharding and close-and-refund).
+The two fidelity risks (R-02, R-03) carry the deepest verification spend.
+
+**Security (6 risks).** Posture leans on dual audits + the parity harness + staged authority: every
+privileged path (claims mint, upgrades, treasury) sits behind multisig-plus-timelock (D-11, D-15) with
+launch-phase governance guardrails, monitoring with auto-pause on conservation breaches, an economic
+red-team for BME, and a bounty program, all specified in [08](./08-security-and-audits.md). The
+concentration point is the claims program (R-01); the user-side surface (R-34 claim phishing) is
+treated with official-domain signing and takedown operations rather than protocol code.
+
+**Market (8 risks).** The largest aggregate likelihood mass sits here, and treatments are coordination
+and incentives rather than code: the exchange playbook per precedent, provider migration incentives,
+tenant credits, and competitor-aware positioning. Every market risk has a measurable leading indicator
+(venue commitments, re-registration rate, deployment rate) reviewed at gates so adoption risk surfaces
+early rather than at launch.
+
+**Operational (7 risks).** Posture is liveness engineering: redundant cranks/keepers with fallback
+operators, contracted RPC/indexer redundancy, oracle staleness gating with an integration-ready
+secondary, and validator backstops. The deliberately short 90-day wind-down (D-08, D-18) bounds
+old-chain operational exposure by construction; residual-root disputes (R-35) halt only the affected
+weekly cycle by design.
+
+**Legal (2 risks).** Counsel is engaged before G2 on both fronts (claims portal Q-10, unclaimed funds
+Q-02). The design keeps claims non-custodial and the portal separable from the protocol, so legal
+restrictions degrade convenience, not solvency, and never strand funds.
+
+**Schedule (2 risks).** Posture is gate discipline: fixed milestone scope behind payment gates,
+a PMO change board, pre-booked re-audit windows, and a contingency reserve sized in
+[11](./11-scope-of-work.md). Schedule risks are reported monthly against earned-value and burn-down
+indicators.
+
+**Organizational (2 risks).** Governance approval is front-loaded (signal vote before G0) with the
+validator constituency addressed first; knowledge concentration is treated by contractual counterpart
+staffing (A-03) and by maintaining this document set as the transfer artifact.
+
+---
+
+## 5. Killed-risk log
+
+Risks are never deleted or renumbered. When a risk is retired, its row moves here with the closing
+evidence. Kill reasons: **mitigated-out** (score reduced to Low and the exposure window closed),
+**expired** (exposure window passed without occurrence), **superseded** (merged into another R-xx),
+**path-descoped** (Gate 0 retired the path; expected for all SOL- or EVM-scoped rows). Killing a High
+or Critical risk requires PMO sign-off at a monthly or gate review.
+
+| ID | Title | Final score | Killed at (date / gate) | Reason | Evidence |
+|---|---|---|---|---|---|
+| none | (none at v0.9) | none | none | none | none |
+
+---
+
+## 6. Escalation, acceptance, and risk budget
+
+### 6.1 Acceptance authority
+
+| Band | Score | Default treatment | Acceptance authority | Reporting |
+|---|---|---|---|---|
+| Critical | 9 | Mitigate or stop the affected workstream | Not acceptable. The steering committee (composition per the [11](./11-scope-of-work.md) RACI) MUST approve a treatment plan; convened within 5 business days of the risk being scored 9 | Immediate notification, then weekly until reduced to ≤ 6 |
+| High | 6 | Mitigate | Acceptance (proceeding without further mitigation) REQUIRES steering-committee sign-off, recorded as a decision in [13](./13-open-questions-and-assumptions.md) | Monthly steering report |
+| Medium | 3–4 | Mitigate or accept | PMO, with documented rationale in this register | Monthly PMO review |
+| Low | 1–2 | Accept and monitor | Risk owner | Gate reviews |
+
+### 6.2 Gate rules
+
+A gate review (G0–G5, per [10](./10-rollout-and-cutover.md)) MUST NOT pass while:
+
+1. any open risk scores 9; or
+2. any High (6) risk lacks either a funded mitigation plan or a recorded steering-committee acceptance; or
+3. any trigger in this register has fired without a completed re-score.
+
+Cutover-critical gates additionally verify the specific gate criteria delegated to them by rows above
+(R-07 stability buffer, R-14 validator commitments, R-15 re-registration threshold, R-12 venue
+commitments).
+
+### 6.3 Risk budget and contingency reserve
+
+The reactive side of this register is funded by the **contingency reserve** established in
+[11. Scope of work](./11-scope-of-work.md); proactive mitigations are funded in baseline workstream
+budgets. Rules:
+
+1. Owners of High/Critical risks maintain an expected-cost estimate (likelihood-band midpoint ×
+   cost-if-realized), refreshed at the monthly review.
+2. The sum of expected costs of open High/Critical risks MUST remain within the remaining contingency
+   reserve. If projected to exceed it, the PMO MUST re-baseline (descope, add budget, or obtain
+   steering-committee acceptance) before the next gate.
+3. Any single reserve drawdown exceeding 25% of the remaining reserve REQUIRES steering-committee
+   approval in advance.
+4. Every drawdown is recorded in this file against the triggering R-xx, with amount and date.
+5. Reserve consumption is reported at every gate alongside the re-scored register.
+
+---
+
+## Cross-references
+
+- [13. Open questions & assumptions](./13-open-questions-and-assumptions.md): D/A/Q items linked throughout; new decisions arising from risk treatment are appended there.
+- [10. Rollout & cutover](./10-rollout-and-cutover.md): gates G0–G5, cutover runbook, and the contingency runbooks R-07/R-14 rely on.
+- [11. Scope of work](./11-scope-of-work.md): contingency reserve, RACI (steering committee, owner roles), budget lines named in mitigations.
+- [08. Security & audits](./08-security-and-audits.md): audit plan, key management, incident response, monitoring behind R-01, R-03, R-04, R-22, R-23, R-31.
+- [09. Testing & verification](./09-testing-and-verification.md): parity harness, dry-runs, conformance suites cited as mitigations.
+- [05. Token migration](./05-token-migration.md) / [06. State & data migration](./06-state-and-data-migration.md): claims, conservation accounting, wind-down mechanics underlying R-01, R-02, R-13, R-14, R-21.
+- [07. Off-chain & clients](./07-offchain-and-clients.md): indexer, relayer, provider tooling behind R-05, R-06, R-15, R-25, R-32.
+
+## Feeds into
+
+- [10. Rollout & cutover](./10-rollout-and-cutover.md): gate reviews consume the re-scored register and §6.2 gate rules.
+- [11. Scope of work](./11-scope-of-work.md): contingency-reserve sizing and the change-board process take input from §6.3 and R-29.
+- [00. Executive summary](./00-executive-summary.md): top-10 snapshot (§3.2).
+- Monthly PMO operations: this file is the working register of record; Vendor assumes its maintenance at kickoff.

--- a/spec/aep-79/doc/13-open-questions-and-assumptions.md
+++ b/spec/aep-79/doc/13-open-questions-and-assumptions.md
@@ -1,0 +1,357 @@
+# 13. Open Questions, Assumptions & Decision Log
+
+| | |
+|---|---|
+| **Document** | 13. Open questions, assumptions & decision log |
+| **Doc ID** | AKASH-MIG-13 |
+| **Version** | 0.9 (draft for review) |
+| **Date** | 2026-08-10 |
+| **Owner** | Overclock Labs |
+| **Audience** | All program participants |
+| **Status** | Living document: single index for D/A/Q items referenced across the set |
+
+## Purpose
+
+Every consequential judgment in this document set is recorded here in one of three forms so the Vendor
+never has to guess what is settled and what is not:
+
+- **Decisions (D-xx)**: made, with alternatives considered and rationale. Build on these; reopening one
+  requires client sign-off and a version bump across affected docs.
+- **Assumptions (A-xx)**: believed true and load-bearing; each has a validation step. If one fails, the
+  named docs must be revisited.
+- **Open questions (Q-xx)**: genuinely unresolved, each with an owner and a needed-by milestone.
+
+## In scope
+
+- Program-wide decisions, assumptions, questions.
+- The list of time-sensitive ecosystem facts the Vendor must re-verify at kickoff.
+
+## Out of scope
+
+- Risks with likelihood/impact treatment: see [12. Risk register](./12-risk-register.md).
+- Requirement statements: those live in their home documents as `REQ-*`.
+
+---
+
+## 1. Decision log
+
+Statuses: **Fixed** (design-level decision, stable), **Open (G0)** (selected at Gate 0),
+**Provisional** (best current answer; revisit at the named gate).
+
+| ID | Decision | Status |
+|---|---|---|
+| D-01 | Target selection: two candidate paths, Solana mainnet (A) and an existing EVM L2 (B), specified to equal execution depth; selected at Gate 0 on the evidence items in [02 §4.2](./02-target-selection.md) | Open (G0) |
+| D-02 | No new sovereign chain on either path (Solana mainnet; an existing EVM L2 for the Ethereum path, host chain per Q-42; Arbitrum Orbit as the specified non-default dedicated-rollup variant) | Fixed |
+| D-03 | AKT on Solana: Token-2022 mint, 6 decimals, metadata extension only, no transfer hook, no freeze authority | Provisional (G1) |
+| D-04 | AKT on EVM: OpenZeppelin ERC-20, 6 decimals, EIP-2612 permit | Fixed |
+| D-05 | Migration mechanism: dual snapshot, S1 (liquid supply, at cutover C) + weekly residual distributions during wind-down + S2 (residuals, at halt H=C+90d); Merkle claims + exchange swaps; no persistent bridge | Fixed |
+| D-06 | Bonded/unbonding AKT credited as liquid at S1 incl. accrued rewards; vesting re-created with same end dates | Fixed |
+| D-07 | IBC-out AKT: pre-snapshot return campaign + bounded foundation-operated redemption window | Provisional (G1) |
+| D-08 | No cross-VM migration of live marketplace state; 90-day wind-down of leases on old chain (C→H), old-chain earnings honored via weekly residual distributions | Fixed |
+| D-09 | Marketplace semantics preserved: order→bid→lease flow, SDL unchanged, dseq/gseq/oseq UX retained | Fixed |
+| D-10 | x/cert x509 registry not ported; provider auth via JWT + on-chain registered signing keys | Fixed |
+| D-11 | Governance: Realms DAO + Squads v4 + timelock (Solana) / OZ Governor + AkashTimelock + Safe (EVM) | Provisional (G1) |
+| D-12 | Sovereign inflation ends at halt; replacement emissions to provider-incentive pool + community treasury per modeled schedule | Fixed (curve open: Q-01) |
+| D-13 | Price oracle: Pyth pull feeds | Fixed |
+| D-14 | Lease settlement in a natively-issued, deeply-liquid stablecoin (the settlement stablecoin) first-class alongside AKT; asset selected per Q-43 (USDC a candidate), configurable, no hard dependency on a single issuer | Fixed |
+| D-15 | Programs/contracts launch upgradeable behind multisig + timelock, published path to immutability/on-chain-governed upgrades | Fixed |
+| D-16 | Indexing: dedicated indexer (Geyser/webhooks → Postgres on Solana; Ponder-class on EVM) serving existing Console API shapes | Fixed |
+| D-17 | provider-services gets a Go chain-adapter interface; Solana impl pairs Go client reads with a co-located signing/tx service; EVM impl via abigen | Provisional (G1) |
+| D-18 | Sunset: cutover C (=S1) stops new marketplace writes via sunset upgrade (msg filter + min-gas raise); halt H (=S2) = C+90d; archives published; infra decommission H+90d | Fixed |
+| D-19 | ACT ported as first-class asset: Solana Token-2022 NonTransferable mint (protocol moves = burn/mint CPIs); EVM restricted ERC-20; lease pricing stays ACT-denominated | Fixed |
+| D-20 | BME engine ported: queued epoch-batched AKT↔ACT swaps, CR circuit breaker (9500/9000 bps defaults), mint spread, vault seeded from migrated bme module account; epochs become time-based, executed by permissionless cranks (Solana) / keeper automation (EVM) | Fixed |
+| D-21 | Escrow streaming ports on a per-second time basis (converted from per-block at S1); fully lazy settlement + permissionless settle; FIFO multi-depositor, overdrawn, and AKT-fallback semantics preserved; authz deposit grants become an on-chain delegated-deposit allowance with restore-on-refund | Fixed |
+| D-22 | No general-purpose smart-contract platform carried over: CosmWasm existed to host Pyth plumbing; targets read Pyth pull feeds directly; awasm filter layer has no successor | Fixed |
+| D-23 | Market state sharded per entity (one account/PDA or struct per deployment/group/order/bid/lease); accounts closed + rent refunded at terminal state; history lives in the indexer (events are the system of record); no global order-book account (Solana 12M CU/account cap) | Fixed |
+| D-24 | Provider-initiated lease reclamation windows (min 1h / max 720h) port 1:1 | Fixed |
+
+### Decision details
+
+**D-01. Target selection: two candidate paths, selected at Gate 0.**
+*Alternatives considered:* (a) selecting a single target now, before kickoff verification; (b) building
+both paths through implementation and deciding late (cost-prohibitive); (c) stay on Cosmos with shared
+security (the [`RFP_SHARED_SECURITY.md`](../README.md) path); (d) status quo.
+*Rationale:* Solana mainnet and the Ethereum path (an existing EVM L2) both clear the target requirements of
+[02 §2](./02-target-selection.md) as of 2026-08 and are specified to equal execution depth in
+[03](./03-solana-architecture.md)/[04](./04-ethereum-architecture.md). The factors weighing toward
+each differ in kind. Solana: DePIN category concentration (Helium, Render, io.net, Nosana,
+Hivemapper), two completed precedent migrations, fee/latency fit for a chatty marketplace, runtime
+fit (native Pyth; Token-2022 non-transferability for ACT); Ethereum/EVM L2: engineering/audit market
+depth, enterprise perception, exchange-affiliated distribution (e.g. Base's Coinbase funnel),
+commodity claims/vesting/governance tooling. Selection happens at Gate 0 against the [02 §4.2](./02-target-selection.md) evidence items
+and is an Akash community/leadership decision, not a Vendor decision.
+
+**D-02. No new sovereign chain.**
+*Alternatives:* dedicated OP Stack rollup; Arbitrum Orbit chain; SVM L2 (Eclipse/SOON-class); Solana
+network extension. *Rationale:* migration driver #2 is eliminating consensus/infra operational burden;
+operating a rollup (sequencer, DA posting, fault-proof ops, upgrade trains) re-creates that burden in a
+different shape. Deploying onto a shared chain maximizes the point of leaving Cosmos. The dedicated
+rollup is retained as variant B2 in [04](./04-ethereum-architecture.md) with an explicit revisit
+trigger (Q-06).
+
+**D-03. AKT as Token-2022, no exotic extensions.**
+*Alternatives:* legacy SPL token (maximum compatibility); Token-2022 with transfer hooks (protocol fee
+capture at token layer). *Rationale:* metadata extension removes the Metaplex dependency; hooks and
+permanent delegate materially degrade exchange/DeFi compatibility and are unnecessary because take
+fees are enforced in the escrow program (see [03](./03-solana-architecture.md)), not at the token
+layer. Provisional pending Q-05 (custody/exchange support matrix for Token-2022 as of kickoff); the
+fallback is a legacy SPL mint with Metaplex metadata, which changes no other design element.
+
+**D-04. ERC-20 with 6 decimals.**
+*Alternatives:* 18 decimals (EVM convention). *Rationale:* 1:1 micro-unit parity with `uakt` removes an
+entire class of rounding/accounting defects in claims and reconciliation; USDC (6 decimals) proves
+ecosystem tooling handles it fine.
+
+**D-05. Dual snapshot + claims; no persistent bridge.**
+*Alternatives:* single snapshot at halt (leaves the new-chain marketplace without AKT for 90 days, or
+forces a hard stop of running workloads); Render-style burn-and-mint window (requires live validation
+of the old chain for the whole window and real bridge infrastructure); indefinite two-way bridge
+(permanent security liability). *Rationale:* S1 at cutover moves the liquid supply when exchanges and
+holders need it (the day the new-chain marketplace opens) while funds locked in module accounts
+(escrow, BME vault, community pool, IBC escrows) are reserved on the target chain and paid out as the
+old chain's wind-down resolves them: weekly interim residual Merkle distributions during C→H (so
+providers receive old-chain lease earnings in new-chain AKT with ≤1 week lag), and a final S2
+distribution at halt. This bounds scope (no bridge), keeps supply conserved and auditable
+(liquid@S1 + reserved@S1 = total; reserved is fully allocated by S2), and follows the Helium
+precedent for the snapshot/claims machinery. Details in [05](./05-token-migration.md).
+
+**D-06. Bonded AKT goes liquid.**
+*Alternatives:* forced re-lock into new-chain governance staking; honoring residual unbonding periods
+post-migration. *Rationale:* bonding existed to secure consensus that no longer exists post-migration;
+carrying lock state across adds claims complexity for no security benefit. New-chain incentives (D-12)
+attract voluntary participation instead. Vesting is different: it encodes contractual obligations, so
+it is re-created (see [05](./05-token-migration.md) §vesting).
+
+**D-07. IBC-out AKT handling.**
+*Alternatives:* trust-minimized claims against counterparty-chain snapshots (requires per-chain proof
+tooling for Osmosis/Hub/etc.; disproportionate engineering); ignoring stranded vouchers
+(unacceptable, breaks holders). *Rationale:* drive supply home before snapshot via a coordinated
+campaign with wallets/DEX frontends, then operate a bounded, published redemption process for
+stragglers from reserved supply. Legal review required (Q-03, Q-10).
+
+**D-08. Wind-down instead of live-state migration.**
+*Alternatives:* trustless re-creation of live leases on the target chain (cross-VM state proofs,
+oracle-attested workload liveness; the riskiest component of the whole program for marginal benefit);
+hard cutover with forced lease termination on day one (interrupts running workloads, worst tenant
+experience). *Rationale:* leases are finite-lived and expire naturally; a 90-day wind-down lets
+workloads either conclude or redeploy on the new chain on the tenant's schedule. Escrow refunds on the
+old chain are automatic at close, and both refunds and provider withdrawals during C→H are made whole
+in new-chain AKT via the weekly residual distributions (D-05). Providers re-register on the new chain
+immediately at launch, so supply is live before demand cuts over. The sunset upgrade at C restricts
+the old chain to wind-down message types (settle/withdraw/close/top-up/BME burn) and raises min-gas
+to deter spam on a chain whose gas token has just lost claim value. Details in
+[06](./06-state-and-data-migration.md).
+
+**D-19/D-20. ACT and the BME engine port.**
+The current protocol prices every lease in ACT (`uact`), a bank-transfer-disabled compute token
+minted/redeemed against AKT through the burn-mint-escrow module at oracle prices with a
+collateral-ratio circuit breaker. This is core protocol economics, not incidental plumbing, so both
+target architectures carry it: ACT keeps its non-transferability (Solana: Token-2022 NonTransferable
+extension with burn/mint at protocol boundaries; EVM: transfer-restricted ERC-20), and the BME queue +
+CR breaker + spread logic becomes a program/contract whose epoch execution is driven by permissionless
+cranks or keeper automation instead of EndBlocker. *Alternative considered:* collapse ACT into
+pure-AKT pricing as part of the migration; rejected: it would bundle a tokenomics redesign into an
+already-large program and invalidate current-chain behavior parity testing (see
+[09](./09-testing-and-verification.md)).
+
+**D-21. Escrow time basis.**
+Current escrow rates are per-block (6.5 s target). Blocks are not a stable time unit on either target,
+so rates convert to per-second at a fixed factor at S1. Settlement stays lazy (computed on
+interaction), with an explicitly permissionless settle entrypoint so cranks/providers can force
+overdrawn detection, replacing the implicit guarantee that Cosmos EndBlocker-era code got from
+running settle inside consensus. FIFO depositor refunds and grant-restore-on-refund semantics are
+preserved because Console fee-sponsorship flows depend on them.
+
+### Amendments from the v0.9 drafting round
+
+Ratified refinements produced while drafting docs 03–12; each extends (never contradicts) its parent
+decision. Detail lives in the named documents.
+
+- **D-02.a**: Variant B2 concretized: Arbitrum Orbit **L3 on Arbitrum One**, AnyTrust DA, AKT +
+  MigrationClaims on the parent chain with a WAKT gas wrapper on-chain. The B1 host chain is not
+  fixed: it is selected per Q-42 against the chain criteria in 04 §1, and the contract suite stays
+  portable EVM so the host can change before G1 at bounded cost.
+- **D-04.a**: AKT (EVM) includes ERC20Votes with the timestamp clock mode (AkashGovernor
+  dependency) (04).
+- **D-05.a**: Point of no return = execution of S1 itself (sunset-upgrade activation at C + start of
+  exchange custodial swaps). The later attested-root publication + claims opening (D-05.b) is the
+  final verification milestone, after which no accounting adjustment to the S1 distribution is
+  possible. Abort paths exist only pre-S1: expedited cancellation proposal to ≈S1−36h, then
+  coordinated validator skip-upgrade to S1−6h (10 §6).
+- **D-05.b**: Claims-open sequence: S1 root computed and published ≤24 h after C; **7-day public
+  verification window** (dual-implementation match + community recomputation) before the root is
+  armed; self-custody claims open ≈C+8–10 d. Exchange custodial swaps execute at S1 and are NOT
+  gated on this window (05/06/10).
+- **D-05.c**: Anti-duplication rule: supply is fixed at S1. Post-S1 old-chain mints (inflation, BME
+  mints) carry zero claim value; post-S1 inflows into reserved module accounts are claim-inert; escrow
+  residual credits are FIFO-attributed and capped at each account's S1 principal (via
+  `Depositor.Height`), which makes the Wind-down Reserve sufficient by construction and blocks
+  self-lease duplicate-mint attacks (05 §5, 06 §3). Comms must state plainly that post-S1 escrow
+  top-ups spend already-credited AKT.
+- **D-06.a**: "Rewards up to halt" is implemented as rewards-to-C in the S1 leaves; C→H staking
+  yield is not honored individually; the validator/delegator wind-down budget (Q-13) is the
+  compensation channel for C→H service (05).
+- **D-10.a**: Provider identity splits into a cold owner authority plus rotating registered operator
+  hot keys, with provider TLS SPKI hashes anchored in the registry record. JWT claims schema carries
+  over with identical access levels and scopes; signature algs: EdDSA (Solana) / EIP-191 secp256k1 +
+  ERC-1271 (EVM); dual issuance modes (offline-signed token, SIWS/SIWE challenge) (07 §3).
+- **D-11.a**: EVM launch Governor parameters: quorum default 10% of supply (no clean equivalent of
+  Cosmos 20%-of-bonded; calibration = Q-23) (04).
+- **D-13.a**: **Oracle keep-alive C→H:** the sunset upgrade's allow-list retains
+  `MsgExecuteContract` pinned to the Pyth contract plus `MsgAddPriceEntry`, and Overclock operates
+  the Hermes price pusher until H; otherwise BME enters `halt_oracle`, which would block ACT→AKT
+  refunds and the escrow AKT-fallback during wind-down (06 §5).
+- **D-16.a**: API versioning: `/v1` frozen serving old-chain archive shapes (bech32, hex tx hashes);
+  `/v2` target-native with a `chain_id` discriminator (07 §4).
+- **D-18.a**: Sunset upgrade named `v3.0.0-sunset` (S1 height = first block with timestamp ≥ the
+  governance-approved instant, fixed in the software-upgrade proposal at S1−21d); halt implemented as
+  no-binary upgrade `v3.1.0-halt` at H+1, H = last committed block = S2 export height; S2 performs a
+  final virtual settlement of still-open escrow accounts (06/10).
+- **D-19.a**: Escrowed ACT is burned at deposit; BME's collateral-ratio denominator = ACT mint
+  supply + the program-tracked `act_escrowed` ledger (03 DELTA-12; 04 equivalent).
+- **D-20.a**: BME epoch execution: permissionless cranks with tips (Solana); Chainlink Automation
+  primary + Gelato secondary with permissionless entrypoints always available (EVM). Per-epoch swap
+  volume caps added as a new governed parameter (value = Q-25) (03/04, R-04).
+- **D-21.a**: Rates are stored as **u128 fixed-point (×10¹⁸) micro-ACT per second**; plain u64 loses
+  precision on typical fractional rates. Per-block→per-second conversion at S1 is the exact rational
+  ×2/13 (6.5 s blocks) (14 §7, 03/04/06).
+- **D-21.b**: Delegated-deposit allowances are funded-at-grant (locked at grant), restore-on-refund,
+  revoke-returns-remainder (03 DELTA-07).
+- **D-23.a**: The Cosmos hook cascades (escrow→market→deployment) become guarded permissionless
+  "reap" instructions/functions with a ≤60 s p95 crank SLA; losing-bid refunds execute asynchronously
+  (03 DELTA-04/06).
+- **D-14.a**: Settlement-stablecoin mechanism: the settlement stablecoin settles ACT-denominated
+  obligations at a governed parity (`stable_act_parity_bps`, default 10000 = par; USD-denominated
+  units, decimals normalized if the selected asset is not 6-decimal); pricing remains
+  ACT-denominated. Asset selection = Q-43; ratification + whether BME grows a stablecoin PSM = Q-22
+  (03 DELTA-08, 04).
+- **Escrow bound**: `max_depositors` becomes a DAO-config parameter, initial value 16; other
+  protocol bounds (groups ≤8/deployment, resource units ≤4/group, attributes ≤24, signed-by ≤4)
+  validated against the mainnet SDL corpus before design freeze (03/14, A-18/Q-38).
+
+**D-10. Drop the on-chain x509 registry.**
+*Alternatives:* port x/cert as-is (on-chain certificate blobs are expensive on both targets and the
+revocation UX was never good); TLS with trust-on-first-use (weakens provider authentication).
+*Rationale:* the provider stack already supports JWT-based auth; anchoring provider signing keys in the
+on-chain provider registry gives equivalent trust with two orders of magnitude less state. Tenant mTLS
+client certificates are replaced by wallet-signed ephemeral credentials. Details in
+[07](./07-offchain-and-clients.md).
+
+**D-12. Emissions replacement.**
+Sovereign inflation currently pays validators+delegators. Post-migration there are no validators to
+pay. The replacement schedule (reduced gross emissions, directed to provider incentives and the
+community treasury) is a tokenomics decision with a dedicated modeling deliverable in
+[11. SOW](./11-scope-of-work.md) (WS-1). The Vendor implements whatever curve the model + governance
+ratifies via the `akash-emissions` program / `EmissionsMinter` contract; the mechanism (timelocked,
+DAO-adjustable, hard-capped) is fixed even though the curve is not.
+
+**D-17. Provider daemon chain adapter.**
+*Alternatives:* rewrite provider-services in Rust/TS (enormous, unnecessary); pure-Go Solana
+integration including tx assembly for all flows (Go SDK maturity risk for edge cases: priority fees,
+lookup tables, retries). *Rationale:* an interface seam (`pkg/chain`) keeps the daemon's Kubernetes
+logic untouched; reads and simple txs go through the Go client, and a small co-located signer service
+(Rust or TS, gRPC, localhost-only) handles tx assembly/broadcast where Go tooling is weak. Provisional:
+if kickoff evaluation shows the Go client alone is sufficient (Q-15), drop the signer service.
+
+---
+
+## 2. Assumptions
+
+| ID | Assumption | Validation | If false, affects |
+|---|---|---|---|
+| A-01 | `akashnet-2` operates normally through the program; no upgrades that materially change state layout before halt | Coordination with core team; freeze on state-affecting upgrades from G2 | 05, 06, 10 |
+| A-02 | Akash on-chain governance approves the migration (and later, the halt-height proposal) | Signal proposal before G0; binding proposals per [10](./10-rollout-and-cutover.md) | Entire program |
+| A-03 | Overclock provides ≥2 FTE counterpart engineers + product/comms staffing for the duration | Contract/SOW ratification | 11 |
+| A-04 | ≥85–90% of circulating AKT is reachable via exchange swaps + active-wallet claims within 12 months (Helium/Render precedent) | Exchange coordination (Q-04); claims telemetry | 05, 12 |
+| A-05 | Provider operators accept one daemon upgrade + one on-chain re-registration | Provider council preview; testnet incentives | 07, 10 |
+| A-06 | No adversarial fork of the old chain retains economic weight post-halt | Exchange alignment on ticker/chain identity (Q-04) | 05, 10, 12 |
+| A-07 | Ecosystem facts in the research pack (fees, versions, feature status) hold as of 2026-08; all volatile items re-verified at kickoff | Kickoff verification sprint (§4 list) | 02, 03, 04 |
+| A-08 | At least one natively-issued, deeply-liquid stablecoin exists and is unrestricted on the selected target (true for all candidates as of 2026-08) | Kickoff verification (Q-43) | 03, 04, 05 |
+| A-09 | AKT ticker is retained across venues (no rebrand) | Exchange coordination | 05 |
+| A-10 | SDL and manifest semantics need no changes for the new chain (manifests never lived on-chain) | Confirmed in [01](./01-current-architecture.md) | 03, 04, 07 |
+| A-11 | The existing Console/indexer API surface can be preserved for clients modulo address/tx-hash formats | 07 design review | 07 |
+| A-12 | The protocol being migrated is the v2 line as at commit `096bff57` (dual-token AKT/ACT, BME, oracle, epochs, CosmWasm-hosted Pyth feed); any protocol changes shipped before G1 must be folded into [01](./01-current-architecture.md) and [14](./14-appendix-protocol-mapping.md) | Kickoff re-baseline against mainnet | 01, 03, 04, 14 |
+| A-13 | Solana's Alpenglow consensus upgrade (expected Q3–Q4 2026) ships without breaking deployed program semantics; program-visible changes are limited to timing/finality characteristics | Track SIMD-0326 rollout at kickoff | 03, 12 |
+| A-14 | Client renders the Gate 0 decision ≤10 business days after M1 acceptance; Stage B calendar slips day-for-day otherwise | SOW ratification | 11 |
+| A-15 | Single prime Vendor; subcontractors (e.g. WS1 economist) only with client approval and prime liability | SOW ratification | 11 |
+| A-16 | An `akashnet-2` archive node with full state/tx/event history since genesis is available to the Vendor (golden vectors, Q-19 pull, weekly wind-down exports) | Overclock provisions at kickoff | 06, 09 |
+| A-17 | Launch multisig baseline (4-of-7, ≤2 signers per org, ≥3 jurisdictions) is an example; exact roster and thresholds fixed at G1 key ceremony | G1 ceremony | 08 |
+| A-18 | Explicit protocol bounds introduced by the target designs (groups ≤8, resource units ≤4, attributes ≤24, depositors init 16, signed-by ≤4) accommodate the real mainnet SDL corpus | Corpus scan pre-design-freeze (Q-38) | 03, 04, 14 |
+| A-19 | Exchanges can execute Merkle claims programmatically via the Vendor-supplied integration kit; old-chain AKT deposit crediting at venues is permanently disabled at S1 | Exchange tech-pack review (Q-04) | 05, 10 |
+| A-20 | provider-services Kubernetes resource naming (namespaces/ingress derived from lease IDs) does not collide across chains during the dual-stack window | Test in 09 (REQ-OFF-060) | 07, 09 |
+| A-21 | `bseq` is retained as constant 0 in API shapes (current chain enforces bseq==0) and dropped from target-chain identity derivations | Parity review | 03, 04, 07, 14 |
+| A-22 | The API-types module baseline is `pkg.akt.dev/go` v0.2.14 (go.mod pin); research citations against v0.3.0 module-cache paths are shape-identical | Kickoff re-baseline (with A-12/Q-19) | 01, 14 |
+| A-23 | ≥2/3 of bonded voting power remains online C→H given the Q-13 incentive program (contingency: accelerate S2 from last good height) | Signed uptime commitments (Q-26) | 06, 10, 12 |
+
+## 3. Open questions
+
+| ID | Question | Owner | Needed by |
+|---|---|---|---|
+| Q-01 | Replacement emissions curve + provider-incentive budget: gross rate, decay, split, hard cap | Overclock finance + community (Vendor models) | G1 |
+| Q-02 | Unclaimed-funds policy after the 2-year claim window (sweep to treasury? extend?); legal posture per jurisdiction | Legal counsel | G2 |
+| Q-03 | IBC voucher redemption: which counterparty chains to snapshot for outreach (Osmosis, Cosmos Hub, others?), redemption window length, KYC posture | Overclock + legal | G1 |
+| Q-04 | Exchange coordination list, lead times, and technical requirements per venue (top ~10 by AKT volume) | Overclock BD | G1 |
+| Q-05 | Token-2022 support matrix across target exchanges/custodians as of kickoff; fallback trigger to legacy SPL (D-03) | Vendor (kickoff verification) | G1 |
+| Q-06 | Revisit trigger for dedicated-rollup variant B2: define the host-chain cost/throughput threshold that would reopen D-02 | Vendor + Overclock | G1 |
+| Q-07 | Operational ownership post-launch: fee-sponsorship relayer, indexer, RPC; Vendor-operated, Overclock-operated, or third party (with budget) | Overclock | G2 |
+| Q-08 | Provider registration collateral size and slashing conditions (partial replacement for staking-based Sybil resistance) | Protocol WG (Vendor proposes) | G1 |
+| Q-09 | Old-chain archive hosting: storage vendor, retention (≥5y?), funding | Overclock | G3 |
+| Q-10 | Legal review of the claims process (securities/MiCA/OFAC screening for the claim portal?) | Legal counsel | G2 |
+| Q-11 | Realms stock vs light fork: gap analysis for council/veto features Akash governance requires | Vendor | G1 |
+| Q-12 | dseq semantics: program-maintained counter (working assumption in 03/04) vs slot-derived; confirm no tooling depends on dseq==block-height | Vendor + Console team | G1 |
+| Q-13 | Validator wind-down program: recognition/incentives for `akashnet-2` validators through halt | Overclock + community | G2 |
+| Q-14 | Console managed-wallet users: custodial migration mechanics and comms | Console team | G2 |
+| Q-15 | Go-only Solana integration feasibility for provider daemon (drop signer sidecar?); prototype verdict | Vendor | G1 |
+| Q-16 | ACT wallet presentation: token metadata (name/symbol), whether wallets should surface it at all, and how Console explains non-transferability | Console team + Vendor | G2 |
+| Q-17 | Old-chain post-S1 anti-spam calibration: sunset msg allow-list contents and min-gas multiplier | Vendor + core team | G3 |
+| Q-18 | Interim residual distribution cadence (weekly default) and minimum-payout threshold to keep Merkle drops economical | Vendor | G2 |
+| Q-19 | Current mainnet inflation/mint parameters and vesting-account inventory (NOT in source; must be read from live akashnet-2 state export) as inputs to Q-01 modeling and 05 supply accounting; include live gov/staking/consensus params and marketplace op-mix statistics | Vendor (kickoff data pull) | G1 |
+| Q-20 | Audit firm selection and budget cap (≥2 protocol firms + ≥1 migration-engine review); contracts signed by M2 | Overclock + Vendor | G1 |
+| Q-21 | Incentivized provider-testnet rewards budget and funding source (targets: ≥25 providers, ≥3 regions, GPU presence) | Overclock | G1 |
+| Q-22 | Settlement-stablecoin↔ACT parity: ratify the governed `stable_act_parity_bps` par rule (D-14.a) and decide whether BME grows a stablecoin PSM | Protocol WG (Vendor proposes) | G1 |
+| Q-23 | EVM Governor quorum/threshold calibration (launch default 10% of supply; Cosmos 20%-of-bonded has no clean ERC20Votes equivalent) | Governance WG | G1 |
+| Q-24 | Secondary price oracle (Switchboard-class): selection, integration readiness, and switch criteria as the Pyth fallback | Vendor | G1 |
+| Q-25 | BME per-epoch swap volume caps: new governed parameter (mechanism in 03/04); value from WS1 modeling | Vendor + protocol WG | G1 |
+| Q-26 | Signed validator uptime commitments covering >2/3 voting power as a cutover gate criterion: mechanism and threshold | Overclock | G2 |
+| Q-27 | Which ≥2 exchange venues commit to the pre-G3 sandbox swap test | Overclock BD | G2 |
+| Q-28 | Immutability burn-in duration N for claims + escrow core (default proposal: 12 months) | Steering | G2 |
+| Q-29 | Claims velocity-breaker threshold (fraction of unclaimed supply per 24 h that auto-pauses claims) | Vendor + steering | G2 |
+| Q-30 | Auto-pause policy: may monitors trigger a pre-authorized guardian intake pause on supply-conservation violation? | Steering | G2 |
+| Q-31 | Bug-bounty platform selection and final tier sizing | Overclock | G2 |
+| Q-32 | Economic-security firm procurement (Gauntlet-class) for the BME/emissions review | Overclock + Vendor | G1 |
+| Q-33 | Claims dust threshold DUST_MIN (default 10,000 micro-units) and the legal posture for sweeping dust at tree build | Legal + steering | G2 |
+| Q-34 | DEX liquidity seeding at launch: amounts, venue split (Raydium/Orca on Solana vs the leading DEX on the EVM host chain), LP policy; pre-authorized community-pool carve-out executable at S1 | Overclock finance | G2 |
+| Q-35 | Disposition of non-native IBC-voucher balances (e.g. IBC USDC) still on the Akash chain at H | Overclock + legal | G3 |
+| Q-36 | Signer-sidecar implementation language (Rust vs TS) and pod packaging for provider-services | Vendor (with Q-15 prototype) | G1 |
+| Q-37 | Does the `akash claim` CLI need Cosmos-multisig ADR-036 signing support (tooling capability unclear in Keplr/CLI)? | Vendor | G2 |
+| Q-38 | Validate A-18 bounds against the full mainnet SDL corpus; confirm `max_depositors` initial 16 | Vendor | G1 |
+| Q-39 | Crank tip funding source (BME spread vs treasury) and tip rates | Vendor + protocol WG | G1 |
+| Q-40 | May a provider re-bid on an order after closing its own bid (PDA/id freed)? Benign delta vs must-block (adjunct to Q-12/bseq) | Vendor | G1 |
+| Q-41 | BME swap-execution pricing window: `bme` params define a 1 h oracle TWAP while `x/oracle` TwapWindow defaults to 5 s; confirm which the engine actually uses (port fidelity for D-20) | Vendor (code trace at kickoff) | G1 |
+| Q-42 | EVM host-chain selection (path B): evaluate candidates (Base, Arbitrum One, Robinhood Chain, others) against the chain criteria in 04 §1; decided with the Gate 0 evidence pack if path B is selected | Overclock + Vendor | G0 |
+| Q-43 | Settlement-stablecoin selection: evaluate natively-issued candidates (e.g. USDC, PYUSD, USDT where natively issued) on liquidity depth, issuer and regulatory posture, freeze/blacklist policy, decimals, and availability across both candidate paths; the asset is a configurable protocol parameter | Overclock + Vendor | G1 |
+
+Folded into existing questions during drafting: delegator coverage and continuity-payout constants
+(power cap, 90%/80% eligibility, equivocation forfeiture) → **Q-13**; C→H IBC voucher returns acting
+as de-facto bearer claims (needs legal/policy sign-off) → **Q-03/Q-10**; residual-cadence economics →
+**Q-18**.
+
+## 4. Volatile facts: re-verify at Vendor kickoff
+
+Solana: current fee levels and compute-unit limits; Token-2022 exchange/custody support; Alpenglow
+rollout status; Firedancer share; Realms/SPL-governance maintenance status; rent (storage) cost per
+byte; Pyth AKT feed availability. Ethereum/EVM L2s: blob fee levels and L2 fee reality; OP Stack
+fault-proof and custom-gas-token status; candidate host-chain throughput, fees, and commercial policy
+(Q-42); NTT/OFT security posture.
+Both: settlement-stablecoin issuance/liquidity status (Q-43), WalletConnect/wallet support assumptions in [07](./07-offchain-and-clients.md),
+RPC-provider SLAs.
+
+## Cross-references
+
+- [02. Target selection](./02-target-selection.md): full rationale for D-01/D-02.
+- [12. Risk register](./12-risk-register.md): risks tied to A-04/A-05/A-06.
+- [10. Rollout & cutover](./10-rollout-and-cutover.md): gates G0–G5 referenced by Q items.
+
+## Feeds into
+
+Every document in the set references this index; Vendor onboarding starts here after 00/02.

--- a/spec/aep-79/doc/14-appendix-protocol-mapping.md
+++ b/spec/aep-79/doc/14-appendix-protocol-mapping.md
@@ -1,0 +1,573 @@
+# 14. Appendix: Protocol Mapping (Cosmos → Solana → EVM)
+
+| | |
+|---|---|
+| **Document** | 14. Appendix: protocol mapping |
+| **Doc ID** | AKASH-MIG-14 |
+| **Version** | 0.9 (draft for review) |
+| **Date** | 2026-08-10 |
+| **Owner** | Overclock Labs |
+| **Audience** | Vendor engineering (all workstreams) |
+| **Status** | Informative: realizes decisions D-01…D-24; contains no new requirements |
+
+## Purpose
+
+- Single lookup artifact mapping every Cosmos-side protocol element (message, query, state object,
+  event, parameter, module account, unit, error) to its Solana equivalent (per
+  [03](./03-solana-architecture.md)) and EVM equivalent (per [04](./04-ethereum-architecture.md)).
+- Source of truth for parity test matrices ([09](./09-testing-and-verification.md)) and SOW
+  traceability ([11](./11-scope-of-work.md)).
+
+## In scope
+
+- All messages, queries, stored state, typed events, and parameters of the ten Akash modules at
+  commit `096bff57` (protocol line per A-12), plus the stock Cosmos SDK surface Akash users actually
+  exercise.
+- Module-account, identity, unit, time-basis, fee, and error-taxonomy mappings.
+- A Cosmos↔Solana↔EVM concept glossary.
+
+## Out of scope
+
+- Rationale for target designs (see [03](./03-solana-architecture.md) /
+  [04](./04-ethereum-architecture.md)) and for decisions (see
+  [13](./13-open-questions-and-assumptions.md)).
+- Token-migration accounting ([05](./05-token-migration.md)) and snapshot tooling
+  ([06](./06-state-and-data-migration.md)).
+- Off-chain API/indexer schemas ([07](./07-offchain-and-clients.md)).
+
+## Notation
+
+| Convention | Meaning |
+|---|---|
+| `akash-market.create_bid` | Solana: program (BRIEF-fixed name) `.` Anchor instruction (snake_case) |
+| `Marketplace.createBid` | EVM: contract (BRIEF-fixed name) `.` external function |
+| `["bid", owner, dseq, gseq, oseq, provider]` | PDA seed tuple under the owning program. String literals = UTF-8 bytes; `owner`/`provider` = 32-byte pubkey; integers little-endian fixed width (`dseq` u64 = 8 B, `gseq`/`oseq` u32 = 4 B) |
+| lifecycle `init: X / close: Y / rent: A→B` | account created by instruction X, closed by Y, rent paid by A and refunded to B (D-23) |
+| gov-gated | executable only by governance executor: Realms governance PDA (Solana) / `AkashTimelock` (EVM) per D-11 |
+| n/a post-migration | concept ends with the sovereign chain; no target equivalent |
+| Code paths | `x/…/file.go:NN` = [akash-network/node](https://github.com/akash-network/node) @ `096bff57`; proto types from `pkg.akt.dev/go` |
+
+Names in this appendix are the shared registry proposed to docs 03/04; if 03/04 diverge, 03/04 govern
+and the divergence is a doc defect to reconcile before G1. Amounts are micro-units (`uakt`/`uact`,
+6 decimals) throughout.
+
+---
+
+## 1. Message mapping
+
+Every transaction message accepted by the current chain. Type URLs are the protobuf `Any` type URLs.
+
+### 1.1 x/deployment (`akash.deployment.v1beta4`, handlers `x/deployment/handler/server.go`)
+
+| Cosmos msg (type URL) | Semantics | Solana | EVM | Behavioral deltas / notes |
+|---|---|---|---|---|
+| `/akash.deployment.v1beta4.MsgCreateDeployment` | Create deployment + N groups, open escrow account, create one order per group (`server.go:41-130`) | `akash-deployment.create_deployment` (CPI → `akash-escrow.create_account`, `akash-market.create_order` per group) | `DeploymentRegistry.createDeployment` (calls `EscrowVault`, `Marketplace`) | Parity: deposit MUST be ACT (uakt rejected at create, `server.go:60-62`); group price denom MUST be uact (`server.go:93`); reclamation window validated against market config (D-24). Delta: dseq from per-tenant counter, not block height (D-09, Q-12). Deposit `Sources` resolve balance and/or deposit allowance (§1.10, D-21) |
+| `/akash.deployment.v1beta4.MsgUpdateDeployment` | Replace SDL hash pointer on active deployment (`server.go:132-157`) | `akash-deployment.update_deployment` | `DeploymentRegistry.updateDeployment` | Hash must differ; active-only. SDL itself stays off-chain (D-09, A-10) |
+| `/akash.deployment.v1beta4.MsgCloseDeployment` | Close deployment; escrow account close cascades to groups/orders/bids/leases via hooks (`server.go:159-177`, `x/market/hooks/hooks.go`) | `akash-deployment.close_deployment` + permissionless `finalize_deployment_close` cranks (one per group/lease) | `DeploymentRegistry.closeDeployment` (inline bounded cascade) | Delta (Solana): Cosmos cascade is one atomic tx; Solana splits terminal-state finalization across crank instructions (CU/account limits, D-23); funds are safe in between (escrow marked closed first). EVM keeps single-tx cascade bounded by group count |
+| `/akash.deployment.v1beta4.MsgCloseGroup` | Close one group + its order/bid/lease (`server.go:179-201`) | `akash-deployment.close_group` | `DeploymentRegistry.closeGroup` | 1:1 |
+| `/akash.deployment.v1beta4.MsgPauseGroup` | Pause group; closes order/lease, keeps group resumable (`server.go:203-214`) | `akash-deployment.pause_group` | `DeploymentRegistry.pauseGroup` | 1:1 |
+| `/akash.deployment.v1beta4.MsgStartGroup` | Resume paused group; creates a fresh order (oseq+1) (`server.go:226-253`) | `akash-deployment.start_group` (CPI create_order) | `DeploymentRegistry.startGroup` | Carries deployment's reclamation config into new order |
+| `/akash.deployment.v1beta4.MsgUpdateParams` | Gov-gated param update (`server.go:255-268`) | gov-gated `akash-config.set_deployment_params` | gov-gated `AkashConfig.setDeploymentParams` | All module `MsgUpdateParams` collapse into the config program/contract (D-11); §5 |
+
+### 1.2 x/market (`akash.market.v1beta5`, handlers `x/market/handler/server.go`)
+
+| Cosmos msg (type URL) | Semantics | Solana | EVM | Behavioral deltas / notes |
+|---|---|---|---|---|
+| `/akash.market.v1beta5.MsgCreateBid` | Provider bids on open order; opens bid-collateral escrow account (`server.go:29-136`) | `akash-market.create_bid` (CPI → `akash-escrow.create_account`) | `Marketplace.createBid` | Parity: per-denom `BidMinDeposits`; reject when existing bids > `OrderMaxBids` (`server.go:45-46`, wraps `ErrInvalidBid`); `bseq` MUST be 0; bid price ≤ order price; resources offer must match group spec; attribute match vs provider self-attrs + audited attrs (`x/audit`); reclamation window bounds (D-24). Delta: bid count tracked as a counter on the order account (no index scan) |
+| `/akash.market.v1beta5.MsgCloseBid` | Provider closes own bid; on active lease, gated by reclamation (`server.go:138-192`) | `akash-market.close_bid` | `Marketplace.closeBid` | Parity: lease active + reclamation configured ⇒ must `LeaseStartReclaim` first (`ErrReclamationNotStarted`); reclaiming + now < deadline ⇒ `ErrReclamationWindowNotElapsed` (D-24). Cascades: pause group, close lease/order, close payment |
+| `/akash.market.v1beta5.MsgCreateLease` | Tenant accepts a bid: creates lease + streaming payment; all other open bids lose and their collateral refunds (`server.go:209-283`) | `akash-market.create_lease` (CPI → `akash-escrow.create_payment`); losing bids closed by permissionless `akash-market.close_lost_bid` (one per bid, crank) | `Marketplace.createLease` (inline loop over ≤ `OrderMaxBids` bids) | Delta (Solana): losing-bid refunds are NOT in the accept tx (account/CU caps, D-23); order is marked matched so lost bids can only be closed/refunded, never matched. EVM keeps Cosmos atomicity (bounded at 20). Payment rate = bid price converted to per-second (§7.3, D-21) |
+| `/akash.market.v1beta5.MsgCloseLease` | Tenant closes lease; if group still open, order is re-listed (oseq+1) (`server.go:285-336`) | `akash-market.close_lease` | `Marketplace.closeLease` | Relist parity preserved. Reason recorded (`LeaseClosedReason`, §4) |
+| `/akash.market.v1beta5.MsgWithdrawLease` | Provider settles + withdraws accrued earnings (`server.go:194-207` → `escrow.PaymentWithdraw`) | `akash-market.withdraw_lease` (CPI → `akash-escrow.settle_and_withdraw`) | `Marketplace.withdrawLease` | Parity: provider receives 100% (no protocol take today, `x/take` dead). Also callable by anyone as bare `akash-escrow.settle` (§1.11, D-21) |
+| `/akash.market.v1beta5.MsgLeaseStartReclaim` | Provider starts graceful wind-down; sets deadline = now + window (`server.go:338-379`) | `akash-market.lease_start_reclaim` | `Marketplace.startLeaseReclaim` | 1:1 (already wall-clock-based on Cosmos). Window ∈ [1h, 720h] per config (D-24) |
+| `/akash.market.v1beta5.MsgUpdateParams` | Gov-gated (`server.go:381-392`) | gov-gated `akash-config.set_market_params` | gov-gated `AkashConfig.setMarketParams` | §5 |
+
+### 1.3 x/escrow (`akash.escrow.v1`, handler `x/escrow/handler/server.go`)
+
+| Cosmos msg (type URL) | Semantics | Solana | EVM | Behavioral deltas / notes |
+|---|---|---|---|---|
+| `/akash.escrow.v1.MsgAccountDeposit` | Top up an escrow account from balance and/or authz grant sources (`server.go:31-44`; `keeper.go:176-345`) | `akash-escrow.account_deposit` | `EscrowVault.accountDeposit` | Parity: the ONLY path that accepts uakt into deployment escrow (create is ACT-only); settles first when account overdrawn; grant source draws down the delegated deposit allowance (D-21). Delta: AKT moves as token transfer into per-account vault; ACT deposit = burn-from-depositor + ledger credit (D-19) |
+
+### 1.4 x/bme (`akash.bme.v1`, handlers `x/bme/handler/server.go`)
+
+| Cosmos msg (type URL) | Semantics | Solana | EVM | Behavioral deltas / notes |
+|---|---|---|---|---|
+| `/akash.bme.v1.MsgBurnMint` | Queue an AKT↔ACT swap request; executed at next epoch (`server.go:52-75`; `keeper.go:786-865`) | `akash-bme.request_burn_mint` (creates pending-record PDA) | `BurnMintEscrow.requestBurnMint` | Parity: only uakt↔uact; healthy oracle price required on both denoms; rejected when status ≥ halt_cr EXCEPT ACT→AKT refunds under CR-halt (blocked under halt_oracle); funds escrowed into vault at request; pending balances excluded from CR (D-20). Delta: request pays rent for its queue record (refunded on execute/cancel) |
+| `/akash.bme.v1.MsgMintACT` | Sugar: BurnMint with `DenomToMint = uact` (`server.go:77-98`) | `akash-bme.mint_act` | `BurnMintEscrow.mintACT` | `MinMint = 10,000,000 uact` floor applies (§5) |
+| `/akash.bme.v1.MsgBurnACT` | Sugar: BurnMint with `DenomToMint = uakt` (`server.go:100-121`) | `akash-bme.burn_act` | `BurnMintEscrow.burnACT` | Allowed under CR-halt (refund path), not under oracle-halt |
+| `/akash.bme.v1.MsgFundVault` | Gov-only vault top-up from a non-module source (`server.go:123-167`) | gov-gated `akash-bme.fund_vault` | gov-gated `BurnMintEscrow.fundVault` | Vault seeded at S1 from migrated bme module account via Wind-down Reserve (D-05, D-20; [05](./05-token-migration.md)) |
+| `/akash.bme.v1.MsgUpdateParams` | Gov-gated (`server.go:34-50`) | gov-gated `akash-config.set_bme_params` | gov-gated `AkashConfig.setBmeParams` | §5; epoch params convert block→time basis (D-20) |
+
+### 1.5 x/oracle (`akash.oracle.v2`)
+
+| Cosmos msg (type URL) | Semantics | Solana | EVM | Behavioral deltas / notes |
+|---|---|---|---|---|
+| `/akash.oracle.v2.MsgAddPriceEntry` | Authorized source (the CosmWasm Pyth contract) submits AKT/USD price; only `akt`/`usd` accepted | Not ported. Replaced by permissionless Pyth pull update: post/refresh the AKT/USD price-update account via `pyth-solana-receiver`; protocol programs read it directly (D-13, D-22) | Not ported. `IPyth.updatePriceFeeds` (permissionless, fee-paid); contracts read `getPriceNoOlderThan` | Trust moves from a single authorized source address (`RESEARCH: params.Sources`) to Pyth's signed price attestations. On-chain TWAP/median aggregation (oracle EndBlocker) is retired; consumers use Pyth price + confidence + staleness bound from config (§5.4). Feed: `[TO-VERIFY: Pyth AKT/USD feed ID and Solana feed account at kickoff]` |
+| `/akash.oracle.v2.MsgUpdateParams` | Gov-gated | gov-gated `akash-config.set_oracle_params` (staleness/deviation bounds, feed ID) | gov-gated `AkashConfig.setOracleParams` | §5.4 |
+
+### 1.6 x/provider (`akash.provider.v1beta4`, handlers `x/provider/handler/server.go`)
+
+| Cosmos msg (type URL) | Semantics | Solana | EVM | Behavioral deltas / notes |
+|---|---|---|---|---|
+| `/akash.provider.v1beta4.MsgCreateProvider` | Register provider: host URI, attributes, contact info (`server.go:33-51`) | `akash-provider-registry.create_provider` | `ProviderRegistry.createProvider` | Delta: registration additionally anchors the provider's JWT signing key(s) (D-10; [07](./07-offchain-and-clients.md)); optional registration collateral per Q-08. Providers re-register on the target chain at launch (D-08) |
+| `/akash.provider.v1beta4.MsgUpdateProvider` | Update registry record (`server.go:53-72`) | `akash-provider-registry.update_provider` | `ProviderRegistry.updateProvider` | Parity incl. historical quirk: "no active leases" check was removed in v0.32.0 and is NOT reintroduced |
+| `/akash.provider.v1beta4.MsgDeleteProvider` | Currently returns `ErrInternal` "NOTIMPLEMENTED" (`server.go:74-88`) | `akash-provider-registry.deactivate_provider` then `close_provider`: staged, rejected while provider has active leases/open bids (03 REQ-SOL-035) | `ProviderRegistry.beginDeregister` / `finalizeDeregister` (same guard, 04) | Deliberate delta: target implements the staged deregistration the Cosmos chain stubbed; closes registry account, refunds rent/collateral |
+
+### 1.7 x/audit (`akash.audit.v1`)
+
+| Cosmos msg (type URL) | Semantics | Solana | EVM | Behavioral deltas / notes |
+|---|---|---|---|---|
+| `/akash.audit.v1.MsgSignProviderAttributes` | Auditor signs an attribute set for a provider; consumed by bid matching | `akash-audit.sign_provider_attributes` | `AuditRegistry.signProviderAttributes` | Upsert per (provider, auditor) pair; attributes bounded to fit account (realloc on growth) |
+| `/akash.audit.v1.MsgDeleteProviderAttributes` | Auditor deletes named attribute keys (or all) for a provider | `akash-audit.delete_provider_attributes` | `AuditRegistry.deleteProviderAttributes` | Account closed (rent→auditor) when the set empties |
+
+### 1.8 x/cert (`akash.cert.v1`): NOT PORTED (D-10)
+
+| Cosmos msg (type URL) | Semantics | Solana | EVM | Behavioral deltas / notes |
+|---|---|---|---|---|
+| `/akash.cert.v1.MsgCreateCertificate` | Store x509 cert (PEM) + pubkey on chain, keyed by owner+serial | Not ported | Not ported | Replaced by JWT auth against signing keys in the provider registry; tenant mTLS client certs replaced by wallet-signed ephemeral credentials ([07](./07-offchain-and-clients.md)). Historical certs archived per [06](./06-state-and-data-migration.md) |
+| `/akash.cert.v1.MsgRevokeCertificate` | Move cert to revoked state | Not ported | Not ported | Key rotation = `update_provider` / `updateProvider` (registry key replacement is the revocation) |
+
+### 1.9 x/wasm (awasm) + wasmd: NOT PORTED (D-22)
+
+| Cosmos msg (type URL) | Semantics | Solana | EVM | Behavioral deltas / notes |
+|---|---|---|---|---|
+| `/akash.wasm.v1.MsgUpdateParams` | Gov-gated blocked-address list for the CosmWasm msg filter | Not ported | Not ported | The awasm filter existed to confine the Pyth CosmWasm contracts (`x/wasm/keeper/msg_filter.go:64-180`); direct Pyth reads make it moot |
+| `/cosmwasm.wasm.v1.MsgStoreCode`, `MsgInstantiateContract`, `MsgExecuteContract` (wasmd) | Host/drive the Pyth price-feed contracts; upload locked to gov on mainnet | Not ported | Not ported | Sole production use = Pyth VAA verification → `MsgAddPriceEntry`; collapses to Pyth pull reads (D-13, D-22) |
+
+### 1.10 Stock Cosmos SDK messages in active use
+
+| Cosmos msg (type URL) | Semantics | Solana | EVM | Behavioral deltas / notes |
+|---|---|---|---|---|
+| `/cosmos.bank.v1beta1.MsgSend` (uakt) | Transfer AKT | SPL Token-2022 `transfer_checked` (AKT mint, D-03) | `AKT.transfer` / `transferFrom` (D-04) | 1:1 in micro-units (6 decimals both sides) |
+| `/cosmos.bank.v1beta1.MsgSend` (uact) | Rejected today: `SendEnabled=false` for uact (`cmd/akash/cmd/genesis.go:121-130`) | n/a: ACT mint has Token-2022 `NonTransferable`; only protocol burn/mint CPIs move it (D-19) | n/a: `ACT` transfers revert except for protocol contracts (D-19) | Non-transferability parity is a hard requirement of D-19 |
+| `/cosmos.bank.v1beta1.MsgMultiSend` | Batch transfer | Multiple transfer instructions in one Solana tx | Multicall / batch-disperse contract (non-protocol) | Convenience only; not a protocol surface |
+| `/cosmos.staking.v1beta1.MsgDelegate` | Bond AKT to a validator | n/a post-migration (D-06): no sovereign consensus; governance power via Realms AKT deposits | n/a post-migration: governance via `AkashGovernor` votes | Bonded/unbonding stake is credited liquid at S1 (D-06); replacement participation incentives per D-12 |
+| `/cosmos.staking.v1beta1.MsgUndelegate`, `MsgBeginRedelegate` | Unbond / move stake | n/a post-migration | n/a post-migration | Unbonding entries at S1 credited liquid (D-06) |
+| `/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward`, `MsgWithdrawValidatorCommission` | Claim staking rewards | n/a post-migration | n/a post-migration | Accrued unclaimed rewards up to halt are folded into claims (D-06; [05](./05-token-migration.md)) |
+| `/cosmos.gov.v1.MsgSubmitProposal` | Submit governance proposal (deposit-gated) | Realms (SPL Governance) create-proposal in the AKT realm (D-11) | `AkashGovernor.propose` | Deposit model → proposal-creation token threshold (Realms) / `proposalThreshold` (Governor); no burn-on-veto equivalent |
+| `/cosmos.gov.v1.MsgVote` (+`MsgVoteWeighted`) | Vote on proposal | Realms cast-vote | `AkashGovernor.castVote` / `castVoteWithReason` | Quorum/period values set at G1 per D-11 (§5.6) |
+| `/cosmos.gov.v1.MsgDeposit` | Top up proposal deposit | n/a: no deposit phase in Realms | n/a: no deposit phase in Governor | Spam control shifts to creation thresholds |
+| `/cosmos.authz.v1beta1.MsgGrant` with `/akash.escrow.v1.DepositAuthorization` | Grant deposit-on-behalf right `{SpendLimit legacy, SpendLimits Coins, Scopes}` (`x/escrow/keeper/keeper.go:176-345`) | `akash-escrow.grant_deposit_allowance`: creates allowance PDA `["allowance", granter, grantee]` {limits per denom, scopes} | `EscrowVault.approveDepositAllowance(grantee, limits, scopes)` | D-21: explicit on-chain delegated-deposit allowance replaces authz. Parity: partial spends decrement the allowance; refunds on account close RESTORE it (`keeper.go:1050-1075`); scopes = {deployment, bid} msg classes. Console fee-sponsorship flows depend on restore-on-refund |
+| `/cosmos.authz.v1beta1.MsgRevoke` (same grant) | Revoke grant | `akash-escrow.revoke_deposit_allowance` (closes PDA, rent→granter) | `EscrowVault.revokeDepositAllowance(grantee)` | Outstanding escrow deposits unaffected; only future draws blocked |
+| `/cosmos.authz.v1beta1.MsgExec` | Execute a granted msg | n/a: depositor signs deposit ix directly; allowance consumed inside `account_deposit` / `create_deployment` / `create_bid` paths | n/a: same | Matches current semantics: grants are consumed inside escrow's `AuthorizeDeposits`, not via generic exec |
+| `/cosmos.authz.v1beta1.MsgGrant` (generic, other types) | Arbitrary msg delegation | No general successor; app-level session keys/delegates per [07](./07-offchain-and-clients.md) | No general successor; account-abstraction session keys | Only the DepositAuthorization seam is protocol-load-bearing today |
+| `/cosmos.feegrant.v1beta1.MsgGrantAllowance` / `MsgRevokeAllowance` | Sponsor another account's tx fees (used for onboarding; fees only; deposits use authz) | Fee-sponsorship service: sponsor co-signs as Solana fee payer (relayer per [07](./07-offchain-and-clients.md), Q-07) | ERC-4337 paymaster charging/settling in AKT ([07](./07-offchain-and-clients.md)) | Moves from consensus feature to operated service on Solana; on EVM paymaster is on-chain but operated (Q-07) |
+| `/ibc.applications.transfer.v1.MsgTransfer` | ICS-20 send AKT to other Cosmos chains | n/a post-migration: no IBC; third-party bridges out of protocol scope | n/a post-migration: canonical/third-party bridges out of protocol scope | IBC-out AKT handled by the D-07 pre-C return-home window + redemption process ([05](./05-token-migration.md) §7) |
+
+### 1.11 New target-chain entrypoints with no Cosmos msg predecessor (context)
+
+| Solana | EVM | Purpose |
+|---|---|---|
+| `akash-escrow.settle` (permissionless) | `EscrowVault.settle` (permissionless) | Force lazy settlement / overdrawn detection; replaces the implicit in-consensus settle points (D-21). Cosmos exposes `AccountSettle` only as a keeper method with no tx caller (`x/escrow/keeper/keeper.go`) |
+| `akash-market.close_lost_bid` (crank) | inline in `createLease` | Losing-bid close + collateral/rent refund (§1.2) |
+| `akash-deployment.finalize_deployment_close` (crank) | inline in `closeDeployment` | Cascade finalization (§1.1) |
+| `akash-bme.crank_epoch` (permissionless, tipped) | keeper automation calling `BurnMintEscrow.executeEpoch` | Replaces bme EndBlocker epoch execution (D-20); processes ≤ `max_records_per_crank` |
+| Pyth receiver `post_update` (ecosystem ix) | `IPyth.updatePriceFeeds` | Replaces the CosmWasm pyth contract → `MsgAddPriceEntry` path (D-13) |
+| `akash-claims.claim` / residual claim | `MigrationClaims.claim` | Token migration (D-05; [05](./05-token-migration.md)) |
+| `akash-emissions.distribute` | `EmissionsMinter.mint` (timelocked schedule) | Replacement emissions (D-12) |
+
+---
+
+## 2. Query mapping
+
+Read-path legend: **PDA** = direct `getAccountInfo` + Anchor/Borsh decode (authoritative for LIVE
+entities); **view** = `eth_call` on a view function (authoritative live); **indexer** = Console
+indexer API (D-16), authoritative for lists, filters, and anything CLOSED (accounts are closed at
+terminal state; events are the system of record for history, D-23). Cosmos `PageRequest`
+(key/offset/limit/reverse) maps to indexer cursor pagination; on-chain enumeration is not provided on
+either target (`getProgramAccounts` scans are not a supported API path).
+
+| Cosmos gRPC endpoint | Request filters | Solana read path | EVM read path | Notes |
+|---|---|---|---|---|
+| `akash.deployment.v1beta4.Query/Deployments` | `DeploymentFilters{owner,dseq,state}`, pagination | indexer (authoritative for list/closed) | indexer | State filter incl. `closed` only answerable by indexer on both targets |
+| `akash.deployment.v1beta4.Query/Deployment` | `DeploymentID{owner,dseq}` | PDA `["deployment", owner, dseq]` (authoritative live); indexer if closed | view `DeploymentRegistry.deployments(owner,dseq)`; indexer if closed | Response bundles groups + escrow account: clients fetch group PDAs / `groups()` views alongside |
+| `akash.deployment.v1beta4.Query/Group` | `GroupID{owner,dseq,gseq}` | PDA `["group", owner, dseq, gseq]` | view `DeploymentRegistry.groups(...)` | none |
+| `akash.deployment.v1beta4.Query/Params` | none | PDA `["config"]` (akash-config), deployment section | view `AkashConfig.deploymentParams()` | §5 |
+| `akash.market.v1beta5.Query/Orders` | `OrderFilters`, pagination | indexer | indexer | none |
+| `akash.market.v1beta5.Query/Order` | `OrderID` | PDA `["order", owner, dseq, gseq, oseq]` | view `Marketplace.orders(...)` | none |
+| `akash.market.v1beta5.Query/Bids` | `BidFilters`, pagination | indexer | indexer | Provider-side bid engines subscribe to events instead of polling ([07](./07-offchain-and-clients.md)) |
+| `akash.market.v1beta5.Query/Bid` | `BidID` | PDA `["bid", owner, dseq, gseq, oseq, provider]` | view `Marketplace.bids(...)` | Response includes bid escrow account; fetch escrow PDA / view too |
+| `akash.market.v1beta5.Query/Leases` | `LeaseFilters`, pagination | indexer | indexer | none |
+| `akash.market.v1beta5.Query/Lease` | `LeaseID` | PDA `["lease", owner, dseq, gseq, oseq, provider]` | view `Marketplace.leases(...)` | Response includes payment; fetch payment PDA / view |
+| `akash.market.v1beta5.Query/Params` | none | `["config"]` market section | view `AkashConfig.marketParams()` | none |
+| `akash.escrow.v1.Query/Accounts` | `state`, `xid`, pagination (`grpc_query.go`) | open/overdrawn: escrow account PDA (§3.3); lists & closed: indexer | live: view `EscrowVault.accounts(accountId)`; lists & closed: indexer | Cosmos state-in-key probing (3 prefixes) disappears: state is an explicit enum field (§3.3) |
+| `akash.escrow.v1.Query/Payments` | `state`, `xid`, pagination | live: payment PDA; lists & closed: indexer | live: view `EscrowVault.payments(paymentId)`; else indexer | Accrued balance is computed lazily: clients derive live accrual as `rate × (now − settled_at)` client-side or call `settle` first |
+| `akash.bme.v1.Query/Params` | none | `["config"]` bme section | view `AkashConfig.bmeParams()` | none |
+| `akash.bme.v1.Query/VaultState` | none | PDA `["bme-state"]` + vault token account balance | view `BurnMintEscrow.vaultState()` | Vault AKT = token-account balance (Solana) / contract AKT balance (EVM); pending balances netted per CR formula (D-20) |
+| `akash.bme.v1.Query/Status` | none | `["bme-state"]` (mint status, previous, CR, backoff) | view `BurnMintEscrow.status()` | none |
+| `akash.bme.v1.Query/LedgerRecords` | filters, pagination | pending: queue PDAs (live); executed/canceled: indexer ONLY | pending: view/iterable queue; executed/canceled: indexer ONLY | Delta: executed/canceled ledger is not stored on-chain on targets; events are the record (D-23, §3.4) |
+| `akash.oracle.v2.Query/Prices` | source/denom filters | Pyth AKT/USD price account (live); history: indexer | `IPyth.getPriceUnsafe` (live); history: indexer | Per-source price rows disappear (Pyth aggregates upstream) |
+| `akash.oracle.v2.Query/AggregatedPrice` | `DataID{akt,usd}` | Pyth price account read with staleness/confidence bounds from config | `IPyth.getPriceNoOlderThan(feedId, maxAge)` | This is the protocol-facing read used by BME/escrow paths |
+| `akash.oracle.v2.Query/Params` | none | `["config"]` oracle section | view `AkashConfig.oracleParams()` | §5.4 |
+| `akash.provider.v1beta4.Query/Providers` | pagination | indexer | indexer | none |
+| `akash.provider.v1beta4.Query/Provider` | `owner` | PDA `["provider", owner]` (authoritative) | view `ProviderRegistry.providers(addr)` | none |
+| `akash.audit.v1.Query/AllProvidersAttributes` | pagination | indexer | indexer | none |
+| `akash.audit.v1.Query/ProviderAttributes` | `owner`, pagination | indexer (all auditors for provider) | indexer | Per-pair PDAs are not enumerable on-chain |
+| `akash.audit.v1.Query/ProviderAuditorAttributes` | `owner`, `auditor` | PDA `["audit", provider, auditor]` (authoritative) | view `AuditRegistry.attributes(provider, auditor)` | The bid-matching read path: MUST be on-chain-readable (used inside `create_bid`) |
+| `akash.audit.v1.Query/AuditorAttributes` | `auditor`, pagination | indexer | indexer | none |
+| `akash.cert.v1.Query/Certificates` | owner/serial/state filter | n/a: not ported (D-10); historical certs in archive ([06](./06-state-and-data-migration.md)) | n/a | Provider key lookups go to the provider registry instead |
+| `akash.epochs.v1beta1.Query/EpochInfos` | none | `["bme-state"]` next-epoch timestamps | view `BurnMintEscrow.epochs()` | Generic epochs module has no successor; only bme epochs survive (§3.5) |
+| `akash.epochs.v1beta1.Query/CurrentEpoch` | epoch id | same | same | none |
+| `akash.discovery.v1.Discovery/GetInfo` (+ REST `/akash/discovery/v1/info`) | none | akash-config version registry account (program versions, min client version) + on-chain Anchor IDL accounts | `AkashConfig.versions()` + published ABI registry | Client version negotiation moves to config + Console `/info` ([07](./07-offchain-and-clients.md)); today: `app/app.go:538-578`, consumed by chain-sdk |
+
+---
+
+## 3. State-object mapping
+
+### 3.1 Conventions
+
+- Every live entity is its own Solana account / EVM struct (D-23). Terminal state ⇒ account closed,
+  rent refunded; history thereafter only in the indexer.
+- Cosmos `LegacyDec` (18 fractional digits) → Solana `u128` fixed-point ×1e18 / EVM `uint256` ×1e18
+  (WAD). Plain token amounts → `u64` micro-units (Solana) / `uint256` micro-units (EVM).
+- All Cosmos block-height fields (`CreatedAt`, `SettledAt`, `Depositor.Height`, reclamation
+  `StartedAt`) → unix-seconds `i64`/`uint64` timestamps (D-21). Rates → per-second (§7.3).
+- EVM entity keys: `bytes32 id = keccak256(abi.encode(...))` of the ID tuple, stored in mappings.
+
+### 3.2 x/deployment (store `deployment`, `x/deployment/keeper/keeper.go:63-66`)
+
+| Cosmos object (key) | Solana account | EVM storage | Representation deltas |
+|---|---|---|---|
+| `v1.Deployment{ID{Owner,DSeq}, State(active/closed), Hash, CreatedAt, Reclamation{MinWindow}}`; IndexedMap @ `0x11 0x00`, state index @ `0x11 0x02` | PDA `["deployment", owner, dseq]` (akash-deployment). init: `create_deployment` / close: `finalize_deployment_close` / rent: tenant→tenant | `DeploymentRegistry`: `mapping(bytes32 => Deployment)`, id = keccak(owner,dseq) | State index → indexer. `Hash` = 32-byte SDL manifest hash (unchanged). `CreatedAt` height→timestamp |
+| `v1beta4.Group{ID{Owner,DSeq,GSeq}, State(open/paused/insufficient_funds/closed), GroupSpec{Name, Requirements, Resources[]{cpu,mem,storage,gpu,endpoints, Count, Price DecCoin}}, CreatedAt}`; IndexedMap, indexes by state + deployment @ `0x12 0x03` | PDA `["group", owner, dseq, gseq]`. init: `create_deployment`/`start_group` / close: with deployment finalization / rent: tenant→tenant | `mapping(bytes32 => Group)` | `Price DecCoin` (uact per block) → `price_per_second` u128 ×1e18 micro-ACT (§7.3). GroupSpec serialized Borsh/ABI; size-bounded (SDL stays off-chain, only spec summary on-chain as today) |
+| per-tenant dseq counter (implicit today: client defaults dseq = current block height) | PDA `["tenant", owner]` `{next_dseq u64}`. init: first `create_deployment` / never closed / rent: tenant | `mapping(address => uint64) nextDseq` | D-09/Q-12: explicit monotonic counter replaces height-derived convention; old/new histories namespaced by chain-id in indexer |
+| `pendingDenomMigrations Map[DeploymentID, Int]` @ `0x13 0x01` (AKT→ACT scratch; drained by v2.1.0) | not ported | not ported | Transitional artifact; excluded from snapshot transform ([06](./06-state-and-data-migration.md)) |
+| `Params{MinDeposits Coins}` Item | `["config"]` deployment section | `AkashConfig` | §5.1 |
+
+### 3.3 x/market (store `market`, keys `x/market/keeper/keys/key.go:29-56`)
+
+| Cosmos object (key) | Solana account | EVM storage | Representation deltas |
+|---|---|---|---|
+| `Order{ID{Owner,DSeq,GSeq,OSeq}, State(open/active/closed), Spec GroupSpec, CreatedAt, Reclamation}`; IndexedMap @ `0x11 0x01`, state/group indexes | PDA `["order", owner, dseq, gseq, oseq]` (akash-market) + `bid_count u32`. init: CPI from deployment / close: `close_lost_bid` sweep completion or order close / rent: tenant→tenant | `Marketplace`: `mapping(bytes32 => Order)` | `bid_count` field replaces `BidCountForOrder` index scan (enforces `OrderMaxBids`) |
+| `Bid{ID{Owner,DSeq,GSeq,OSeq,Provider,BSeq}, State(open/active/lost/closed), Price DecCoin, CreatedAt, ResourcesOffer, ReclamationWindow}`; IndexedMap @ `0x12 0x02`, indexes by state/provider/order | PDA `["bid", owner, dseq, gseq, oseq, provider]`. init: `create_bid` / close: `close_bid`/`close_lost_bid` / rent: provider→provider | `mapping(bytes32 => Bid)`, id incl. provider | `bseq` dropped from key (chain enforces `bseq == 0` at create, `server.go`); retained as constant 0 in API shapes for client compat. Price → per-second u128 ×1e18 |
+| `Lease{ID, State(active/insufficient_funds/closed/reclaiming), Price DecCoin, CreatedAt, ClosedOn, Reason, Reclamation{Window,StartedAt,Deadline,Reason}}`; IndexedMap @ `0x13 0x02` | PDA `["lease", owner, dseq, gseq, oseq, provider]`. init: `create_lease` / close: `close_lease`/cascade / rent: tenant→tenant | `mapping(bytes32 => Lease)` | `ClosedOn` height→timestamp; `Reclamation.StartedAt/Deadline` already time-friendly (deadline is blockTime-based today, `server.go:338-379`). `LeaseClosedReason` enum values preserved verbatim (Invalid=0, Owner=1, Unstable=10000, Decommissioned=10001, Unspecified=10002, ManifestTimeout=10003, InsufficientFunds=20000) |
+| `Params` Item @ `0x14 0x00` | `["config"]` market section | `AkashConfig` | §5.2 |
+
+### 3.4 x/escrow (store `escrow`, raw KV, `x/escrow/keeper/key.go:19-26`) and x/bme (store `bme`, `x/bme/keeper/key.go:12-26`)
+
+| Cosmos object (key) | Solana account | EVM storage | Representation deltas |
+|---|---|---|---|
+| escrow `Account{ID{Scope(deployment/bid), XID}, State}` + `AccountState{Owner, State(open/closed/overdrawn), Transferred DecCoins, SettledAt height, Funds []Balance (LegacyDec, negative = overdrawn marker), Deposits []Depositor}`; key `0x11 0x00 + state byte + id` (state-in-key; lookups probe 3 prefixes, `keeper.go:1335-1375`) | deployment scope: PDA `["account", 0x01, owner, dseq]`; bid scope: PDA `["account", 0x02, owner, dseq, gseq, oseq, provider]` (akash-escrow). init: CPI from deployment/market / close: account close after refunds / rent: creator→creator. AKT vault = ATA(account PDA, AKT mint), created on first AKT deposit, closed with account | `EscrowVault`: `mapping(bytes32 => Account)`; AKT/ACT balances held by the contract, attributed in the struct | Three deliberate re-representations: (1) state-in-key → explicit `state` enum field; (2) negative `Funds` overdrawn marker → non-negative per-denom balances + explicit `debt` u128 field; (3) `SettledAt` height → `settled_at` unix i64. `Transferred` → cumulative u128 per denom. ACT "funds" are ledger numbers backed by burn/mint (D-19). No ACT token account exists (Solana); EVM holds restricted ACT directly |
+| escrow `Depositor{Owner, Height, Source(balance/grant), Balance DecCoin}` (ordered list, FIFO refunds, `keeper.go:1211-1280`) | `Vec<Depositor{owner: Pubkey, deposited_at: i64, source: enum{Balance, Allowance}, balance: u128}>` inside the account (bounded `MAX_DEPOSITORS`, config §5.1) | `Depositor[]` in Account struct (same bound) | FIFO order + grant-restore-on-refund preserved (D-21). Cosmos list is unbounded in code but practically bounded (single authz depositor rule); target sets an explicit bound |
+| escrow `Payment{ID{AID, XID=lease}, State}` + `PaymentState{Owner(payee), State, Rate DecCoin/block, Balance DecCoin, Unsettled DecCoin, Withdrawn Coin}`; key `0x12 0x00 + state byte + id` | PDA `["payment", account_pubkey, gseq, oseq, provider]`. init: `create_payment` (CPI from market) / close: payment close / rent: tenant→tenant | `mapping(bytes32 => Payment)` | `Rate` per-block LegacyDec → `rate_per_second` u128 ×1e18 micro-ACT (§7.3; D-21; u64 micro-ACT/s alone is insufficient: typical rates are fractional micro-units per second). `Balance` (accrued unwithdrawn) → u128 ×1e18; `Unsettled` debt → explicit `debt` field; `Withdrawn` → u64 micro. AKT-fallback settlement path (BME-halted, priced via oracle, `keeper.go:609-687`) preserved as instruction branch |
+| escrow `BmeAccountsPrefix` @ `0x14 0x01` (declared, unused) | not ported | not ported | Dead key |
+| bme `status Item` @ `0x04 0x00` `{Status MintStatus(healthy/warning/halt_cr/halt_oracle), PreviousStatus, EpochHeightDiff}` | PDA `["bme-state"]` (akash-bme): `{mint_status, previous_status, cr_bps, epoch_backoff_secs, next_mint_epoch_at i64, next_burn_epoch_at i64, pending_uakt u64, pending_uact u64, total_burned {uakt,uact} u128, total_minted {uakt,uact} u128, remint_credits {uakt,uact} u128, next_record_seq u64}`. init: program init / never closed | `BurnMintEscrow` top-level storage (same fields) | Consolidates 7 Cosmos collections (status, epochs map keys "mint"/"burn", ledgerPendingBalances, totalBurned, totalMinted, remintCredits, ledgerSequence) into one state account/contract storage. `EpochHeightDiff` (blocks) → seconds; transient per-block sequence → persistent global `next_record_seq` (LedgerRecordID `{Denom,ToDenom,Source,Height,Sequence}` → global u64 seq) |
+| bme `ledgerPending Map[LedgerRecordID, LedgerPendingRecord{Owner, To, CoinsToBurn, DenomToMint, Attempts}]` @ `0x03 0x01` | PDA per record `["bme-pending", seq]`. init: `request_burn_mint` / close: `crank_epoch` (execute or cancel) / rent: requester→requester | queue mapping `(uint64 seq => PendingRecord)` + head/tail cursors | Retry semantics preserved: `Attempts` ≤ `MaxPendingAttempts`, cancel at max (D-20) |
+| bme `ledger` (executed records) @ `0x03 0x02`, `ledgerCanceled` @ `0x03 0x04` | NOT stored on-chain: emitted as events, indexer is the record (D-23) | same | Query delta noted in §2 (`LedgerRecords`) |
+| bme `Params` Item @ `0x09 0x00` | `["config"]` bme section | `AkashConfig` | §5.3 |
+
+### 3.5 x/oracle, x/epochs
+
+| Cosmos object (key) | Solana account | EVM storage | Representation deltas |
+|---|---|---|---|
+| oracle `latestPriceID`, `prices` (per-source timestamped records), `aggregatedPrices`, `pricesHealth`, `sourceSequence`/`sourceID`, transient `pricesSequence` (`x/oracle/keeper/key.go:12-24`) | All replaced by the Pyth AKT/USD price(-update) account; consumers read price, confidence, publish_time directly (D-13, D-22) | Replaced by Pyth contract storage (`IPyth`) | On-chain per-source history, TWAP/median aggregation, and health tracking retire; staleness/deviation enforcement moves to consuming programs using §5.4 config bounds. Price history for analytics → indexer |
+| oracle `Params` | `["config"]` oracle section (feed ID, max age, deviation bound) | `AkashConfig` | §5.4 |
+| epochs `EpochInfo{ID, StartTime, Duration, CurrentEpoch, CurrentEpochStartTime/Height, EpochCountingStarted}`; named epochs `"hour"` (oracle prune), `"bme"` | Not ported as a module. bme epochs live in `["bme-state"]` (§3.4); `"hour"` prune epoch has no successor (no on-chain price history to prune) | same | Epoch scheduling becomes timestamp comparison inside `crank_epoch` / keeper job (D-20) |
+
+### 3.6 x/provider, x/audit, x/cert, awasm
+
+| Cosmos object (key) | Solana account | EVM storage | Representation deltas |
+|---|---|---|---|
+| `Provider{Owner, HostURI, Attributes, Info{EMail, Website}}`; raw KV `ProviderPrefix ‖ len-prefixed addr` | PDA `["provider", owner]` (akash-provider-registry). init: `create_provider` / close: `delete_provider` / rent: provider→provider | `ProviderRegistry`: `mapping(address => Provider)` | Adds `signing_keys` (rotating operator hot keys for JWT auth) + TLS SPKI hash anchors (D-10/D-10.a) and optional collateral fields (Q-08); owner address = cold owner authority. Attributes bounded; account realloc on update (Solana) |
+| `AuditedAttributesStore{Attributes}` keyed `owner ‖ auditor` (read model `AuditedProvider{Owner, Auditor, Attributes}`) | PDA `["audit", provider, auditor]` (akash-audit). init: `sign_provider_attributes` / close: full delete / rent: auditor→auditor | `AuditRegistry`: `mapping(bytes32 (provider,auditor) => Attributes)` | 1:1; consumed on-chain by `create_bid` attribute matching |
+| `Certificate{State(valid/revoked), Cert PEM, Pubkey}` keyed `owner ‖ serial` (≤40-byte serial) | not ported (D-10) | not ported | Archived at halt ([06](./06-state-and-data-migration.md)); replacement = registry signing keys + JWT ([07](./07-offchain-and-clients.md)) |
+| awasm `Params{BlockedAddresses}` | not ported (D-22) | not ported | Filter layer has no successor |
+
+---
+
+## 4. Event mapping
+
+Solana: Anchor events emitted via event-CPI (log-truncation-safe), names = Cosmos names minus the
+`Event` prefix. EVM: Solidity events; `indexed` fields chosen to match today's indexer access
+patterns (by owner, by provider). The legacy string-event convention
+`sdkutil.BaseModuleEvent{module, action}` under `EventTypeMessage = "akash.v1"`
+(`pkg.akt.dev/go/sdkutil/event.go`) is fully superseded by these typed events; the canonical
+event-schema registry (names, versions, indexer topics) is maintained in
+[07](./07-offchain-and-clients.md).
+
+| Cosmos typed event (fields) | Anchor event | EVM event signature | Notes |
+|---|---|---|---|
+| `deployment/v1.EventDeploymentCreated{ID, Hash}` | `DeploymentCreated{owner, dseq, hash}` | `DeploymentCreated(address indexed owner, uint64 indexed dseq, bytes32 hash)` | none |
+| `EventDeploymentUpdated{ID, Hash}` | `DeploymentUpdated{owner, dseq, hash}` | `DeploymentUpdated(address indexed owner, uint64 indexed dseq, bytes32 hash)` | none |
+| `EventDeploymentClosed{ID}` | `DeploymentClosed{owner, dseq}` | `DeploymentClosed(address indexed owner, uint64 indexed dseq)` | none |
+| `EventGroupStarted{ID}` | `GroupStarted{owner, dseq, gseq}` | `GroupStarted(address indexed owner, uint64 indexed dseq, uint32 gseq)` | none |
+| `EventGroupPaused{ID}` | `GroupPaused{owner, dseq, gseq}` | `GroupPaused(address indexed owner, uint64 indexed dseq, uint32 gseq)` | none |
+| `EventGroupClosed{ID}` | `GroupClosed{owner, dseq, gseq}` | `GroupClosed(address indexed owner, uint64 indexed dseq, uint32 gseq)` | none |
+| `market/v1.EventOrderCreated{ID}` | `OrderCreated{owner, dseq, gseq, oseq}` | `OrderCreated(address indexed owner, uint64 indexed dseq, uint32 gseq, uint32 oseq)` | Bid engines' primary trigger |
+| `EventOrderClosed{ID}` | `OrderClosed{...}` | `OrderClosed(address indexed owner, uint64 indexed dseq, uint32 gseq, uint32 oseq)` | none |
+| `EventBidCreated{ID, Price}` | `BidCreated{order_id, provider, price_per_second}` | `BidCreated(bytes32 indexed orderId, address indexed provider, uint256 pricePerSecond)` | Price basis converted (§7.3) |
+| `EventBidClosed{ID}` | `BidClosed{order_id, provider}` | `BidClosed(bytes32 indexed orderId, address indexed provider)` | Emitted for lost bids too |
+| `EventLeaseCreated{ID, Price}` | `LeaseCreated{lease_id, price_per_second}` | `LeaseCreated(bytes32 indexed leaseId, address indexed owner, address indexed provider, uint256 pricePerSecond)` | Provider daemon deploy trigger |
+| `EventLeaseClosed{ID, Reason}` | `LeaseClosed{lease_id, reason}` | `LeaseClosed(bytes32 indexed leaseId, uint32 reason)` | `LeaseClosedReason` codes preserved (§3.3) |
+| `EventLeaseReclaimStarted{ID, Reason, Deadline}` | `LeaseReclaimStarted{lease_id, reason, deadline}` | `LeaseReclaimStarted(bytes32 indexed leaseId, uint32 reason, uint64 deadline)` | D-24 |
+| `bme/v1.EventMintStatusChange{PreviousStatus, NewStatus, CollateralRatio}` | `MintStatusChange{previous, new, cr_bps}` | `MintStatusChange(uint8 previous, uint8 next, uint32 crBps)` | Emitted by `crank_epoch`/`executeEpoch` on transitions; primary circuit-breaker monitor signal ([08](./08-security-and-audits.md)) |
+| `EventVaultFunded{Amount, Source, NewVaultBalance}` | `VaultFunded{amount, source, new_balance}` | `VaultFunded(uint256 amount, address indexed source, uint256 newBalance)` | Gov-gated path + S1 seeding (D-05) |
+| `EventLedgerRecordExecuted{ID, BurnedFrom, MintedTo, Burner, Minter, Burned CoinPrice, Minted CoinPrice, Spread, RemintCreditIssued/Accrued}` | `LedgerRecordExecuted{seq, ...same fields, prices ×1e18}` | `LedgerRecordExecuted(uint64 indexed seq, ...)` | System of record for executed swaps (§3.4): indexer MUST persist losslessly |
+| `EventLedgerRecordCanceled{ID, CancelReason, Owner, To, CoinsToBurn, DenomToMint}` | `LedgerRecordCanceled{seq, reason, ...}` | `LedgerRecordCanceled(uint64 indexed seq, uint8 reason, ...)` | Incl. `MaxAttempts` cancels |
+| `oracle/v2.EventPriceData{Source, Id, Price, Timestamp}` | n/a: superseded by Pyth's own feed updates | n/a: Pyth `PriceFeedUpdate` event | Indexer ingests Pyth updates for price history |
+| `EventPriceStaleWarning{Id, LastHeight, BlocksToStall}` | n/a: off-chain monitor on Pyth publish_time age | n/a: same | Alerting moves to ops monitoring ([08](./08-security-and-audits.md)); on-chain effect surfaces as `MintStatusChange(halt_oracle)` |
+| `EventPriceStaled{Id, LastHeight}` | n/a (as above) | n/a | none |
+| `EventPriceRecovered{Id, Height}` | n/a (as above) | n/a | none |
+| `EventAggregatedPrice{Price}` | n/a: no on-chain aggregation | n/a | none |
+| `provider/v1beta4.EventProviderCreated{Owner}` | `ProviderCreated{owner}` | `ProviderCreated(address indexed owner)` | none |
+| `EventProviderUpdated{Owner}` | `ProviderUpdated{owner}` | `ProviderUpdated(address indexed owner)` | none |
+| `EventProviderDeleted{Owner}` (in proto, never emitted; delete unimplemented) | `ProviderDeleted{owner}` | `ProviderDeleted(address indexed owner)` | Actually emitted on targets (§1.6 delta) |
+| `audit/v1.EventTrustedAuditorCreated{Owner, Auditor}` | `TrustedAuditorCreated{owner, auditor}` | `TrustedAuditorCreated(address indexed owner, address indexed auditor)` | none |
+| `EventTrustedAuditorDeleted{Owner, Auditor}` | `TrustedAuditorDeleted{owner, auditor}` | `TrustedAuditorDeleted(address indexed owner, address indexed auditor)` | none |
+| `epochs/v1beta1.EventEpochEnd{EpochNumber}` / `EventEpochStart{EpochNumber, EpochStartTime}` | `EpochExecuted{kind(mint/burn), epoch_at, records_processed}` emitted by `crank_epoch` | `EpochExecuted(uint8 kind, uint64 epochAt, uint32 processed)` | Only bme epochs survive; generic module retired (§3.5) |
+| `wasm/v1.EventMsgBlocked{ContractAddress, MsgType, Reason}` (context) | n/a: awasm not ported (D-22) | n/a | none |
+| none (escrow emits NO events today; state changes surface via market hooks only) | NEW: `AccountDeposited`, `PaymentSettled`, `PaymentWithdrawn`, `AccountOverdrawn`, `AccountClosed{refunds[]}` | NEW: same names as Solidity events | Deliberate addition: with lazy settlement + indexer-as-history (D-21/D-23), escrow lifecycle MUST be event-visible; schema in [07](./07-offchain-and-clients.md) |
+
+---
+
+## 5. Parameter mapping
+
+Target locations: Solana = the `["config"]` account of `akash-config` (one account, per-module
+sections); EVM = `AkashConfig` storage. Mutability: **DAO** = changeable by governance
+(Realms executor / `AkashTimelock`, D-11); **immutable** = compile-time/launch constant. Defaults
+below are the current-chain values (code-cited); launch values are the same unless a decision says
+otherwise.
+
+### 5.1 x/deployment (`deployment/v1beta4/params.go:32-38`) + escrow bounds
+
+| Param | Current default | Target location | Mutability | Notes |
+|---|---|---|---|---|
+| `MinDeposits` (Coins) | `500000uakt, 500000uact` | config.deployment.min_deposits | DAO | Per-denom validation preserved; uakt entry applies to `account_deposit` top-ups (create is ACT-only, §1.1) |
+| (new) `MAX_DEPOSITORS` per escrow account | n/a (unbounded in code) | config.escrow.max_depositors (initial value 16) | DAO | Target-only bound required by fixed account sizing (§3.4); DAO-config parameter, initial value 16 (13 §amendments) |
+
+### 5.2 x/market (`market/v1beta5/params.go:16-58`)
+
+| Param | Current default | Target location | Mutability | Notes |
+|---|---|---|---|---|
+| `BidMinDeposit` (Coin, legacy) | `500000uakt` | dropped | none | Superseded by `BidMinDeposits`; not carried |
+| `BidMinDeposits` (Coins) | `500000uakt, 500000uact` | config.market.bid_min_deposits | DAO | Provider bid collateral |
+| `OrderMaxBids` | `20` (validation cap 500) | config.market.order_max_bids | DAO | Enforced via order `bid_count` (§3.3); EVM `createLease` loop bound; raising it has gas implications (04) |
+| `MinReclamationWindow` | `1h` | config.market.min_reclamation_window_secs | DAO | D-24 |
+| `MaxReclamationWindow` | `720h` | config.market.max_reclamation_window_secs | DAO | D-24 |
+
+### 5.3 x/bme (`bme/v1/params.pb.go`; defaults per research pack / `pkg.akt.dev/go/node/bme/v1/params.go`)
+
+| Param | Current default | Target location | Mutability | Notes |
+|---|---|---|---|---|
+| `CircuitBreakerWarnThreshold` | `9500` bps | config.bme.cr_warn_bps | DAO | warn > halt, both ≤ 10000 (validation preserved) |
+| `CircuitBreakerHaltThreshold` | `9000` bps | config.bme.cr_halt_bps | DAO | D-20 carries both defaults |
+| `MinEpochBlocks` | `10` blocks | config.bme.min_epoch_secs = `65` | DAO | ×6.5 s/block conversion (D-20/D-21 time basis) |
+| `EpochBlocksBackoffPercent` | `10` % | config.bme.epoch_backoff_pct | DAO | Backoff formula unchanged; cap 14400 blocks → `93600` s |
+| `MintSpreadBps` | `25` | config.bme.mint_spread_bps | DAO | ≤ 1000 validation preserved |
+| `SettleSpreadBps` | `0` | config.bme.settle_spread_bps | DAO | ≤ 1000 |
+| `MaxEndblockerRecords` | `50` | config.bme.max_records_per_crank | DAO | Per `crank_epoch` call / keeper run (D-20) |
+| `MinMint` | `10,000,000uact` | config.bme.min_mint | DAO | none |
+| `MaxPendingAttempts` | `3` | config.bme.max_pending_attempts | DAO | Backfilled to 3 by v2.1.0 upgrade if zero |
+
+### 5.4 x/oracle (`oracle/v2` params; defaults `x/oracle` research pack `params.go:31-46`)
+
+| Param | Current default | Target location | Mutability | Notes |
+|---|---|---|---|---|
+| `Sources` | `[akash1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrqyagled]` (single CosmWasm Pyth contract) | replaced: config.oracle.pyth_feed_id (+ Solana feed account) | DAO | Trust root moves to Pyth attestation (D-13); `[TO-VERIFY: Pyth AKT/USD feed ID]` |
+| `MinPriceSources` | `1` | n/a | none | Pyth aggregates publishers upstream |
+| `MaxPriceStalenessPeriod` | `30s` | config.oracle.max_price_age_secs = 30 | DAO | Enforced at every protocol read (`getPriceNoOlderThan` / receiver check) |
+| `TwapWindow` | `5s` | n/a (option: read Pyth EMA price for smoothing) | none | On-chain TWAP retired; parity decision for BME pricing in 03/04 |
+| `MaxPriceDeviationBps` | `150` | config.oracle.max_deviation_bps | DAO | Retained as sanity bound: reject spot price deviating > bound from Pyth EMA/confidence |
+| `PriceRetention` | `24h` | n/a | none | No on-chain history to retain |
+| `PruneEpoch` | `"hour"` | n/a | none | No pruning needed |
+| `MaxPrunePerEpoch` | `1000` | n/a | none | none |
+| `MaxFutureTimeDrift` | `10s` | n/a | none | Pyth receiver validates publish_time |
+| `FeedContractsParams` | `[]*Any` (feed contract config) | folded into config.oracle.pyth_feed_id | DAO | none |
+
+### 5.5 awasm + dead take module
+
+| Param | Current default | Target location | Mutability | Notes |
+|---|---|---|---|---|
+| awasm `BlockedAddresses` | `[]` | n/a (D-22) | none | No filter layer on targets |
+| take `DefaultTakeRate` / `DenomTakeRates[uakt]` | `20` % / `2` % (DEAD: store deleted v2.0.0, module unwired; providers keep 100% today) | no take at launch (parity). Placeholder config.escrow.take_rate_bps = 0 reserved for future DAO decision | DAO | Historical only (`x/take`, `pkg.akt.dev/go/node/take/v1/params.go:29-38`); any future fee is a config addition to the escrow payout path, not a token-layer hook (see D-03 detail) |
+
+### 5.6 Chain-level parameters (from `cmd/akash/cmd/genesis.go:219-299`, intended genesis values; live akashnet-2 state may differ: `[TO-VERIFY: live param values via state export, Q-19]`)
+
+| Param | Current value | Target disposition | Notes |
+|---|---|---|---|
+| staking.UnbondingTime | 14 days | n/a post-migration (D-06) | No sovereign staking |
+| staking.MaxValidators | 100 | n/a | none |
+| staking.BondDenom | uakt | n/a | none |
+| staking.MinCommissionRate | 0.05 | n/a | none |
+| mint (inflation) params | NOT in repo; on-chain state only (Q-19) | replaced by `akash-emissions`/`EmissionsMinter` schedule (D-12, curve per Q-01) | Modeling input for [05](./05-token-migration.md) |
+| distribution.CommunityTax | 0 | n/a: treasury funded by emissions split (D-12) | none |
+| distribution.WithdrawAddrEnabled | true | n/a | none |
+| gov.MinDeposit | 2,500,000,000 uakt (2,500 AKT) | Realms proposal-creation threshold / `AkashGovernor.proposalThreshold`; values set at G1 (D-11) | No deposit-refund/burn mechanic on targets |
+| gov.MaxDepositPeriod | 14 days | n/a (no deposit phase) | none |
+| gov.VotingPeriod | 3 days | Realms voting time / `votingPeriod`; set at G1 (D-11) | none |
+| gov.Quorum | 0.2 | Realms vote threshold config / `quorum()`; set at G1 | none |
+| gov MaxMetadataLen | 10200 (`app/types/app.go:377-379`) | n/a: proposal metadata off-chain in both stacks | Off-chain gov tooling note for [07](./07-offchain-and-clients.md) |
+| slashing.SignedBlocksWindow | 30000 | n/a post-migration | none |
+| slashing.MinSignedPerWindow | 0.05 | n/a | none |
+| slashing.DowntimeJailDuration | 1 min | n/a | none |
+| slashing.SlashFractionDoubleSign | 0.05 | n/a | none |
+| slashing.SlashFractionDowntime | 0 | n/a | none |
+| crisis.ConstantFee | 500,000,000,000 uakt | n/a (invariants module unwired anyway) | none |
+| min gas price | 0.0025 vs 0.025 uakt (inconsistent: `cmd/akash/cmd/config.go:26` vs `util/cli/configs.go:361`) | n/a: target fee regimes per §7.4 | Known defect; do not port |
+| block time | 6.5 s target (`util/network/network.go:8`) | conversion constant for §7.3 only | none |
+| auth unordered txs | enabled (`app/types/app.go:279`) | see §7.4 sequence row | Client/indexer assumption |
+
+---
+
+## 6. Module-account mapping
+
+Current perms per `app/mac.go:15-27`; `allowedReceivingModAcc` is EMPTY ⇒ every module account is
+blocked from receiving external bank sends today.
+
+| Module account (perms) | Solana | EVM | Notes |
+|---|---|---|---|
+| `escrow` (no perms) | Per-escrow-account token accounts: each escrow account PDA owns its own AKT ATA (§3.4); no pooled vault | `EscrowVault` contract holds AKT/ACT with per-account struct attribution | DELIBERATE DIFFERENCE (Solana): Cosmos pools all escrow funds in one module account with logical attribution; Solana segregates funds per entity, so mis-attribution becomes structurally impossible and write contention is per-lease (D-23). Balance at S1 → Wind-down Reserve (D-05) |
+| `bme` (Burner, Minter) | `akash-bme`: vault = AKT token account owned by PDA `["vault"]`; ACT mint+burn authority = PDA `["mint-authority"]` (D-19) | `BurnMintEscrow` holds vault AKT; has mint/burn rights on `ACT` (role-gated) | Vault seeded from migrated bme module balance (D-20 via D-05). Burner/Minter perms → explicit mint-authority PDAs / `MINTER_ROLE` |
+| `fee_collector` (no perms) | n/a: tx fees go to Solana validators (burn+tips) | n/a: gas to the host-chain sequencer | No protocol fee capture today (take dead); §5.5 |
+| `distribution` (no perms) | n/a: community pool balance at S1 → Wind-down Reserve → DAO treasury (Realms treasury account) | → `AkashTimelock`-owned treasury | [05](./05-token-migration.md); precedent: v2.1.0 already moved 427,414,453 uakt distribution→escrow imperatively (`upgrades/software/v2.1.0/upgrade.go:88-108`) |
+| `mint` (Minter) | `akash-emissions` PDA holds AKT mint authority post-claims (D-03, D-12) | `EmissionsMinter` sole minter alongside `MigrationClaims` (D-04) | Sovereign inflation ends at halt |
+| `bonded_tokens_pool` (Burner, Staking) | n/a: bonded stake credited liquid at S1 (D-06) | n/a | none |
+| `not_bonded_tokens_pool` (Burner, Staking) | n/a: unbonding stake credited liquid at S1 (D-06) | n/a | none |
+| `gov` (Burner) | Realms governance PDAs (proposal escrows) | `AkashGovernor`/`AkashTimelock` | Live gov deposits at S1 reserved and resolved per [05](./05-token-migration.md) |
+| `transfer` / ibc (Minter, Burner) | n/a: IBC escrow balances at S1 reserved; stranded vouchers per D-07 | n/a | none |
+| receive-blocking (`allowedReceivingModAcc` empty, `app/app.go:85,496-504`) | Program vaults writable only via program instructions (owner = program PDAs), an equivalent guarantee | Cannot block bare ERC-20 transfers to a contract address: guard via internal accounting + `sweep()` for unattributed AKT | EVM delta flagged for [08](./08-security-and-audits.md) monitoring |
+
+---
+
+## 7. Identity, units, time & fees
+
+### 7.1 Identity
+
+| Cosmos | Solana | EVM | Notes |
+|---|---|---|---|
+| `akash1…` bech32 account (secp256k1; addr = ripemd160(sha256(pubkey))) | base58 ed25519 pubkey (32 B) | `0x…` 20-B EIP-55 (keccak of secp256k1 pubkey) | NO derivation mapping in either direction; linkage established only by signed claim (old key authorizes new address) per [05](./05-token-migration.md) |
+| `akashvaloper…` / `akashvalcons…` | n/a post-migration | n/a | Validator identities end (D-06) |
+| Module account address (`authtypes.NewModuleAddress`) | Program PDA | Contract address | §6 |
+| x509 cert identity (x/cert) | wallet signature + provider registry signing keys (D-10) | same | [07](./07-offchain-and-clients.md) |
+
+### 7.2 Units & sequences
+
+| Cosmos | Solana | EVM | Notes |
+|---|---|---|---|
+| `uakt` (10⁻⁶ AKT; display `akt`) | AKT Token-2022 mint base unit, 6 decimals (D-03) | `AKT` ERC-20, 6 decimals (D-04) | 1:1 micro-unit parity by design |
+| `uact` (10⁻⁶ ACT; `SendEnabled=false`) | ACT Token-2022 NonTransferable mint, 6 decimals (D-19) | `ACT` restricted ERC-20, 6 decimals | Wallet presentation per Q-16 |
+| `uusd` (oracle quote, exponent 6) | Pyth USD quote, exponent −8 | same | ×100 rescale at every oracle read; implement once in a shared price lib |
+| `LegacyDec` (18 fractional digits) | u128 fixed-point ×1e18 | uint256 ×1e18 (WAD) | Used for rates, prices, CR math |
+| `dseq` u64 (client convention: creation block height; user-choosable) | per-tenant counter PDA (§3.2) | `nextDseq[owner]` | D-09/Q-12. Indexers namespace (chain, owner, dseq): old heights and new counters may numerically overlap |
+| `gseq` u32 (1..N), `oseq` u32 (bumps on relist/restart) | identical u32 semantics | identical | none |
+| `bseq` u32 (MUST be 0 at CreateBid today) | constant 0 in API shapes; not in bid PDA seeds | constant 0; not in bid id hash | Kept for wire-shape compat only |
+| Tx hash: uppercase hex SHA-256, 64 chars | base58 tx signature (first sig, 64 B) | `0x` + 64 hex keccak256 | Explorer/Console link formats change (A-11, [07](./07-offchain-and-clients.md)) |
+| Account `sequence` (+ unordered txs enabled today) | recent-blockhash validity window; durable nonce opt-in for offline signers | strict per-account nonce | EVM is a regression for parallel submitters vs unordered txs; provider daemon queues per-key ([07](./07-offchain-and-clients.md)) |
+
+### 7.3 Time basis (D-21)
+
+| Concept | Cosmos today | Solana | EVM | Rule |
+|---|---|---|---|---|
+| Clock | block height; 6.5 s target block time | `Clock` sysvar `unix_timestamp` (slots ≈ 400 ms are NOT the protocol clock) | `block.timestamp` (seconds-scale host-chain blocks, e.g. Base ≈ 2 s) | All protocol state/durations in unix seconds |
+| Streaming rate | `Rate DecCoin` per block | `rate_per_second` u128 ×1e18 micro-ACT | same in uint256 | Conversion at the pricing layer: `rate_per_second = rate_per_block × 2/13` (exact rational for 6.5 s; fixed at S1). Applies to price quoting/tooling parity; live payments do not migrate (D-08) |
+| Accrual | `Rate × (height − SettledAt)`, lazy (`x/escrow/keeper/keeper.go:535-604`) | `rate × (now − settled_at)`, lazy + permissionless `settle` | same | D-21 |
+| Epochs | bme: every `MinEpochBlocks` blocks via EndBlocker | timestamp-gated, crank-executed | timestamp-gated, keeper-executed | D-20; §5.3 conversion |
+| Reclamation deadline | `blockTime + Window` (already time-based) | identical | identical | D-24 |
+
+### 7.4 Fees / gas
+
+| Concept | Cosmos today | Solana | EVM (host chain) | Notes |
+|---|---|---|---|---|
+| Fee token | uakt (min gas price 0.025 uakt community floor; no fee market) | SOL: 5000 lamports/signature + priority fee (CU price × CU limit, local fee markets) | ETH: EIP-1559 gas + L1 data fee | Users lose "pay fees in AKT" natively |
+| AKT fee UX | native | fee-payer sponsorship service co-signs; costs accounted in AKT ([07](./07-offchain-and-clients.md), Q-07) | ERC-4337 paymaster accepting AKT | Operated services; ownership per Q-07 |
+| Gas metering | gas wanted/used per msg | compute units (per-tx CU limit; per-writable-account 12M CU/block cap, which motivates D-23 sharding) | gas | Perf targets in [09](./09-testing-and-verification.md) |
+| feegrant | `x/feegrant` allowance (tx fees only) | sponsorship service allow-list | paymaster policy | §1.10 |
+
+---
+
+## 8. Error taxonomy mapping
+
+The ~operationally-relevant set (provider daemons, Console, and BME ops branch on these). Cosmos
+errors are registered with gRPC codes in `pkg.akt.dev/go` (`node/<module>/.../errors.go`,
+`node/escrow/module/error.go:29-47`). Targets: Anchor error enums per program (numeric code = 6000 +
+enum index, frozen at IDL freeze, [07](./07-offchain-and-clients.md)); EVM = Solidity custom errors
+(4-byte selector from the signature shown). Names below are the stable contract.
+
+| Cosmos error | Condition | Solana (program: error) | EVM custom error | Notes |
+|---|---|---|---|---|
+| escrow `ErrInvalidDeposit` | deposit sources don't cover amount; bad denom | akash-escrow: `InvalidDeposit` | `InvalidDeposit()` | Incl. allowance shortfall (D-21) |
+| escrow `ErrAccountClosed` | op on closed escrow account | akash-escrow: `AccountClosed` | `AccountClosed()` | Solana: also surfaces as account-not-found once closed+reaped; clients treat both as closed |
+| escrow `ErrAccountNotFound` | unknown account id | akash-escrow: `AccountNotFound` (Anchor `AccountNotInitialized`) | `AccountNotFound()` | none |
+| escrow `ErrAccountOverdrawn` | settle found funds exhausted | akash-escrow: `AccountOverdrawn` | `AccountOverdrawn()` | Explicit `debt` field replaces negative-funds marker (§3.4) |
+| escrow `ErrPaymentClosed` | withdraw/close on closed payment | akash-escrow: `PaymentClosed` | `PaymentClosed()` | none |
+| escrow `ErrPaymentRateZero` | zero-rate payment create | akash-escrow: `PaymentRateZero` | `PaymentRateZero()` | none |
+| escrow `ErrUnauthorizedDepositScope` / `ErrInvalidAuthzScope` | grant used outside its scopes | akash-escrow: `UnauthorizedDepositScope` | `UnauthorizedDepositScope()` | Allowance scopes (§1.10) |
+| deployment `ErrDeploymentExists` | duplicate (owner,dseq) | akash-deployment: `DeploymentExists` (Anchor account-already-in-use) | `DeploymentExists()` | Counter-based dseq makes this unreachable except manual dseq reuse |
+| deployment `ErrDeploymentClosed` | update/close on closed deployment | akash-deployment: `DeploymentClosed` | `DeploymentClosed()` | none |
+| deployment `ErrInvalidDeposit` | create deposit invalid, incl. uakt at create | akash-deployment: `InvalidDeposit` | `DeploymentRegistry.InvalidDeposit()` | ACT-only-at-create parity (§1.1) |
+| deployment `ErrInvalidPrice` | group price not uact / non-positive | akash-deployment: `InvalidPrice` | `InvalidPrice()` | D-19 lease pricing stays ACT |
+| deployment `ErrGroupNotOpen` / `ErrGroupClosed` / `ErrGroupPaused` | group state gate failures | akash-deployment: `InvalidGroupState{expected, actual}` | `InvalidGroupState(uint8 expected, uint8 actual)` | Collapsed into one parameterized error |
+| market `ErrInvalidBid` (wraps "too many existing bids") | bid validation incl. > `OrderMaxBids` (`server.go:45-46`) | akash-market: `InvalidBid`, `TooManyBids` | `InvalidBid()`, `TooManyBids(uint32 max)` | Max-bids split into its own code (operationally distinct for bid engines) |
+| market `ErrBidExists` | provider already bid this order | akash-market: `BidExists` | `BidExists()` | none |
+| market `ErrBidOverOrder` | bid price > order max price | akash-market: `BidOverOrder` | `BidOverOrder()` | none |
+| market `ErrBidInvalidPrice` / `ErrBidZeroPrice` | zero/invalid bid price | akash-market: `BidInvalidPrice` | `BidInvalidPrice()` | none |
+| market `ErrAttributeMismatch` / `ErrCapabilitiesMismatch` | provider attrs/capabilities fail order requirements | akash-market: `AttributeMismatch`, `CapabilitiesMismatch` | `AttributeMismatch()`, `CapabilitiesMismatch()` | Matching runs on-chain against registry + audit PDAs (§2) |
+| market `ErrOrderNotOpen` | bid/lease on non-open order | akash-market: `OrderNotOpen` | `OrderNotOpen()` | none |
+| market `ErrBidNotOpen` / `ErrBidNotActive` | lease-create/close on wrong bid state | akash-market: `InvalidBidState` | `InvalidBidState(uint8)` | none |
+| market `ErrLeaseNotActive` | withdraw/reclaim/close on inactive lease | akash-market: `LeaseNotActive` | `LeaseNotActive()` | none |
+| market `ErrReclamationNotStarted` | provider close_bid on active lease without reclaim | akash-market: `ReclamationNotStarted` | `ReclamationNotStarted()` | D-24 |
+| market `ErrReclamationWindowNotElapsed` | close before deadline | akash-market: `ReclamationWindowNotElapsed` | `ReclamationWindowNotElapsed(uint64 deadline)` | D-24 |
+| market `ErrReclamationWindowInvalid` / `...Required` / `...TooShort` | window outside gov bounds / missing / short | akash-market: `ReclamationWindowInvalid` | `ReclamationWindowInvalid()` | Bounds from config (§5.2) |
+| bme `ErrOracleUnhealthy` / `ErrZeroPrice` | oracle stale/zero at request or execution | akash-bme: `OracleUnhealthy` | `OracleUnhealthy()` | Raised off Pyth staleness/confidence checks (§5.4) |
+| bme `ErrCircuitBreakerActive` | status ≥ halt_cr (except ACT→AKT under CR-halt) | akash-bme: `CircuitBreakerActive` | `CircuitBreakerActive(uint8 status)` | D-20 refund exception preserved |
+| bme `ErrInsufficientVaultFunds` | vault can't cover mint/settle | akash-bme: `InsufficientVaultFunds` | `InsufficientVaultFunds()` | none |
+| bme `ErrMinimumMint` | mint below `MinMint` | akash-bme: `BelowMinimumMint` | `BelowMinimumMint(uint256 min)` | none |
+| bme `ErrEpsilon` | result below denom precision | akash-bme: `AmountBelowPrecision` | `AmountBelowPrecision()` | none |
+| oracle `ErrUnauthorizedWriterAddress` | non-source submitted price | n/a: price posting permissionless via Pyth (§1.5) | n/a | Trust-model change, not an error rename |
+| oracle `ErrPriceStalled` | price beyond staleness | consumer-side: `StalePrice` in each consuming program | `StalePrice(uint64 age)` | Every consumer enforces the same config bound |
+
+---
+
+## 9. Glossary: Cosmos/Akash ↔ Solana ↔ EVM
+
+| Cosmos / Akash term | Solana equivalent | EVM equivalent |
+|---|---|---|
+| Module (`x/foo`) + keeper | Program (`akash-foo`) + its state accounts | Contract (`Foo…`) + its storage |
+| `Msg` (protobuf tx body) | Instruction | External function call |
+| Msg type URL (`/akash…Msg…`) | 8-byte Anchor instruction discriminator | 4-byte function selector |
+| Multi-msg tx (atomic) | Multi-instruction transaction (atomic) | Multicall within one tx / one function call |
+| KVStore (module store key) | Per-entity accounts owned by the program | Contract storage (mappings/structs) |
+| `collections.IndexedMap` secondary index | None on-chain: PDA derivation is the primary key; secondary access via indexer (D-16/D-23) | None on-chain: mapping key primary; indexer secondary |
+| Ante handler (sigverify, fees, sequence) | Runtime checks (signatures, blockhash, fee payer) + Anchor account constraints | EVM intrinsic checks + `require`/modifiers |
+| BeginBlocker / EndBlocker | Permissionless crank instruction (tip-incentivized) | Keeper automation (Gelato / Chainlink Automation) |
+| CacheContext (revert-on-error subcall) | Instruction fails ⇒ whole tx reverts; per-record isolation via separate crank txs | try/catch around external subcall |
+| Module hooks (escrow→market) | CPI between programs | Cross-contract call |
+| Gov proposal (`x/gov`) | Realms (SPL Governance) proposal | `AkashGovernor` proposal + `AkashTimelock` operation |
+| Gov module authority address | Realms governance PDA (executor) | `AkashTimelock` address |
+| `MsgUpdateParams` / params subspace | gov-gated write to `["config"]` (akash-config) | gov-gated `AkashConfig` setter |
+| Denom (`uakt`) | SPL Token-2022 mint | ERC-20 |
+| `SendEnabled=false` (uact) | Token-2022 `NonTransferable` extension | Transfer-restricted ERC-20 |
+| `bank.SendCoins` | SPL `transfer_checked` | `ERC20.transfer` |
+| Bank `Minter`/`Burner` perms | Mint/burn authority PDAs on the mint | `MINTER_ROLE`-style access control |
+| Module account | Program PDA + owned token accounts | Contract-held balances |
+| Typed event (`EmitTypedEvent`) | Anchor event (event-CPI) | Solidity event (log + indexed topics) |
+| Tendermint event indexing / WebSocket subscribe | Geyser/webhook stream → indexer; RPC `logsSubscribe` | `eth_subscribe(logs)` → indexer |
+| IBC / ICS-20 | None (third-party bridges outside protocol scope) | Canonical/third-party bridges outside protocol scope |
+| bech32 `akash1…` | base58 pubkey | `0x` hex (EIP-55) |
+| Account sequence (+ unordered txs) | Recent blockhash window; durable nonce for offline signing | Per-account nonce |
+| `x/feegrant` | Fee-payer sponsorship service | ERC-4337 paymaster |
+| `x/authz` grant (DepositAuthorization) | Deposit-allowance PDA with restore-on-refund (D-21) | `EscrowVault` allowance mapping |
+| Genesis / `InitGenesis` | Program `initialize` instructions + claims seeding | Constructor/initializer + claims seeding |
+| Genesis export (`akash export`) | Snapshot artifacts pipeline ([06](./06-state-and-data-migration.md)) | Same |
+| Upgrade handler + cosmovisor | Program upgrade via upgradeable BPF loader, authority = Squads v4 + timelock (D-11/D-15) | Proxy (UUPS) upgrade behind `AkashTimelock` + Safe |
+| Store migration / ConsensusVersion | Account schema `version` field + lazy per-account migrate on touch | Storage-layout discipline + `reinitializer` |
+| `in-place-testnet` (testnetify) | Fork tooling: Surfpool / `solana-test-validator --clone` of mainnet accounts | Anvil fork of the host chain |
+| Invariants (`x/crisis`) | Off-chain property tests + monitors (none registered on current chain either) | Same |
+| `simulate` / CheckTx | `simulateTransaction` | `eth_call` / `estimateGas` |
+| Discovery service (`GetInfo`, min_client_version) | akash-config version registry + on-chain Anchor IDL accounts | `AkashConfig.versions()` + published ABI registry |
+| SDL / manifest (off-chain, hash on-chain) | Unchanged: hash in deployment account (D-09, A-10) | Unchanged: hash in Deployment struct |
+
+---
+
+## Cross-references
+
+- [01. Current architecture](./01-current-architecture.md): narrative behind every Cosmos-side row.
+- [03. Solana architecture](./03-solana-architecture.md) / [04. Ethereum architecture](./04-ethereum-architecture.md): normative target designs these mappings summarize.
+- [05. Token migration](./05-token-migration.md) / [06. State & data migration](./06-state-and-data-migration.md): module-account balance disposition; snapshot transforms.
+- [07. Off-chain & clients](./07-offchain-and-clients.md): indexer, event-schema registry, fee sponsorship, JWT auth.
+- [13. Open questions & decision log](./13-open-questions-and-assumptions.md): all D/A/Q items cited here.
+
+## Feeds into
+
+- [09. Testing & verification](./09-testing-and-verification.md): parity test matrix rows are generated from §1/§3/§8 tables.
+- [11. Scope of work](./11-scope-of-work.md): per-workstream deliverable traceability (message/query coverage counts).
+- Vendor implementation of 03/04: shared naming registry (instructions, events, errors, config fields).

--- a/spec/aep-79/doc/README.md
+++ b/spec/aep-79/doc/README.md
@@ -1,0 +1,96 @@
+# Akash Network: Chain Migration Program (Cosmos SDK → Solana / Ethereum)
+
+| | |
+|---|---|
+| **Program** | Akash chain migration (working title: "Akash 3.0") |
+| **Doc set ID** | AKASH-MIG |
+| **Version** | 0.9 (draft for review) |
+| **Date** | 2026-08-10 |
+| **Owner** | Overclock Labs |
+| **Audience** | Executing developer agency ("the Vendor"), Akash core team, community reviewers |
+| **Status** | Target selection open; decided at Gate 0 (see [10](./10-rollout-and-cutover.md)) |
+
+## What this is
+
+This document set specifies, to execution depth, the migration of the Akash Network protocol from its
+sovereign Cosmos SDK Layer-1 chain (`akashnet-2`) to one of two target ecosystems:
+
+- **Path A (Solana)**: the Akash marketplace re-implemented as a suite of
+  Solana programs on Solana mainnet.
+- **Path B (Ethereum)**: the Akash marketplace re-implemented as EVM contracts, default variant on an
+  existing EVM L2 (host chain selected against the criteria in [04](./04-ethereum-architecture.md);
+  candidates include Base, Arbitrum One, and Robinhood Chain), non-default variant as a dedicated
+  Arbitrum Orbit rollup.
+
+Both paths are specified fully enough to execute. The comparative analysis lives in
+[02. Target selection](./02-target-selection.md); the final choice is a client decision at **Gate 0**
+and does not block Vendor mobilization on shared workstreams (token migration design, indexing,
+off-chain adaptation layers).
+
+This document set is the successor to, and supersedes where in conflict, the earlier
+[`RFP_SHARED_SECURITY.md`](../README.md) exploration (shared security within Cosmos),
+which is retained in the option analysis as the stay-Cosmos baseline.
+
+## Document map
+
+Read in numeric order for full context; role-based shortcuts below.
+
+| # | Document | Contents |
+|---|---|---|
+| 00 | [Executive summary](./00-executive-summary.md) | Drivers, candidate targets, migration shape, effort at a glance |
+| 01 | [Current architecture](./01-current-architecture.md) | Akash on Cosmos SDK today: modules, state, transactions, escrow mechanics, parameters, off-chain seams |
+| 02 | [Target selection](./02-target-selection.md) | Option space, analysis, Gate 0 |
+| 03 | [Solana target architecture](./03-solana-architecture.md) | Programs, accounts/PDAs, instructions, settlement cranks, fees, governance, oracles |
+| 04 | [Ethereum target architecture](./04-ethereum-architecture.md) | Contracts, existing-L2 variant vs dedicated-rollup variant, host-chain criteria, gas abstraction, governance |
+| 05 | [Token migration](./05-token-migration.md) | AKT supply accounting, snapshot, claims, staking/vesting/IBC handling, exchanges, emissions |
+| 06 | [State & data migration](./06-state-and-data-migration.md) | What migrates vs winds down, export/transform tooling, verification, archives |
+| 07 | [Off-chain services & clients](./07-offchain-and-clients.md) | provider-services adaptation, Console/API, indexers, SDKs, wallets, provider auth |
+| 08 | [Security & audits](./08-security-and-audits.md) | Threat model, key management, upgrade authority, audit plan, bug bounty |
+| 09 | [Testing & verification](./09-testing-and-verification.md) | Test strategy, testnets, load targets, migration dry-runs, acceptance criteria |
+| 10 | [Rollout & cutover](./10-rollout-and-cutover.md) | Phases, gates, cutover runbook, rollback, old-chain sunset |
+| 11 | [Scope of work](./11-scope-of-work.md) | Workstreams, deliverables, milestone sequence, effort estimates, team, RACI, acceptance gates |
+| 12 | [Risk register](./12-risk-register.md) | Risks with likelihood/impact/mitigation/owner |
+| 13 | [Open questions & assumptions](./13-open-questions-and-assumptions.md) | Decision log (D-xx), assumptions (A-xx), open questions (Q-xx) |
+| 14 | [Appendix: protocol mapping](./14-appendix-protocol-mapping.md) | Exhaustive Cosmos→Solana→EVM mapping of every message, query, state object, event, parameter; glossary |
+
+### Reading paths by role
+
+- **Agency engagement lead / PM**: 00 → 02 → 11 → 10 → 12 → 13.
+- **Protocol engineer (target chain)**: 01 → 14 → 03 or 04 → 05 → 06 → 08 → 09.
+- **Off-chain / infra engineer**: 01 (§ off-chain seams) → 07 → 09 → 10.
+- **Security lead**: 03/04 → 08 → 05 → 10.
+- **Akash community reviewer**: 00 → 02 → 05 → 10 → 13.
+
+## Conventions used throughout
+
+1. **RFC-2119 keywords.** MUST/SHALL/SHOULD/MAY are normative obligations on the Vendor unless a
+   different actor is named.
+2. **Requirement IDs.** Normative requirements are numbered `REQ-<AREA>-NNN` (e.g. `REQ-SOL-014`) and
+   are stable: they will be referenced in the contract, test plans, and acceptance reviews. Areas:
+   GEN (program-wide), SOL, EVM, TOK (token), STA (state migration), OFF (off-chain), SEC, TST, ROL
+   (rollout), SOW.
+3. **Decision / assumption / question / risk IDs.** `D-xx` (decisions made), `A-xx` (assumptions to
+   validate), `Q-xx` (open questions with owners), `R-xx` (risks). All indexed in
+   [13](./13-open-questions-and-assumptions.md) and [12](./12-risk-register.md).
+4. **Event notation.** Protocol events are sequenced relative to `C` (cutover = S1) and `H`
+   (halt/snapshot = S2), e.g. `H+90d`, `S1−24h`; gates `G0–G5` order the program. Calendar planning
+   (dates, durations, milestones-with-dates) is intentionally excluded from this technical set.
+5. **Code citations.** References like `x/escrow/keeper/keeper.go:210` point into
+   [`akash-network/node`](https://github.com/akash-network/node) at the commit current on 2026-08-10;
+   protobuf type references point into `akash-api` (`pkg.akt.dev/go`).
+6. **Ecosystem facts.** Statements about Solana/Ethereum mainnet capabilities are stated "as of
+   2026-08". The Vendor MUST re-verify time-sensitive facts (versions, fees, feature status) at kickoff;
+   [13](./13-open-questions-and-assumptions.md) lists the ones we consider volatile.
+
+## Status & change control
+
+- This set is a **draft for internal and community review**. Nothing here is a governance decision;
+  on-chain governance approval of the migration itself is a precondition tracked in
+  [10](./10-rollout-and-cutover.md).
+- Changes flow via pull request to this directory. Each merged revision bumps the version in each
+  affected file's metadata table. Requirement IDs are never renumbered; superseded requirements are
+  marked `[WITHDRAWN]` in place.
+- Questions from prospective Vendors should be filed as issues referencing doc + requirement IDs.
+- The `internal/` subdirectory holds program planning and communications material (calendars,
+  dated milestones, payment schedules, comms plans) relocated out of this set; it is **not part of
+  the vendor technical package** and is excluded from the doc map above.


### PR DESCRIPTION
- Add doc/ migration document set (00-14) for the chain migration program
- Point AEP readme at doc/README.md for migration details and bump updated date
- Fix doc links to the old RFP_SHARED_SECURITY.md path to resolve to ../README.md